### PR TITLE
feat: multiplot VSpan creation mode

### DIFF
--- a/docs/superpowers/plans/2026-03-21-multiplot-vspan-creation.md
+++ b/docs/superpowers/plans/2026-03-21-multiplot-vspan-creation.md
@@ -1,0 +1,373 @@
+# Multiplot VSpan Creation Mode — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Enable interactive drawing of `MultiPlotsVerticalSpan` items across a `SciQLopMultiPlotPanel` via click-move-click gestures, with synchronized live preview on all plots.
+
+**Architecture:** The panel installs NeoQCP's `ItemCreator`/`ItemPositioner` callbacks on each child `QCustomPlot`. During a creation gesture, preview `QCPItemVSpan`s are created on all non-active plots and kept in sync via the positioner. On commit, raw items are removed and a proper `MultiPlotsVerticalSpan` is created. On cancel, previews are cleaned up.
+
+**Tech Stack:** C++20, Qt6, NeoQCP (QCPItemVSpan, ItemCreator, ItemPositioner, creation mode API), Shiboken6 bindings
+
+**Spec:** `docs/superpowers/specs/2026-03-21-multiplot-vspan-creation-design.md`
+
+---
+
+## File Structure
+
+| File | Role |
+|---|---|
+| `include/SciQLopPlots/MultiPlots/SciQLopMultiPlotPanel.hpp` | Add `SpanCreationState` struct, creation mode members, methods, signals |
+| `src/SciQLopMultiPlotPanel.cpp` | Implement creation mode logic |
+| `SciQLopPlots/bindings/bindings.xml` | Expose new methods/signals to Python |
+| `tests/manual-tests/gallery.py` | Add creation mode toggle to Stacked Plots tab |
+
+---
+
+### Task 1: Add creation mode state and API to SciQLopMultiPlotPanel header
+
+**Files:**
+- Modify: `include/SciQLopPlots/MultiPlots/SciQLopMultiPlotPanel.hpp`
+
+- [ ] **Step 1: Add includes and forward declarations**
+
+At top of file, add:
+```cpp
+#include <qcustomplot.h>  // for QCPItemVSpan, QCPRange
+```
+
+- [ ] **Step 2: Add SpanCreationState struct and members**
+
+Add inside `SciQLopMultiPlotPanel` class, in the private section (before `protected:`):
+
+```cpp
+private:
+    struct SpanCreationState {
+        QCustomPlot* active_plot = nullptr;
+        QList<QPointer<QCPItemVSpan>> preview_spans;
+        void clear() {
+            active_plot = nullptr;
+            preview_spans.clear();
+        }
+    };
+
+    bool m_span_creation_enabled = false;
+    QColor m_span_creation_color = QColor(100, 100, 200, 80);
+    SpanCreationState m_creation_state;
+    QList<QMetaObject::Connection> m_creation_connections;
+
+    void _install_span_creator(SciQLopPlot* plot);
+    void _uninstall_span_creator(SciQLopPlot* plot);
+    void _on_item_created(QCustomPlot* qcp, QCPAbstractItem* item);
+    void _on_item_canceled(QCustomPlot* qcp);
+    void _clear_preview_spans();
+```
+
+- [ ] **Step 3: Add public API methods**
+
+Add in the `public:` section, after the existing `save_*` methods:
+
+```cpp
+    void set_span_creation_enabled(bool enabled);
+    bool span_creation_enabled() const { return m_span_creation_enabled; }
+    void set_span_creation_color(const QColor& color) { m_span_creation_color = color; }
+    QColor span_creation_color() const { return m_span_creation_color; }
+```
+
+- [ ] **Step 4: Add signals**
+
+Add in the signals section (before `Q_SIGNAL void panel_added`):
+
+```cpp
+    Q_SIGNAL void span_created(MultiPlotsVerticalSpan* span);
+    Q_SIGNAL void span_creation_canceled();
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add include/SciQLopPlots/MultiPlots/SciQLopMultiPlotPanel.hpp
+git commit -m "feat: add span creation mode API to SciQLopMultiPlotPanel header"
+```
+
+---
+
+### Task 2: Implement creation mode logic in SciQLopMultiPlotPanel.cpp
+
+**Files:**
+- Modify: `src/SciQLopMultiPlotPanel.cpp`
+
+- [ ] **Step 1: Add include for MultiPlotsVSpan**
+
+Add at top with other includes:
+```cpp
+#include "SciQLopPlots/MultiPlots/MultiPlotsVSpan.hpp"
+```
+
+- [ ] **Step 2: Implement _install_span_creator**
+
+```cpp
+void SciQLopMultiPlotPanel::_install_span_creator(SciQLopPlot* plot)
+{
+    auto* qcp = plot->qcp_plot();
+
+    qcp->setItemCreator([this, qcp](QCustomPlot*, QCPAxis*, QCPAxis*) -> QCPAbstractItem* {
+        auto* vspan = new QCPItemVSpan(qcp);
+        vspan->setPen(QPen(m_span_creation_color.darker(120)));
+        vspan->setBrush(QBrush(m_span_creation_color));
+
+        m_creation_state.active_plot = qcp;
+        m_creation_state.preview_spans.clear();
+        for (auto& p : plots()) {
+            auto* sp = dynamic_cast<SciQLopPlot*>(p.data());
+            if (!sp) continue;
+            auto* other_qcp = sp->qcp_plot();
+            if (other_qcp == qcp) continue;
+            auto* preview = new QCPItemVSpan(other_qcp);
+            preview->setPen(QPen(m_span_creation_color.darker(120)));
+            preview->setBrush(QBrush(m_span_creation_color));
+            m_creation_state.preview_spans.append(preview);
+            other_qcp->replot(QCustomPlot::rpQueuedReplot);
+        }
+        return vspan;
+    });
+
+    qcp->setItemPositioner([this](QCPAbstractItem* item, double anchorKey, double,
+                                   double currentKey, double) {
+        double lower = std::min(anchorKey, currentKey);
+        double upper = std::max(anchorKey, currentKey);
+        if (auto* vspan = qobject_cast<QCPItemVSpan*>(item))
+            vspan->setRange(QCPRange(lower, upper));
+        for (auto& preview : m_creation_state.preview_spans) {
+            if (preview) {
+                preview->setRange(QCPRange(lower, upper));
+                preview->parentPlot()->replot(QCustomPlot::rpQueuedReplot);
+            }
+        }
+    });
+
+    m_creation_connections.append(
+        connect(qcp, &QCustomPlot::itemCreated, this,
+                [this, qcp](QCPAbstractItem* item) { _on_item_created(qcp, item); }));
+    m_creation_connections.append(
+        connect(qcp, &QCustomPlot::itemCanceled, this,
+                [this, qcp]() { _on_item_canceled(qcp); }));
+
+    qcp->setCreationModeEnabled(true);
+}
+```
+
+- [ ] **Step 3: Implement _uninstall_span_creator**
+
+```cpp
+void SciQLopMultiPlotPanel::_uninstall_span_creator(SciQLopPlot* plot)
+{
+    auto* qcp = plot->qcp_plot();
+    qcp->setCreationModeEnabled(false);
+    qcp->setItemCreator(nullptr);
+    qcp->setItemPositioner(nullptr);
+}
+```
+
+- [ ] **Step 4: Implement _clear_preview_spans**
+
+```cpp
+void SciQLopMultiPlotPanel::_clear_preview_spans()
+{
+    for (auto& preview : m_creation_state.preview_spans) {
+        if (preview)
+            preview->parentPlot()->removeItem(preview);
+    }
+    m_creation_state.clear();
+}
+```
+
+- [ ] **Step 5: Implement _on_item_created**
+
+```cpp
+void SciQLopMultiPlotPanel::_on_item_created(QCustomPlot* qcp, QCPAbstractItem* item)
+{
+    auto* vspan = qobject_cast<QCPItemVSpan*>(item);
+    if (!vspan) return;
+
+    auto qcp_range = vspan->range();
+    SciQLopPlotRange range(qcp_range.lower, qcp_range.upper);
+
+    qcp->removeItem(vspan);
+    _clear_preview_spans();
+
+    auto* mpvspan = new MultiPlotsVerticalSpan(
+        this, range, m_span_creation_color, false, true, "");
+    Q_EMIT span_created(mpvspan);
+}
+```
+
+- [ ] **Step 6: Implement _on_item_canceled**
+
+```cpp
+void SciQLopMultiPlotPanel::_on_item_canceled(QCustomPlot*)
+{
+    _clear_preview_spans();
+    Q_EMIT span_creation_canceled();
+}
+```
+
+- [ ] **Step 7: Implement set_span_creation_enabled**
+
+```cpp
+void SciQLopMultiPlotPanel::set_span_creation_enabled(bool enabled)
+{
+    if (m_span_creation_enabled == enabled)
+        return;
+    m_span_creation_enabled = enabled;
+
+    if (enabled) {
+        for (auto& p : plots()) {
+            if (auto* sp = dynamic_cast<SciQLopPlot*>(p.data()))
+                _install_span_creator(sp);
+        }
+        connect(this, &SciQLopMultiPlotPanel::plot_added, this,
+                [this](SciQLopPlotInterface* plot) {
+                    if (m_span_creation_enabled) {
+                        if (auto* sp = dynamic_cast<SciQLopPlot*>(plot))
+                            _install_span_creator(sp);
+                    }
+                });
+    } else {
+        _clear_preview_spans();
+        for (auto& conn : m_creation_connections)
+            disconnect(conn);
+        m_creation_connections.clear();
+        for (auto& p : plots()) {
+            if (auto* sp = dynamic_cast<SciQLopPlot*>(p.data()))
+                _uninstall_span_creator(sp);
+        }
+    }
+}
+```
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/SciQLopMultiPlotPanel.cpp
+git commit -m "feat: implement multiplot VSpan creation mode"
+```
+
+---
+
+### Task 3: Expose creation mode API in Python bindings
+
+**Files:**
+- Modify: `SciQLopPlots/bindings/bindings.xml`
+
+- [ ] **Step 1: Add methods/signals to SciQLopMultiPlotPanel type**
+
+Inside the `<object-type name="SciQLopMultiPlotPanel">` block (after the `<property name="name">` line at line 632), add nothing — the methods should be auto-detected by Shiboken since they're public. But we need to verify the `span_created` signal's `MultiPlotsVerticalSpan*` argument is handled correctly since that type is already declared.
+
+Check that `MultiPlotsVerticalSpan` is declared before `SciQLopMultiPlotPanel` in the bindings file, or add a forward declaration if needed.
+
+- [ ] **Step 2: Verify no bindings.xml changes needed**
+
+Shiboken should auto-expose public methods and signals. If the build fails due to missing type info, add:
+```xml
+<!-- Inside SciQLopMultiPlotPanel object-type -->
+<modify-function signature="span_created(MultiPlotsVerticalSpan*)"/>
+```
+
+- [ ] **Step 3: Commit (if changes needed)**
+
+```bash
+git add SciQLopPlots/bindings/bindings.xml
+git commit -m "feat: expose span creation mode in Python bindings"
+```
+
+---
+
+### Task 4: Add creation mode demo to gallery
+
+**Files:**
+- Modify: `tests/manual-tests/gallery.py`
+
+- [ ] **Step 1: Modify create_stacked_tab to add creation mode toggle**
+
+Replace the existing `create_stacked_tab` function:
+
+```python
+def create_stacked_tab():
+    container = QWidget()
+    layout = QVBoxLayout(container)
+    layout.setContentsMargins(0, 0, 0, 0)
+
+    btn = QPushButton("Toggle Span Creation Mode (Shift+Click to draw)")
+    btn.setCheckable(True)
+
+    panel = SciQLopMultiPlotPanel(synchronize_x=False, synchronize_time=True)
+    for _ in range(4):
+        panel.plot(
+            multicomponent_signal,
+            labels=["X", "Y", "Z"],
+            colors=[QColorConstants.Red, QColorConstants.Blue, QColorConstants.Green],
+            plot_type=PlotType.TimeSeries,
+        )
+    x_range = panel.plot_at(0).x_axis().range()
+    MultiPlotsVerticalSpan(
+        panel, x_range / 10,
+        QColor(100, 100, 200, 80),
+        read_only=False, visible=True,
+        tool_tip="Drag across all plots",
+    )
+
+    btn.toggled.connect(panel.set_span_creation_enabled)
+    panel.span_created.connect(
+        lambda s: print(f"Span created: [{s.range().start():.1f}, {s.range().stop():.1f}]"))
+
+    layout.addWidget(btn)
+    layout.addWidget(panel, stretch=1)
+    return container
+```
+
+- [ ] **Step 2: Update the tab registration**
+
+Change the `tabs.addTab` line for "Stacked Plots" from:
+```python
+tabs.addTab(with_export_button(create_stacked_tab()), "Stacked Plots")
+```
+to:
+```python
+tabs.addTab(create_stacked_tab(), "Stacked Plots")
+```
+
+Since `create_stacked_tab` now returns a container widget (not a panel directly), `with_export_button` would nest incorrectly.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/manual-tests/gallery.py
+git commit -m "feat: add span creation mode demo to gallery Stacked Plots tab"
+```
+
+---
+
+### Task 5: Build and manual test
+
+- [ ] **Step 1: Build the project**
+
+```bash
+meson compile -C build
+```
+
+- [ ] **Step 2: Run gallery and test creation mode**
+
+```bash
+python tests/manual-tests/gallery.py
+```
+
+1. Go to "Stacked Plots" tab
+2. Click the toggle button to enable creation mode
+3. Shift+click on any plot, drag, click again — verify synchronized preview on all 4 plots
+4. Verify `MultiPlotsVerticalSpan` is created after commit
+5. Press Escape during creation — verify cleanup
+6. Verify existing drag-to-move span still works when creation mode is off
+
+- [ ] **Step 3: Fix any issues found during testing**
+
+- [ ] **Step 4: Final commit if fixes were needed**

--- a/docs/superpowers/specs/2026-03-21-multiplot-vspan-creation-design.md
+++ b/docs/superpowers/specs/2026-03-21-multiplot-vspan-creation-design.md
@@ -1,0 +1,202 @@
+# Multiplot VSpan Creation Mode — Design Spec
+
+Interactive drawing of `MultiPlotsVerticalSpan` items across a `SciQLopMultiPlotPanel` via click-move-click gestures, with synchronized live preview on all plots.
+
+## Motivation
+
+SciQLop's event catalog workflow currently requires clicking a button to add a span in the middle of the view, then manually editing it. Drawing the range directly on the plot is more natural and faster. The multiplot case is especially important: a single gesture should create a span visible on all plots in the panel.
+
+## API
+
+### SciQLopMultiPlotPanel
+
+```cpp
+void set_span_creation_enabled(bool enabled);
+bool span_creation_enabled() const;
+void set_span_creation_color(const QColor& color);  // optional, default: QColor(100, 100, 200, 80)
+QColor span_creation_color() const;
+
+// Signals
+void span_created(MultiPlotsVerticalSpan* span);
+void span_creation_canceled();
+```
+
+### SciQLopPlot (minor)
+
+Forward NeoQCP creation API for single-plot use cases:
+
+```cpp
+void set_creation_mode_enabled(bool enabled);
+bool creation_mode_enabled() const;
+```
+
+## Interaction Model
+
+Uses NeoQCP's item creation mode (Shift+click quick creation or toggled batch mode).
+
+1. `set_span_creation_enabled(true)` → panel installs `ItemCreator`, `ItemPositioner`, and enables `setCreationModeEnabled(true)` on every child `QCustomPlot`
+2. User clicks on any plot → `ItemCreator` creates a `QCPItemVSpan` on that plot (NeoQCP manages it) AND creates preview `QCPItemVSpan` on every other plot with the same color
+3. Mouse moves → `ItemPositioner` updates the range on ALL preview spans simultaneously
+4. Second click (commit) → NeoQCP emits `itemCreated` → panel reads range from raw VSpan, removes it + all previews, creates a `MultiPlotsVerticalSpan`, emits `span_created`
+5. Escape/right-click (cancel) → NeoQCP emits `itemCanceled` → panel removes all previews, emits `span_creation_canceled`
+
+After commit in batch mode: stays in creation mode, ready for next span.
+
+## Internal State
+
+```cpp
+struct SpanCreationState {
+    QCustomPlot* active_plot = nullptr;
+    QList<QPointer<QCPItemVSpan>> preview_spans;  // one per non-active plot
+};
+```
+
+Held as a member of `SciQLopMultiPlotPanel`. Reset on commit/cancel.
+
+## Implementation
+
+### Enabling creation mode
+
+When `set_span_creation_enabled(true)`:
+
+1. Store `m_span_creation_enabled = true` and `m_span_creation_color`
+2. For each child `SciQLopPlot`, call `installSpanCreator(plot)`:
+   - Get `QCustomPlot* qcp = plot->qcp_plot()`
+   - Set `qcp->setItemCreator(creator_lambda)` — the lambda creates a `QCPItemVSpan` and preview spans
+   - Set `qcp->setItemPositioner(positioner_lambda)` — the lambda syncs all preview spans
+   - Connect `qcp->itemCreated` → `onItemCreated(qcp, item)`
+   - Connect `qcp->itemCanceled` → `onItemCanceled(qcp)`
+   - Call `qcp->setCreationModeEnabled(true)`
+3. Connect `plot_added` → install creator on new plots
+4. Connect `plot_removed` → uninstall creator, clean up any in-progress preview
+
+When `set_span_creation_enabled(false)`:
+
+1. For each child plot: `setCreationModeEnabled(false)`, `setItemCreator(nullptr)`, `setItemPositioner(nullptr)`, disconnect signals
+2. Cancel any in-progress creation
+3. `m_span_creation_enabled = false`
+
+### ItemCreator lambda
+
+```cpp
+auto creator = [this, qcp](QCustomPlot* plot, QCPAxis* keyAxis, QCPAxis* valueAxis) -> QCPAbstractItem* {
+    auto* vspan = new QCPItemVSpan(plot);
+    vspan->setPen(QPen(m_span_creation_color.darker(120)));
+    vspan->setBrush(QBrush(m_span_creation_color));
+
+    // Create preview spans on all other plots
+    m_creation_state.active_plot = qcp;
+    m_creation_state.preview_spans.clear();
+    for (auto& p : plots()) {
+        auto* other_qcp = static_cast<SciQLopPlot*>(p.data())->qcp_plot();
+        if (other_qcp == qcp) continue;
+        auto* preview = new QCPItemVSpan(other_qcp);
+        preview->setPen(QPen(m_span_creation_color.darker(120)));
+        preview->setBrush(QBrush(m_span_creation_color));
+        m_creation_state.preview_spans.append(preview);
+        other_qcp->replot(QCustomPlot::rpQueuedReplot);
+    }
+
+    return vspan;
+};
+```
+
+### ItemPositioner lambda
+
+```cpp
+auto positioner = [this](QCPAbstractItem* item, double anchorKey, double, double currentKey, double) {
+    // Position the main item (VSpan uses key axis only)
+    double lower = std::min(anchorKey, currentKey);
+    double upper = std::max(anchorKey, currentKey);
+    if (auto* vspan = qobject_cast<QCPItemVSpan*>(item)) {
+        vspan->setRange(lower, upper);
+    }
+    // Sync all preview spans
+    for (auto& preview : m_creation_state.preview_spans) {
+        if (preview) {
+            preview->setRange(lower, upper);
+            preview->parentPlot()->replot(QCustomPlot::rpQueuedReplot);
+        }
+    }
+};
+```
+
+### onItemCreated
+
+```cpp
+void SciQLopMultiPlotPanel::onItemCreated(QCustomPlot* qcp, QCPAbstractItem* item) {
+    auto* vspan = qobject_cast<QCPItemVSpan*>(item);
+    if (!vspan) return;
+
+    SciQLopPlotRange range(vspan->range().lower, vspan->range().upper);
+
+    // Remove the raw NeoQCP item
+    qcp->removeItem(vspan);
+
+    // Remove all preview spans
+    for (auto& preview : m_creation_state.preview_spans) {
+        if (preview)
+            preview->parentPlot()->removeItem(preview);
+    }
+    m_creation_state = {};
+
+    // Create the proper MultiPlotsVerticalSpan
+    auto* mpvspan = new MultiPlotsVerticalSpan(
+        this, range, m_span_creation_color, false, true, "");
+    emit span_created(mpvspan);
+}
+```
+
+### onItemCanceled
+
+```cpp
+void SciQLopMultiPlotPanel::onItemCanceled(QCustomPlot*) {
+    for (auto& preview : m_creation_state.preview_spans) {
+        if (preview)
+            preview->parentPlot()->removeItem(preview);
+    }
+    m_creation_state = {};
+    emit span_creation_canceled();
+}
+```
+
+### Dynamic plot management
+
+- `plot_added`: if creation mode is active, call `installSpanCreator(newPlot)`. If a creation is in-progress, add a preview span to the new plot.
+- `plot_removed`: if the removed plot has an in-progress preview, remove it from `m_creation_state.preview_spans`. Disconnect signals.
+
+## Files to Modify
+
+| File | Change |
+|---|---|
+| `include/SciQLopPlots/MultiPlots/SciQLopMultiPlotPanel.hpp` | Add `SpanCreationState` struct, creation mode members, new methods and signals |
+| `src/SciQLopMultiPlotPanel.cpp` | Implement `set_span_creation_enabled`, `installSpanCreator`, `onItemCreated`, `onItemCanceled` |
+| `include/SciQLopPlots/SciQLopPlot.hpp` | Add `set_creation_mode_enabled`/`creation_mode_enabled` forwarding |
+| `src/SciQLopPlot.cpp` | Implement forwarding methods |
+| `SciQLopPlots/bindings/bindings.xml` | Expose new methods/signals to Python |
+| `tests/manual-tests/gallery.py` | Add creation mode toggle button to "Stacked Plots" tab |
+
+## Gallery Demo
+
+Modify the existing "Stacked Plots" tab to add a toggle button:
+
+```python
+def create_stacked_tab():
+    container = QWidget()
+    layout = QVBoxLayout(container)
+    btn = QPushButton("Toggle Span Creation Mode")
+    btn.setCheckable(True)
+    panel = SciQLopMultiPlotPanel(synchronize_x=False, synchronize_time=True)
+    # ... existing plot setup ...
+    btn.toggled.connect(panel.set_span_creation_enabled)
+    panel.span_created.connect(lambda s: print(f"Span created: {s.range()}"))
+    layout.addWidget(btn)
+    layout.addWidget(panel, stretch=1)
+    return container
+```
+
+## Scope
+
+**In scope:** Panel-level creation mode for VSpans, synchronized preview during gesture, batch mode, integration with existing `MultiPlotsVerticalSpan` and `MultiPlotsVSpanCollection`.
+
+**Out of scope:** HSpan/RSpan creation, single-plot creation mode (trivial forwarding only), catalog integration (SciQLop concern), undo/redo, custom creator callbacks on the panel.

--- a/include/SciQLopPlots/MultiPlots/SciQLopMultiPlotPanel.hpp
+++ b/include/SciQLopPlots/MultiPlots/SciQLopMultiPlotPanel.hpp
@@ -52,13 +52,8 @@ class SciQLopMultiPlotPanel : public SciQLopPlotPanelInterface
 
     struct SpanCreationState
     {
-        QCustomPlot* active_plot = nullptr;
         QList<QPointer<QCPItemVSpan>> preview_spans;
-        void clear()
-        {
-            active_plot = nullptr;
-            preview_spans.clear();
-        }
+        void clear() { preview_spans.clear(); }
     };
 
     bool m_span_creation_enabled = false;

--- a/include/SciQLopPlots/MultiPlots/SciQLopMultiPlotPanel.hpp
+++ b/include/SciQLopPlots/MultiPlots/SciQLopMultiPlotPanel.hpp
@@ -59,7 +59,8 @@ class SciQLopMultiPlotPanel : public SciQLopPlotPanelInterface
     bool m_span_creation_enabled = false;
     QColor m_span_creation_color = QColor(100, 100, 200, 80);
     SpanCreationState m_creation_state;
-    QList<QMetaObject::Connection> m_creation_connections;
+    QList<QMetaObject::Connection> m_creation_connections;                // panel-level (plot_added/removed)
+    std::map<QCustomPlot*, QList<QMetaObject::Connection>> m_per_plot_connections;
 
     void _install_span_creator(SciQLopPlot* plot);
     void _uninstall_span_creator(SciQLopPlot* plot);

--- a/include/SciQLopPlots/MultiPlots/SciQLopMultiPlotPanel.hpp
+++ b/include/SciQLopPlots/MultiPlots/SciQLopMultiPlotPanel.hpp
@@ -33,6 +33,10 @@
 class SciQLopPlotContainer;
 class SciQLopPlot;
 class PlaceHolderManager;
+class QCPItemVSpan;
+class QCPAbstractItem;
+class QCustomPlot;
+class MultiPlotsVerticalSpan;
 
 class SciQLopMultiPlotPanel : public SciQLopPlotPanelInterface
 {
@@ -45,6 +49,28 @@ class SciQLopMultiPlotPanel : public SciQLopPlotPanelInterface
     PlotType _default_plot_type = PlotType::BasicXY;
     QUuid _uuid;
     bool _selected = false;
+
+    struct SpanCreationState
+    {
+        QCustomPlot* active_plot = nullptr;
+        QList<QPointer<QCPItemVSpan>> preview_spans;
+        void clear()
+        {
+            active_plot = nullptr;
+            preview_spans.clear();
+        }
+    };
+
+    bool m_span_creation_enabled = false;
+    QColor m_span_creation_color = QColor(100, 100, 200, 80);
+    SpanCreationState m_creation_state;
+    QList<QMetaObject::Connection> m_creation_connections;
+
+    void _install_span_creator(SciQLopPlot* plot);
+    void _uninstall_span_creator(SciQLopPlot* plot);
+    void _on_item_created(QCustomPlot* qcp, QCPAbstractItem* item);
+    void _on_item_canceled(QCustomPlot* qcp);
+    void _clear_preview_spans();
 
 protected:
     template <typename T, GraphType graph_type, typename... Args>
@@ -235,6 +261,11 @@ public:
     bool save_bmp(const QString& filename, int width = 0, int height = 0,
                   double scale = 1.0) override;
 
+    void set_span_creation_enabled(bool enabled);
+    bool span_creation_enabled() const { return m_span_creation_enabled; }
+    void set_span_creation_color(const QColor& color) { m_span_creation_color = color; }
+    QColor span_creation_color() const { return m_span_creation_color; }
+
 protected:
     void keyPressEvent(QKeyEvent* event) override;
     void dragEnterEvent(QDragEnterEvent* event) override;
@@ -247,6 +278,8 @@ public:
 #define Q_SIGNAL
 signals:
 #endif
+    Q_SIGNAL void span_created(MultiPlotsVerticalSpan* span);
+    Q_SIGNAL void span_creation_canceled();
     Q_SIGNAL void panel_added(SciQLopPlotPanelInterface* panel);
     Q_SIGNAL void panel_removed(SciQLopPlotPanelInterface* panel);
 };

--- a/src/SciQLopMultiPlotPanel.cpp
+++ b/src/SciQLopMultiPlotPanel.cpp
@@ -630,9 +630,10 @@ void SciQLopMultiPlotPanel::_install_span_creator(SciQLopPlot* plot)
             }
         });
 
-    m_creation_connections.append(connect(qcp, &QCustomPlot::itemCreated, this,
+    auto& conns = m_per_plot_connections[qcp];
+    conns.append(connect(qcp, &QCustomPlot::itemCreated, this,
         [this, qcp](QCPAbstractItem* item) { _on_item_created(qcp, item); }));
-    m_creation_connections.append(connect(qcp, &QCustomPlot::itemCanceled, this,
+    conns.append(connect(qcp, &QCustomPlot::itemCanceled, this,
         [this, qcp]() { _on_item_canceled(qcp); }));
 
     qcp->setCreationModeEnabled(true);
@@ -644,6 +645,12 @@ void SciQLopMultiPlotPanel::_uninstall_span_creator(SciQLopPlot* plot)
     qcp->setCreationModeEnabled(false);
     qcp->setItemCreator(nullptr);
     qcp->setItemPositioner(nullptr);
+    if (auto it = m_per_plot_connections.find(qcp); it != m_per_plot_connections.end())
+    {
+        for (auto& conn : it->second)
+            disconnect(conn);
+        m_per_plot_connections.erase(it);
+    }
 }
 
 void SciQLopMultiPlotPanel::_clear_preview_spans()

--- a/src/SciQLopMultiPlotPanel.cpp
+++ b/src/SciQLopMultiPlotPanel.cpp
@@ -595,7 +595,6 @@ void SciQLopMultiPlotPanel::_install_span_creator(SciQLopPlot* plot)
             vspan->setPen(QPen(m_span_creation_color.darker(120)));
             vspan->setBrush(QBrush(m_span_creation_color));
 
-            m_creation_state.active_plot = qcp;
             m_creation_state.preview_spans.clear();
             for (auto& p : plots())
             {
@@ -706,6 +705,13 @@ void SciQLopMultiPlotPanel::set_span_creation_enabled(bool enabled)
                         if (auto* sp = dynamic_cast<SciQLopPlot*>(plot))
                             _install_span_creator(sp);
                     }
+                }));
+        m_creation_connections.append(
+            connect(this, &SciQLopMultiPlotPanel::plot_removed, this,
+                [this](SciQLopPlotInterface* plot)
+                {
+                    if (auto* sp = dynamic_cast<SciQLopPlot*>(plot))
+                        _uninstall_span_creator(sp);
                 }));
     }
     else

--- a/src/SciQLopMultiPlotPanel.cpp
+++ b/src/SciQLopMultiPlotPanel.cpp
@@ -30,6 +30,7 @@
 
 #include "SciQLopPlots/MultiPlots/SciQLopMultiPlotPanel.hpp"
 #include "SciQLopPlots/MultiPlots/MultiPlotsVSpan.hpp"
+#include "SciQLopPlots/constants.hpp"
 #include "SciQLopPlots/MultiPlots/SciQLopPlotCollection.hpp"
 #include "SciQLopPlots/MultiPlots/SciQLopPlotContainer.hpp"
 #include "SciQLopPlots/MultiPlots/TimeAxisSynchronizer.hpp"
@@ -594,6 +595,7 @@ void SciQLopMultiPlotPanel::_install_span_creator(SciQLopPlot* plot)
             auto* vspan = new QCPItemVSpan(qcp);
             vspan->setPen(QPen(m_span_creation_color.darker(120)));
             vspan->setBrush(QBrush(m_span_creation_color));
+            vspan->setLayer(Constants::LayersNames::Spans);
 
             _clear_preview_spans();
             for (auto& p : plots())
@@ -607,6 +609,7 @@ void SciQLopMultiPlotPanel::_install_span_creator(SciQLopPlot* plot)
                 auto* preview = new QCPItemVSpan(other_qcp);
                 preview->setPen(QPen(m_span_creation_color.darker(120)));
                 preview->setBrush(QBrush(m_span_creation_color));
+                preview->setLayer(Constants::LayersNames::Spans);
                 m_creation_state.preview_spans.append(preview);
                 other_qcp->replot(QCustomPlot::rpQueuedReplot);
             }

--- a/src/SciQLopMultiPlotPanel.cpp
+++ b/src/SciQLopMultiPlotPanel.cpp
@@ -652,7 +652,11 @@ void SciQLopMultiPlotPanel::_clear_preview_spans()
     for (auto& preview : m_creation_state.preview_spans)
     {
         if (preview)
-            preview->parentPlot()->removeItem(preview);
+        {
+            auto* plot = preview->parentPlot();
+            plot->removeItem(preview);
+            plot->replot(QCustomPlot::rpQueuedReplot);
+        }
     }
     m_creation_state.clear();
 }

--- a/src/SciQLopMultiPlotPanel.cpp
+++ b/src/SciQLopMultiPlotPanel.cpp
@@ -29,6 +29,7 @@
 #include "SciQLopPlots/Inspector/Model/Model.hpp"
 
 #include "SciQLopPlots/MultiPlots/SciQLopMultiPlotPanel.hpp"
+#include "SciQLopPlots/MultiPlots/MultiPlotsVSpan.hpp"
 #include "SciQLopPlots/MultiPlots/SciQLopPlotCollection.hpp"
 #include "SciQLopPlots/MultiPlots/SciQLopPlotContainer.hpp"
 #include "SciQLopPlots/MultiPlots/TimeAxisSynchronizer.hpp"
@@ -581,4 +582,138 @@ bool SciQLopMultiPlotPanel::save(const QString& filename, int width, int height,
     if (ext == "bmp")
         return save_bmp(filename, width, height, scale);
     return false;
+}
+
+void SciQLopMultiPlotPanel::_install_span_creator(SciQLopPlot* plot)
+{
+    auto* qcp = plot->qcp_plot();
+
+    qcp->setItemCreator(
+        [this, qcp](QCustomPlot*, QCPAxis*, QCPAxis*) -> QCPAbstractItem*
+        {
+            auto* vspan = new QCPItemVSpan(qcp);
+            vspan->setPen(QPen(m_span_creation_color.darker(120)));
+            vspan->setBrush(QBrush(m_span_creation_color));
+
+            m_creation_state.active_plot = qcp;
+            m_creation_state.preview_spans.clear();
+            for (auto& p : plots())
+            {
+                auto* sp = dynamic_cast<SciQLopPlot*>(p.data());
+                if (!sp)
+                    continue;
+                auto* other_qcp = sp->qcp_plot();
+                if (other_qcp == qcp)
+                    continue;
+                auto* preview = new QCPItemVSpan(other_qcp);
+                preview->setPen(QPen(m_span_creation_color.darker(120)));
+                preview->setBrush(QBrush(m_span_creation_color));
+                m_creation_state.preview_spans.append(preview);
+                other_qcp->replot(QCustomPlot::rpQueuedReplot);
+            }
+            return vspan;
+        });
+
+    qcp->setItemPositioner(
+        [this](QCPAbstractItem* item, double anchorKey, double, double currentKey, double)
+        {
+            double lower = std::min(anchorKey, currentKey);
+            double upper = std::max(anchorKey, currentKey);
+            if (auto* vspan = qobject_cast<QCPItemVSpan*>(item))
+                vspan->setRange(QCPRange(lower, upper));
+            for (auto& preview : m_creation_state.preview_spans)
+            {
+                if (preview)
+                {
+                    preview->setRange(QCPRange(lower, upper));
+                    preview->parentPlot()->replot(QCustomPlot::rpQueuedReplot);
+                }
+            }
+        });
+
+    m_creation_connections.append(connect(qcp, &QCustomPlot::itemCreated, this,
+        [this, qcp](QCPAbstractItem* item) { _on_item_created(qcp, item); }));
+    m_creation_connections.append(connect(qcp, &QCustomPlot::itemCanceled, this,
+        [this, qcp]() { _on_item_canceled(qcp); }));
+
+    qcp->setCreationModeEnabled(true);
+}
+
+void SciQLopMultiPlotPanel::_uninstall_span_creator(SciQLopPlot* plot)
+{
+    auto* qcp = plot->qcp_plot();
+    qcp->setCreationModeEnabled(false);
+    qcp->setItemCreator(nullptr);
+    qcp->setItemPositioner(nullptr);
+}
+
+void SciQLopMultiPlotPanel::_clear_preview_spans()
+{
+    for (auto& preview : m_creation_state.preview_spans)
+    {
+        if (preview)
+            preview->parentPlot()->removeItem(preview);
+    }
+    m_creation_state.clear();
+}
+
+void SciQLopMultiPlotPanel::_on_item_created(QCustomPlot* qcp, QCPAbstractItem* item)
+{
+    auto* vspan = qobject_cast<QCPItemVSpan*>(item);
+    if (!vspan)
+        return;
+
+    auto qcp_range = vspan->range();
+    SciQLopPlotRange range(qcp_range.lower, qcp_range.upper);
+
+    qcp->removeItem(vspan);
+    _clear_preview_spans();
+
+    auto* mpvspan
+        = new MultiPlotsVerticalSpan(this, range, m_span_creation_color, false, true, "");
+    Q_EMIT span_created(mpvspan);
+}
+
+void SciQLopMultiPlotPanel::_on_item_canceled(QCustomPlot*)
+{
+    _clear_preview_spans();
+    Q_EMIT span_creation_canceled();
+}
+
+void SciQLopMultiPlotPanel::set_span_creation_enabled(bool enabled)
+{
+    if (m_span_creation_enabled == enabled)
+        return;
+    m_span_creation_enabled = enabled;
+
+    if (enabled)
+    {
+        for (auto& p : plots())
+        {
+            if (auto* sp = dynamic_cast<SciQLopPlot*>(p.data()))
+                _install_span_creator(sp);
+        }
+        m_creation_connections.append(
+            connect(this, &SciQLopMultiPlotPanel::plot_added, this,
+                [this](SciQLopPlotInterface* plot)
+                {
+                    if (m_span_creation_enabled)
+                    {
+                        if (auto* sp = dynamic_cast<SciQLopPlot*>(plot))
+                            _install_span_creator(sp);
+                    }
+                }));
+    }
+    else
+    {
+        _clear_preview_spans();
+        for (auto& conn : m_creation_connections)
+            disconnect(conn);
+        m_creation_connections.clear();
+        for (auto& p : plots())
+        {
+            if (auto* sp = dynamic_cast<SciQLopPlot*>(p.data()))
+                _uninstall_span_creator(sp);
+        }
+    }
 }

--- a/src/SciQLopMultiPlotPanel.cpp
+++ b/src/SciQLopMultiPlotPanel.cpp
@@ -620,14 +620,17 @@ void SciQLopMultiPlotPanel::_install_span_creator(SciQLopPlot* plot)
             double upper = std::max(anchorKey, currentKey);
             if (auto* vspan = qobject_cast<QCPItemVSpan*>(item))
                 vspan->setRange(QCPRange(lower, upper));
+            QSet<QCustomPlot*> to_replot;
             for (auto& preview : m_creation_state.preview_spans)
             {
                 if (preview)
                 {
                     preview->setRange(QCPRange(lower, upper));
-                    preview->parentPlot()->replot(QCustomPlot::rpQueuedReplot);
+                    to_replot.insert(preview->parentPlot());
                 }
             }
+            for (auto* p : to_replot)
+                p->replot(QCustomPlot::rpQueuedReplot);
         });
 
     auto& conns = m_per_plot_connections[qcp];
@@ -655,15 +658,18 @@ void SciQLopMultiPlotPanel::_uninstall_span_creator(SciQLopPlot* plot)
 
 void SciQLopMultiPlotPanel::_clear_preview_spans()
 {
+    QSet<QCustomPlot*> to_replot;
     for (auto& preview : m_creation_state.preview_spans)
     {
         if (preview)
         {
             auto* plot = preview->parentPlot();
             plot->removeItem(preview);
-            plot->replot(QCustomPlot::rpQueuedReplot);
+            to_replot.insert(plot);
         }
     }
+    for (auto* p : to_replot)
+        p->replot(QCustomPlot::rpQueuedReplot);
     m_creation_state.clear();
 }
 

--- a/src/SciQLopMultiPlotPanel.cpp
+++ b/src/SciQLopMultiPlotPanel.cpp
@@ -595,7 +595,7 @@ void SciQLopMultiPlotPanel::_install_span_creator(SciQLopPlot* plot)
             vspan->setPen(QPen(m_span_creation_color.darker(120)));
             vspan->setBrush(QBrush(m_span_creation_color));
 
-            m_creation_state.preview_spans.clear();
+            _clear_preview_spans();
             for (auto& p : plots())
             {
                 auto* sp = dynamic_cast<SciQLopPlot*>(p.data());
@@ -711,7 +711,10 @@ void SciQLopMultiPlotPanel::set_span_creation_enabled(bool enabled)
                 [this](SciQLopPlotInterface* plot)
                 {
                     if (auto* sp = dynamic_cast<SciQLopPlot*>(plot))
+                    {
+                        _clear_preview_spans();
                         _uninstall_span_creator(sp);
+                    }
                 }));
     }
     else

--- a/tests/manual-tests/gallery.py
+++ b/tests/manual-tests/gallery.py
@@ -165,6 +165,13 @@ def create_overlay_tab():
 
 
 def create_stacked_tab():
+    container = QWidget()
+    layout = QVBoxLayout(container)
+    layout.setContentsMargins(0, 0, 0, 0)
+
+    btn = QPushButton("Toggle Span Creation Mode (Shift+Click to draw)")
+    btn.setCheckable(True)
+
     panel = SciQLopMultiPlotPanel(synchronize_x=False, synchronize_time=True)
     for _ in range(4):
         panel.plot(
@@ -180,7 +187,14 @@ def create_stacked_tab():
         read_only=False, visible=True,
         tool_tip="Drag across all plots",
     )
-    return panel
+
+    btn.toggled.connect(panel.set_span_creation_enabled)
+    panel.span_created.connect(
+        lambda s: print(f"Span created: [{s.range.start():.1f}, {s.range.stop():.1f}]"))
+
+    layout.addWidget(btn)
+    layout.addWidget(panel, stretch=1)
+    return container
 
 
 def create_pipeline_tab():
@@ -288,7 +302,7 @@ tabs.addTab(with_export_button(create_histogram2d_tab()), "Histogram 2D")
 tabs.addTab(with_export_button(create_curve_tab()), "Parametric Curve")
 tabs.addTab(with_export_button(create_spans_tab()), "Vertical Spans")
 tabs.addTab(with_export_button(create_overlay_tab()), "Overlay")
-tabs.addTab(with_export_button(create_stacked_tab()), "Stacked Plots")
+tabs.addTab(create_stacked_tab(), "Stacked Plots")
 tabs.addTab(with_export_button(create_pipeline_tab()), "Pipeline (FFT)")
 tabs.addTab(with_export_button(create_busy_indicator_tab()), "Busy Indicator")
 


### PR DESCRIPTION
## Summary

- Add interactive VSpan creation mode to `SciQLopMultiPlotPanel` — click-move-click gesture creates `MultiPlotsVerticalSpan` across all plots
- Synchronized live preview on all plots during the creation gesture via NeoQCP's `ItemCreator`/`ItemPositioner` API
- Gallery "Stacked Plots" tab now has a toggle button to demo the feature

## API

```python
panel.set_span_creation_enabled(True)
panel.span_created.connect(lambda span: catalog.add_event(span.range))
```

## Test plan

- [x] Run gallery, go to "Stacked Plots" tab
- [x] Toggle creation mode button
- [x] Shift+click on any plot, drag, click again — verify synchronized preview on all 4 plots
- [x] Verify `MultiPlotsVerticalSpan` is created after commit (printed to console)
- [x] Press Escape during creation — verify cleanup
- [x] Disable creation mode — verify existing span drag still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)