### PR TITLE
feat: expose NeoQCP theming API

### DIFF
--- a/SciQLopPlots/bindings/bindings.h
+++ b/SciQLopPlots/bindings/bindings.h
@@ -39,6 +39,7 @@
 #include <SciQLopPlots/Plotables/SciQLopLineGraph.hpp>
 #include <SciQLopPlots/Plotables/SciQLopSingleLineGraph.hpp>
 #include <SciQLopPlots/SciQLopOverlay.hpp>
+#include <SciQLopPlots/SciQLopTheme.hpp>
 #include <SciQLopPlots/SciQLopPlot.hpp>
 #include <SciQLopPlots/SciQLopPlotAxis.hpp>
 #include <SciQLopPlots/SciQLopPlotInterface.hpp>

--- a/SciQLopPlots/bindings/bindings.xml
+++ b/SciQLopPlots/bindings/bindings.xml
@@ -304,11 +304,6 @@
             <modify-argument index="3"><rename to="height"/></modify-argument>
             <modify-argument index="4"><rename to="scale"/></modify-argument>
         </modify-function>
-        <modify-function signature="set_theme(SciQLopTheme*)">
-            <modify-argument index="1">
-                <parent index="this" action="add"/>
-            </modify-argument>
-        </modify-function>
     </object-type>
     <object-type name="SciQLopPlotAxisInterface" parent-management="yes"/>
     <object-type name="SciQLopPlotAxis" parent-management="yes"/>

--- a/SciQLopPlots/bindings/bindings.xml
+++ b/SciQLopPlots/bindings/bindings.xml
@@ -310,9 +310,7 @@
 
     <object-type name="SciQLopOverlay" parent-management="yes"/>
 
-    <object-type name="SciQLopTheme" parent-management="yes">
-        <modify-function signature="qcp_theme()const" remove="all"/>
-    </object-type>
+    <object-type name="SciQLopTheme" parent-management="yes"/>
 
     <object-type name="SciQLopPlot" parent-management="yes">
     </object-type>

--- a/SciQLopPlots/bindings/bindings.xml
+++ b/SciQLopPlots/bindings/bindings.xml
@@ -304,11 +304,20 @@
             <modify-argument index="3"><rename to="height"/></modify-argument>
             <modify-argument index="4"><rename to="scale"/></modify-argument>
         </modify-function>
+        <modify-function signature="set_theme(SciQLopTheme*)">
+            <modify-argument index="1">
+                <parent index="this" action="add"/>
+            </modify-argument>
+        </modify-function>
     </object-type>
     <object-type name="SciQLopPlotAxisInterface" parent-management="yes"/>
     <object-type name="SciQLopPlotAxis" parent-management="yes"/>
 
     <object-type name="SciQLopOverlay" parent-management="yes"/>
+
+    <object-type name="SciQLopTheme" parent-management="yes">
+        <modify-function signature="qcp_theme()const" remove="all"/>
+    </object-type>
 
     <object-type name="SciQLopPlot" parent-management="yes">
     </object-type>
@@ -628,6 +637,11 @@
           <modify-argument index="1">
             <parent index="this" action="add"/>
           </modify-argument>
+        </modify-function>
+        <modify-function signature="set_theme(SciQLopTheme*)">
+            <modify-argument index="1">
+                <parent index="this" action="add"/>
+            </modify-argument>
         </modify-function>
         <property name="name" type="QString" get="objectName" set="setObjectName" generate-getsetdef="yes"/>
     </object-type>

--- a/SciQLopPlots/meson.build
+++ b/SciQLopPlots/meson.build
@@ -135,6 +135,7 @@ moc_headers = [
     project_source_root + '/include/SciQLopPlots/Products/QueryHighlighter.hpp',
     project_source_root + '/include/SciQLopPlots/Products/QueryLineEdit.hpp',
     project_source_root + '/include/SciQLopPlots/SciQLopOverlay.hpp',
+    project_source_root + '/include/SciQLopPlots/SciQLopTheme.hpp',
     project_source_root + '/include/SciQLopPlots/Icons/icons.hpp'
 ]
 
@@ -168,6 +169,7 @@ sources = moc_files \
             '../src/SciQLopTimeSeriesPlot.cpp',
             '../src/SciQLopNDProjectionPlot.cpp',
             '../src/SciQLopPlotAxis.cpp',
+            '../src/SciQLopTheme.cpp',
             '../src/SciQLopPlotCollection.cpp',
             '../src/AxisSynchronizer.cpp',
             '../src/XAxisSynchronizer.cpp',

--- a/docs/superpowers/plans/2026-03-21-neoqcp-theming.md
+++ b/docs/superpowers/plans/2026-03-21-neoqcp-theming.md
@@ -1,0 +1,537 @@
+# NeoQCP Theming Passthrough Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Expose NeoQCP's QCPTheme API (light/dark presets + custom color roles) through SciQLopPlots to C++ and Python users.
+
+**Architecture:** Thin `SciQLopTheme` QObject wrapper around `QCPTheme`, following the `SciQLopOverlay` pattern. Virtual `set_theme()`/`theme()` on `SciQLopPlotInterface`, overridden in `SciQLopPlot`. Panel-level theme propagation with `plot_added` auto-application.
+
+**Tech Stack:** C++20, Qt6, Shiboken6, Meson
+
+**Spec:** `docs/superpowers/specs/2026-03-21-neoqcp-theming-design.md`
+
+---
+
+### Task 1: Create SciQLopTheme wrapper class
+
+**Files:**
+- Create: `include/SciQLopPlots/SciQLopTheme.hpp`
+
+- [ ] **Step 1: Create the header file**
+
+Follow the `SciQLopOverlay` pattern — a QObject wrapping a `QPointer<QCPTheme>`, with snake_case forwarding methods.
+
+```cpp
+#pragma once
+#include <QColor>
+#include <QObject>
+#include <QPointer>
+#include <QString>
+#include <theme.h>
+
+class SciQLopTheme : public QObject
+{
+    Q_OBJECT
+
+    QPointer<QCPTheme> m_theme;
+
+    // Private constructor from existing QCPTheme
+    explicit SciQLopTheme(QCPTheme* theme, QObject* parent = nullptr);
+
+public:
+    virtual ~SciQLopTheme() override = default;
+
+    static SciQLopTheme* light(QObject* parent = nullptr);
+    static SciQLopTheme* dark(QObject* parent = nullptr);
+
+    QCPTheme* qcp_theme() const { return m_theme; }
+
+    QColor background() const;
+    QColor foreground() const;
+    QColor grid() const;
+    QColor sub_grid() const;
+    QColor selection() const;
+    QColor legend_background() const;
+    QColor legend_border() const;
+
+    void set_background(const QColor& color);
+    void set_foreground(const QColor& color);
+    void set_grid(const QColor& color);
+    void set_sub_grid(const QColor& color);
+    void set_selection(const QColor& color);
+    void set_legend_background(const QColor& color);
+    void set_legend_border(const QColor& color);
+
+    QString busy_indicator_symbol() const;
+    qreal busy_fade_alpha() const;
+    int busy_show_delay_ms() const;
+    int busy_hide_delay_ms() const;
+
+    void set_busy_indicator_symbol(const QString& symbol);
+    void set_busy_fade_alpha(qreal alpha);
+    void set_busy_show_delay_ms(int ms);
+    void set_busy_hide_delay_ms(int ms);
+
+#ifdef BINDINGS_H
+#define Q_SIGNAL
+signals:
+#endif
+    Q_SIGNAL void changed();
+};
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add include/SciQLopPlots/SciQLopTheme.hpp
+git commit -m "feat: add SciQLopTheme header wrapping QCPTheme"
+```
+
+---
+
+### Task 2: Implement SciQLopTheme
+
+**Files:**
+- Create: `src/SciQLopTheme.cpp`
+
+- [ ] **Step 1: Write the implementation**
+
+All getters check `m_theme` pointer (QPointer null-safety), all setters forward to QCPTheme. Factories create a `QCPTheme` via `QCPTheme::light()`/`QCPTheme::dark()` and wrap it.
+
+```cpp
+#include <SciQLopPlots/SciQLopTheme.hpp>
+
+SciQLopTheme::SciQLopTheme(QCPTheme* theme, QObject* parent)
+    : QObject(parent), m_theme(theme)
+{
+    if (m_theme)
+    {
+        m_theme->setParent(this);
+        connect(m_theme, &QCPTheme::changed, this, &SciQLopTheme::changed);
+    }
+}
+
+SciQLopTheme* SciQLopTheme::light(QObject* parent)
+{
+    return new SciQLopTheme(QCPTheme::light(), parent);
+}
+
+SciQLopTheme* SciQLopTheme::dark(QObject* parent)
+{
+    return new SciQLopTheme(QCPTheme::dark(), parent);
+}
+
+// -- Color getters --
+QColor SciQLopTheme::background() const { return m_theme ? m_theme->background() : QColor(); }
+QColor SciQLopTheme::foreground() const { return m_theme ? m_theme->foreground() : QColor(); }
+QColor SciQLopTheme::grid() const { return m_theme ? m_theme->grid() : QColor(); }
+QColor SciQLopTheme::sub_grid() const { return m_theme ? m_theme->subGrid() : QColor(); }
+QColor SciQLopTheme::selection() const { return m_theme ? m_theme->selection() : QColor(); }
+QColor SciQLopTheme::legend_background() const { return m_theme ? m_theme->legendBackground() : QColor(); }
+QColor SciQLopTheme::legend_border() const { return m_theme ? m_theme->legendBorder() : QColor(); }
+
+// -- Color setters --
+void SciQLopTheme::set_background(const QColor& c) { if (m_theme) m_theme->setBackground(c); }
+void SciQLopTheme::set_foreground(const QColor& c) { if (m_theme) m_theme->setForeground(c); }
+void SciQLopTheme::set_grid(const QColor& c) { if (m_theme) m_theme->setGrid(c); }
+void SciQLopTheme::set_sub_grid(const QColor& c) { if (m_theme) m_theme->setSubGrid(c); }
+void SciQLopTheme::set_selection(const QColor& c) { if (m_theme) m_theme->setSelection(c); }
+void SciQLopTheme::set_legend_background(const QColor& c) { if (m_theme) m_theme->setLegendBackground(c); }
+void SciQLopTheme::set_legend_border(const QColor& c) { if (m_theme) m_theme->setLegendBorder(c); }
+
+// -- Busy indicator getters --
+QString SciQLopTheme::busy_indicator_symbol() const { return m_theme ? m_theme->busyIndicatorSymbol() : QString(); }
+qreal SciQLopTheme::busy_fade_alpha() const { return m_theme ? m_theme->busyFadeAlpha() : 0.3; }
+int SciQLopTheme::busy_show_delay_ms() const { return m_theme ? m_theme->busyShowDelayMs() : 500; }
+int SciQLopTheme::busy_hide_delay_ms() const { return m_theme ? m_theme->busyHideDelayMs() : 500; }
+
+// -- Busy indicator setters --
+void SciQLopTheme::set_busy_indicator_symbol(const QString& s) { if (m_theme) m_theme->setBusyIndicatorSymbol(s); }
+void SciQLopTheme::set_busy_fade_alpha(qreal a) { if (m_theme) m_theme->setBusyFadeAlpha(a); }
+void SciQLopTheme::set_busy_show_delay_ms(int ms) { if (m_theme) m_theme->setBusyShowDelayMs(ms); }
+void SciQLopTheme::set_busy_hide_delay_ms(int ms) { if (m_theme) m_theme->setBusyHideDelayMs(ms); }
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/SciQLopTheme.cpp
+git commit -m "feat: implement SciQLopTheme wrapper"
+```
+
+---
+
+### Task 3: Wire up Meson build system
+
+**Files:**
+- Modify: `SciQLopPlots/meson.build`
+
+- [ ] **Step 1: Add SciQLopTheme to moc_headers**
+
+In `SciQLopPlots/meson.build`, add to the `moc_headers` list (after the `SciQLopOverlay.hpp` entry at line 137):
+
+```python
+project_source_root + '/include/SciQLopPlots/SciQLopTheme.hpp',
+```
+
+- [ ] **Step 2: Add SciQLopTheme.cpp to sources**
+
+In the `sources` list, add after `'../src/SciQLopPlotAxis.cpp'` (line 170):
+
+```python
+'../src/SciQLopTheme.cpp',
+```
+
+- [ ] **Step 3: Build to verify**
+
+```bash
+cd /var/home/jeandet/Documents/prog/SciQLopPlots
+meson setup build --buildtype=debug --wipe 2>&1 | tail -5
+meson compile -C build 2>&1 | tail -20
+```
+
+Expected: compiles and links without errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add SciQLopPlots/meson.build
+git commit -m "build: add SciQLopTheme to meson build"
+```
+
+---
+
+### Task 4: Add set_theme/theme to SciQLopPlotInterface and SciQLopPlot
+
+**Files:**
+- Modify: `include/SciQLopPlots/SciQLopPlotInterface.hpp`
+- Modify: `include/SciQLopPlots/SciQLopPlot.hpp`
+- Modify: `src/SciQLopPlot.cpp`
+
+- [ ] **Step 1: Add virtual methods to SciQLopPlotInterface**
+
+Add forward declaration of `SciQLopTheme` at the top of `SciQLopPlotInterface.hpp` (after existing includes). Add virtual methods following the `WARN_ABSTRACT_METHOD` pattern used by `time_axis()`, `legend()`, etc.:
+
+```cpp
+// Forward declaration (near top, after includes)
+class SciQLopTheme;
+
+// In the class body, near the other virtual getters/setters:
+inline virtual void set_theme(SciQLopTheme* theme)
+{
+    Q_UNUSED(theme);
+    WARN_ABSTRACT_METHOD;
+}
+
+inline virtual SciQLopTheme* theme() const
+{
+    WARN_ABSTRACT_METHOD;
+    return nullptr;
+}
+```
+
+- [ ] **Step 2: Add override to SciQLopPlot**
+
+In `include/SciQLopPlots/SciQLopPlot.hpp`:
+
+1. Add `#include "SciQLopPlots/SciQLopTheme.hpp"` to includes
+2. Add `QPointer<SciQLopTheme> m_theme;` to member variables (in the `protected:` section, after `m_overlay`)
+3. Add override declarations:
+
+```cpp
+void set_theme(SciQLopTheme* theme) override;
+SciQLopTheme* theme() const override { return m_theme; }
+```
+
+- [ ] **Step 3: Implement set_theme in SciQLopPlot.cpp**
+
+Add `#include <SciQLopPlots/SciQLopTheme.hpp>` to includes. Connect to the theme's `destroyed` signal to reset when the theme is deleted externally:
+
+```cpp
+void SciQLopPlot::set_theme(SciQLopTheme* theme)
+{
+    if (m_theme)
+        disconnect(m_theme, nullptr, this, nullptr);
+
+    m_theme = theme;
+
+    if (theme && theme->qcp_theme())
+    {
+        m_impl->setTheme(theme->qcp_theme());
+        connect(theme, &QObject::destroyed, this, [this]() { m_impl->setTheme(nullptr); });
+    }
+    else
+    {
+        m_impl->setTheme(nullptr);
+    }
+}
+```
+
+- [ ] **Step 4: Build to verify compilation**
+
+```bash
+meson compile -C build 2>&1 | tail -20
+```
+
+Expected: compiles without errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add include/SciQLopPlots/SciQLopPlotInterface.hpp include/SciQLopPlots/SciQLopPlot.hpp src/SciQLopPlot.cpp
+git commit -m "feat: add set_theme/theme to plot interface and SciQLopPlot"
+```
+
+---
+
+### Task 5: Add theme propagation to SciQLopMultiPlotPanel
+
+**Files:**
+- Modify: `include/SciQLopPlots/MultiPlots/SciQLopMultiPlotPanel.hpp`
+- Modify: `src/SciQLopMultiPlotPanel.cpp`
+
+- [ ] **Step 1: Add declarations to SciQLopMultiPlotPanel.hpp**
+
+1. Add forward declaration `class SciQLopTheme;` near the top
+2. Add member variables in the `private:` section:
+
+```cpp
+QPointer<SciQLopTheme> m_theme;
+QMetaObject::Connection m_theme_connection;
+```
+
+3. Add public methods:
+
+```cpp
+void set_theme(SciQLopTheme* theme);
+SciQLopTheme* theme() const { return m_theme; }
+```
+
+- [ ] **Step 2: Implement set_theme in SciQLopMultiPlotPanel.cpp**
+
+Add `#include <SciQLopPlots/SciQLopTheme.hpp>` to includes. Follow the `set_span_creation_enabled` pattern for iteration and `plot_added` connection:
+
+```cpp
+void SciQLopMultiPlotPanel::set_theme(SciQLopTheme* theme)
+{
+    // Disconnect previous plot_added connection
+    if (m_theme_connection)
+    {
+        disconnect(m_theme_connection);
+        m_theme_connection = {};
+    }
+
+    m_theme = theme;
+    if (theme)
+        theme->setParent(this);
+
+    for (auto& p : plots())
+    {
+        if (auto* sp = dynamic_cast<SciQLopPlot*>(p.data()))
+            sp->set_theme(theme);
+    }
+
+    if (theme)
+    {
+        m_theme_connection = connect(this, &SciQLopMultiPlotPanel::plot_added, this,
+            [this](SciQLopPlotInterface* plot)
+            {
+                if (m_theme)
+                {
+                    if (auto* sp = dynamic_cast<SciQLopPlot*>(plot))
+                        sp->set_theme(m_theme);
+                }
+            });
+    }
+}
+```
+
+- [ ] **Step 3: Build to verify compilation**
+
+```bash
+meson compile -C build 2>&1 | tail -20
+```
+
+Expected: compiles without errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add include/SciQLopPlots/MultiPlots/SciQLopMultiPlotPanel.hpp src/SciQLopMultiPlotPanel.cpp
+git commit -m "feat: add theme propagation to SciQLopMultiPlotPanel"
+```
+
+---
+
+### Task 6: Add Python bindings
+
+**Files:**
+- Modify: `SciQLopPlots/bindings/bindings.h`
+- Modify: `SciQLopPlots/bindings/bindings.xml`
+
+- [ ] **Step 1: Add include to bindings.h**
+
+Add after the existing `#include <SciQLopPlots/SciQLopOverlay.hpp>` line:
+
+```cpp
+#include <SciQLopPlots/SciQLopTheme.hpp>
+```
+
+- [ ] **Step 2: Add SciQLopTheme to bindings.xml**
+
+Add the `object-type` entry after the existing `SciQLopOverlay` entry (around line 311):
+
+```xml
+<object-type name="SciQLopTheme" parent-management="yes">
+    <modify-function signature="qcp_theme()const" remove="all"/>
+</object-type>
+```
+
+- [ ] **Step 3: Add set_theme to SciQLopPlotInterface in bindings.xml**
+
+Inside the existing `<object-type name="SciQLopPlotInterface" ...>` block, add:
+
+```xml
+<modify-function signature="set_theme(SciQLopTheme*)">
+    <modify-argument index="1">
+        <parent index="this" action="add"/>
+    </modify-argument>
+</modify-function>
+```
+
+- [ ] **Step 4: Add set_theme to SciQLopMultiPlotPanel in bindings.xml**
+
+Inside the existing `<object-type name="SciQLopMultiPlotPanel" ...>` block, add:
+
+```xml
+<modify-function signature="set_theme(SciQLopTheme*)">
+    <modify-argument index="1">
+        <parent index="this" action="add"/>
+    </modify-argument>
+</modify-function>
+```
+
+- [ ] **Step 5: Build the Python bindings**
+
+```bash
+meson compile -C build 2>&1 | tail -30
+```
+
+Expected: shiboken generates wrappers and compiles without errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add SciQLopPlots/bindings/bindings.h SciQLopPlots/bindings/bindings.xml
+git commit -m "feat: expose SciQLopTheme in Python bindings"
+```
+
+---
+
+### Task 7: Verify Python exports and add manual test
+
+**Files:**
+- Possibly modify: `SciQLopPlots/__init__.py`
+- Create: `tests/manual-tests/test_theming.py`
+
+- [ ] **Step 1: Check if SciQLopTheme is auto-exported**
+
+`SciQLopPlots/__init__.py` uses `from .SciQLopPlotsBindings import *` which should auto-export `SciQLopTheme`. Verify:
+
+```bash
+QT_QPA_PLATFORM=offscreen python -c "from SciQLopPlots import SciQLopTheme; t = SciQLopTheme.dark(); print(t.background().name())"
+```
+
+Expected: prints `#1e1e1e`. If not, add `SciQLopTheme` to the explicit imports in `__init__.py`.
+
+- [ ] **Step 2: Write the test script**
+
+Follow the `gallery.py` pattern — create a panel with plots, add toggle buttons:
+
+```python
+"""SciQLopPlots Theming Demo — toggle between light and dark themes."""
+import sys
+import numpy as np
+from PySide6.QtWidgets import QApplication, QMainWindow, QVBoxLayout, QWidget, QPushButton, QHBoxLayout
+from PySide6.QtGui import QColor
+
+from SciQLopPlots import (
+    SciQLopMultiPlotPanel, SciQLopTheme,
+    PlotType, SciQLopPlotRange,
+)
+
+
+def sample_data(start, stop):
+    x = np.arange(start, stop, dtype=np.float64)
+    y = np.column_stack([np.sin(x / 50), np.cos(x / 30)])
+    return x, y
+
+
+def main():
+    app = QApplication(sys.argv)
+    win = QMainWindow()
+    central = QWidget()
+    layout = QVBoxLayout(central)
+
+    panel = SciQLopMultiPlotPanel(synchronize_x=False, synchronize_time=True)
+    panel.plot(sample_data, labels=["sin", "cos"], plot_type=PlotType.TimeSeries)
+    panel.plot(sample_data, labels=["sin", "cos"], plot_type=PlotType.TimeSeries)
+
+    dark_theme = SciQLopTheme.dark()
+    light_theme = SciQLopTheme.light()
+    is_dark = [False]
+
+    def toggle():
+        is_dark[0] = not is_dark[0]
+        panel.set_theme(dark_theme if is_dark[0] else light_theme)
+        btn.setText("Switch to Light" if is_dark[0] else "Switch to Dark")
+
+    btn_layout = QHBoxLayout()
+    btn = QPushButton("Switch to Dark")
+    btn.clicked.connect(toggle)
+    btn_layout.addWidget(btn)
+
+    # Per-plot override demo: get the first plot from the panel's plots list
+    custom_theme = SciQLopTheme.dark()
+    custom_theme.set_background(QColor("#1a3a1a"))
+    custom_theme.set_selection(QColor("#00ff88"))
+
+    def apply_custom():
+        plots = panel.plots()
+        if plots:
+            plots[0].set_theme(custom_theme)
+
+    btn2 = QPushButton("Custom Theme on Plot 0")
+    btn2.clicked.connect(apply_custom)
+    btn_layout.addWidget(btn2)
+
+    layout.addLayout(btn_layout)
+    layout.addWidget(panel)
+    win.setCentralWidget(central)
+    win.resize(900, 600)
+    win.show()
+
+    panel.set_x_range(SciQLopPlotRange(0, 500))
+
+    sys.exit(app.exec())
+
+
+if __name__ == "__main__":
+    main()
+```
+
+- [ ] **Step 3: Run the test**
+
+```bash
+cd /var/home/jeandet/Documents/prog/SciQLopPlots
+QT_QPA_PLATFORM=xcb python tests/manual-tests/test_theming.py
+```
+
+Expected: window opens with two plots, buttons toggle themes.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/manual-tests/test_theming.py
+git commit -m "test: add theming manual test with light/dark toggle"
+```

--- a/docs/superpowers/plans/2026-03-21-neoqcp-theming.md
+++ b/docs/superpowers/plans/2026-03-21-neoqcp-theming.md
@@ -511,7 +511,7 @@ def main():
     win.resize(900, 600)
     win.show()
 
-    panel.set_x_range(SciQLopPlotRange(0, 500))
+    panel.set_x_axis_range(SciQLopPlotRange(0, 500))
 
     sys.exit(app.exec())
 

--- a/docs/superpowers/specs/2026-03-21-neoqcp-theming-design.md
+++ b/docs/superpowers/specs/2026-03-21-neoqcp-theming-design.md
@@ -1,0 +1,140 @@
+# NeoQCP Theming Passthrough — Design Spec
+
+## Goal
+
+Expose NeoQCP's `QCPTheme` API to SciQLopPlots users (C++ and Python) as a thin wrapper, enabling light/dark themes and custom color palettes on plots and panels.
+
+## Scope
+
+Minimal passthrough — no extended theming (graph color palettes, gradient defaults), no OS palette detection, no inspector integration. Just wrap what NeoQCP already provides.
+
+## Why a wrapper instead of exposing QCPTheme directly
+
+NeoQCP types are never exposed directly in SciQLopPlots' public API — all NeoQCP concepts are wrapped (e.g., `ColorGradient` enum, `SciQLopOverlay`). A `SciQLopTheme` wrapper maintains this convention and allows snake_case naming consistent with the rest of the API.
+
+## C++ Layer
+
+### SciQLopTheme class
+
+New class in `include/SciQLopPlots/SciQLopTheme.hpp`, implementation in `src/SciQLopTheme.cpp`.
+
+Owns a `QCPTheme*` internally. Exposes:
+
+**Static factories:**
+- `static SciQLopTheme* light(QObject* parent = nullptr)`
+- `static SciQLopTheme* dark(QObject* parent = nullptr)`
+
+**Color properties (get/set):**
+- `background` — QColor
+- `foreground` — QColor
+- `grid` — QColor
+- `sub_grid` — QColor
+- `selection` — QColor
+- `legend_background` — QColor
+- `legend_border` — QColor
+
+**Busy indicator properties (get/set):**
+- `busy_indicator_symbol` — QString
+- `busy_fade_alpha` — qreal
+- `busy_show_delay_ms` — int
+- `busy_hide_delay_ms` — int
+
+**Signal:**
+- `changed()` — forwarded from internal `QCPTheme::changed()`
+
+All property setters forward to `QCPTheme` and the reactive signal chain handles replot automatically.
+
+### Integration points
+
+**SciQLopPlotInterface** (virtual, with `WARN_ABSTRACT_METHOD` default):
+- `virtual void set_theme(SciQLopTheme* theme)`
+- `virtual SciQLopTheme* theme() const`
+
+**SciQLopPlot** (override):
+- `void set_theme(SciQLopTheme* theme)` — stores a `QPointer<SciQLopTheme>` and calls `setTheme(theme->qcp_theme())` on the underlying QCustomPlot
+- `SciQLopTheme* theme() const` — returns stored theme pointer (nullptr if using default)
+
+**SciQLopMultiPlotPanel** (concrete):
+- `void set_theme(SciQLopTheme* theme)` — stores a `QPointer<SciQLopTheme>` as the panel-level theme, then iterates child plots via `for (auto& p : plots()) { ... dynamic_cast<SciQLopPlot*> ... }` and calls `set_theme()` on each. Also connects to `plot_added` signal so newly-added plots receive the panel theme automatically.
+- `SciQLopTheme* theme() const` — returns the panel-level theme (or nullptr)
+
+### Ownership model
+
+- `SciQLopTheme` factory methods create objects with optional Qt parent ownership
+- When `set_theme()` is called on a panel, the panel reparents the `SciQLopTheme` to itself (prevents premature GC from Python side)
+- `SciQLopPlot` and `SciQLopMultiPlotPanel` store `QPointer<SciQLopTheme>` to handle the case where a theme is destroyed externally — null pointer results in falling back to QCustomPlot's default owned theme
+
+### Per-plot override semantics
+
+`panel.set_theme()` unconditionally applies the theme to **all** child plots, overwriting any per-plot override. To maintain a per-plot override, call `plot.set_theme()` **after** `panel.set_theme()`. This is the simplest behavior and avoids tracking per-plot override state.
+
+### Internal accessor
+
+`SciQLopTheme` exposes a `QCPTheme* qcp_theme() const` method for internal use by `SciQLopPlot`. This is rejected in Python bindings.
+
+## Python Bindings
+
+Add `SciQLopTheme` as an `object-type` to `bindings.xml`:
+
+```xml
+<object-type name="SciQLopTheme">
+    <modify-function signature="qcp_theme()const" remove="all"/>
+    <!-- static factories, color/busy getters+setters, changed() signal -->
+</object-type>
+```
+
+On `SciQLopPlotInterface`, add `set_theme(SciQLopTheme*)` and `theme()`.
+
+On `SciQLopMultiPlotPanel`, add `set_theme(SciQLopTheme*)` with parent transfer annotation:
+
+```xml
+<modify-function signature="set_theme(SciQLopTheme*)">
+    <modify-argument index="1">
+        <parent index="this" action="add"/>
+    </modify-argument>
+</modify-function>
+```
+
+### Python usage example
+
+```python
+from SciQLopPlots import SciQLopTheme
+
+# Use a preset
+theme = SciQLopTheme.dark()
+panel.set_theme(theme)
+
+# Customize from preset
+theme = SciQLopTheme.dark()
+theme.set_background(QColor("#2d2d2d"))
+theme.set_foreground(QColor("#f0f0f0"))
+panel.set_theme(theme)
+
+# Per-plot override (must be after panel.set_theme)
+special_theme = SciQLopTheme.light()
+panel.plot_at(0).set_theme(special_theme)
+```
+
+## Testing
+
+Add a manual test script `tests/manual-tests/test_theming.py` that:
+1. Creates a `SciQLopMultiPlotPanel` with 2-3 plots containing sample data
+2. Applies `SciQLopTheme.dark()` to the panel
+3. Adds a button/timer to toggle between light and dark
+4. Demonstrates per-plot theme override on one plot
+
+## Files to create/modify
+
+| File | Action |
+|------|--------|
+| `include/SciQLopPlots/SciQLopTheme.hpp` | Create — new wrapper class |
+| `src/SciQLopTheme.cpp` | Create — implementation |
+| `include/SciQLopPlots/SciQLopPlotInterface.hpp` | Modify — add virtual `set_theme()` / `theme()` with `WARN_ABSTRACT_METHOD` |
+| `include/SciQLopPlots/SciQLopPlot.hpp` | Modify — override `set_theme()` / `theme()` |
+| `src/SciQLopPlot.cpp` | Modify — implement theme methods |
+| `include/SciQLopPlots/MultiPlots/SciQLopMultiPlotPanel.hpp` | Modify — add `set_theme()` / `theme()` + `QPointer<SciQLopTheme>` member |
+| `src/MultiPlots/SciQLopMultiPlotPanel.cpp` | Modify — implement theme propagation + `plot_added` connection |
+| `SciQLopPlots/bindings/bindings.xml` | Modify — add `SciQLopTheme` object-type, theme methods on interfaces, parent transfer annotations |
+| `SciQLopPlots/bindings/bindings.h` | Modify — add `#include <SciQLopPlots/SciQLopTheme.hpp>` |
+| `src/meson.build` | Modify — add SciQLopTheme.cpp to sources |
+| `tests/manual-tests/test_theming.py` | Create — demo/test script |

--- a/docs/superpowers/specs/2026-03-21-neoqcp-theming-design.md
+++ b/docs/superpowers/specs/2026-03-21-neoqcp-theming-design.md
@@ -133,8 +133,8 @@ Add a manual test script `tests/manual-tests/test_theming.py` that:
 | `include/SciQLopPlots/SciQLopPlot.hpp` | Modify — override `set_theme()` / `theme()` |
 | `src/SciQLopPlot.cpp` | Modify — implement theme methods |
 | `include/SciQLopPlots/MultiPlots/SciQLopMultiPlotPanel.hpp` | Modify — add `set_theme()` / `theme()` + `QPointer<SciQLopTheme>` member |
-| `src/MultiPlots/SciQLopMultiPlotPanel.cpp` | Modify — implement theme propagation + `plot_added` connection |
+| `src/SciQLopMultiPlotPanel.cpp` | Modify — implement theme propagation + `plot_added` connection |
 | `SciQLopPlots/bindings/bindings.xml` | Modify — add `SciQLopTheme` object-type, theme methods on interfaces, parent transfer annotations |
 | `SciQLopPlots/bindings/bindings.h` | Modify — add `#include <SciQLopPlots/SciQLopTheme.hpp>` |
-| `src/meson.build` | Modify — add SciQLopTheme.cpp to sources |
+| `SciQLopPlots/meson.build` | Modify — add SciQLopTheme to moc_headers and sources |
 | `tests/manual-tests/test_theming.py` | Create — demo/test script |

--- a/docs/superpowers/specs/2026-03-21-neoqcp-theming-design.md
+++ b/docs/superpowers/specs/2026-03-21-neoqcp-theming-design.md
@@ -60,9 +60,10 @@ All property setters forward to `QCPTheme` and the reactive signal chain handles
 
 ### Ownership model
 
-- `SciQLopTheme` factory methods create objects with optional Qt parent ownership
-- When `set_theme()` is called on a panel, the panel reparents the `SciQLopTheme` to itself (prevents premature GC from Python side)
+- `SciQLopTheme` factory methods create objects with optional Qt parent ownership; callers choose an appropriate parent for deterministic lifetime
+- `set_theme()` does **not** transfer ownership or reparent the `SciQLopTheme`; it forwards the underlying `QCPTheme*` to NeoQCP and keeps a `QPointer` to the wrapper
 - `SciQLopPlot` and `SciQLopMultiPlotPanel` store `QPointer<SciQLopTheme>` to handle the case where a theme is destroyed externally — null pointer results in falling back to QCustomPlot's default owned theme
+- In Python, Shiboken's parent-transfer annotation on `SciQLopMultiPlotPanel.set_theme` manages lifetime; no annotation on `SciQLopPlotInterface.set_theme` to allow theme sharing across plots
 
 ### Per-plot override semantics
 

--- a/include/SciQLopPlots/MultiPlots/SciQLopMultiPlotPanel.hpp
+++ b/include/SciQLopPlots/MultiPlots/SciQLopMultiPlotPanel.hpp
@@ -61,6 +61,7 @@ class SciQLopMultiPlotPanel : public SciQLopPlotPanelInterface
 
     bool m_span_creation_enabled = false;
     QColor m_span_creation_color = QColor(100, 100, 200, 80);
+    Qt::KeyboardModifier m_span_creation_modifier = Qt::ShiftModifier;
     SpanCreationState m_creation_state;
     QList<QMetaObject::Connection> m_creation_connections;                // panel-level (plot_added/removed)
     std::map<QCustomPlot*, QList<QMetaObject::Connection>> m_per_plot_connections;
@@ -266,6 +267,8 @@ public:
     bool span_creation_enabled() const { return m_span_creation_enabled; }
     void set_span_creation_color(const QColor& color) { m_span_creation_color = color; }
     QColor span_creation_color() const { return m_span_creation_color; }
+    void set_span_creation_modifier(Qt::KeyboardModifier modifier);
+    Qt::KeyboardModifier span_creation_modifier() const { return m_span_creation_modifier; }
 
     void set_theme(SciQLopTheme* theme);
     SciQLopTheme* theme() const { return m_theme; }

--- a/include/SciQLopPlots/MultiPlots/SciQLopMultiPlotPanel.hpp
+++ b/include/SciQLopPlots/MultiPlots/SciQLopMultiPlotPanel.hpp
@@ -25,10 +25,13 @@
 #include "SciQLopPlots/MultiPlots/SciQLopPlotPanelInterface.hpp"
 
 #include <QGridLayout>
+#include <QPointer>
 #include <QScrollArea>
 #include <QUuid>
 #include <QWidget>
 #include <map>
+
+class SciQLopTheme;
 
 class SciQLopPlotContainer;
 class SciQLopPlot;
@@ -61,6 +64,8 @@ class SciQLopMultiPlotPanel : public SciQLopPlotPanelInterface
     SpanCreationState m_creation_state;
     QList<QMetaObject::Connection> m_creation_connections;                // panel-level (plot_added/removed)
     std::map<QCustomPlot*, QList<QMetaObject::Connection>> m_per_plot_connections;
+    QPointer<SciQLopTheme> m_theme;
+    QMetaObject::Connection m_theme_connection;
 
     void _install_span_creator(SciQLopPlot* plot);
     void _uninstall_span_creator(SciQLopPlot* plot);
@@ -261,6 +266,9 @@ public:
     bool span_creation_enabled() const { return m_span_creation_enabled; }
     void set_span_creation_color(const QColor& color) { m_span_creation_color = color; }
     QColor span_creation_color() const { return m_span_creation_color; }
+
+    void set_theme(SciQLopTheme* theme);
+    SciQLopTheme* theme() const { return m_theme; }
 
 protected:
     void keyPressEvent(QKeyEvent* event) override;

--- a/include/SciQLopPlots/MultiPlots/VPlotsAlign.hpp
+++ b/include/SciQLopPlots/MultiPlots/VPlotsAlign.hpp
@@ -33,6 +33,8 @@ class VPlotsAlign : public SciQLopPlotCollectionBehavior
 public:
     VPlotsAlign(QObject* parent = nullptr);
     Q_SLOT void updatePlotList(const QList<QPointer<SciQLopPlotInterface>>& plots) override;
+    Q_SLOT void plotAdded(SciQLopPlotInterface* plot) override { Q_UNUSED(plot); }
+    Q_SLOT void plotRemoved(SciQLopPlotInterface* plot) override { Q_UNUSED(plot); }
 
 protected:
     bool eventFilter(QObject* watched, QEvent* event) override;

--- a/include/SciQLopPlots/SciQLopPlot.hpp
+++ b/include/SciQLopPlots/SciQLopPlot.hpp
@@ -32,6 +32,7 @@
 #include "SciQLopPlots/SciQLopPlotInterface.hpp"
 #include "SciQLopPlots/SciQLopPlotLegend.hpp"
 #include "SciQLopPlots/SciQLopOverlay.hpp"
+#include "SciQLopPlots/SciQLopTheme.hpp"
 #include "SciQLopPlots/enums.hpp"
 #include <QPointF>
 #include <optional>
@@ -224,6 +225,7 @@ protected:
     SciQLopPlotDummyAxis* m_time_axis = nullptr;
     _impl::SciQLopPlot* m_impl = nullptr;
     SciQLopOverlay* m_overlay = nullptr;
+    QPointer<SciQLopTheme> m_theme;
     QList<QColor> m_color_palette = {
         QColor(31, 119, 180),  QColor(255, 127, 14),  QColor(44, 160, 44),   QColor(214, 39, 40),
         QColor(148, 103, 189), QColor(140, 86, 75),   QColor(227, 119, 194), QColor(127, 127, 127),
@@ -355,6 +357,9 @@ public:
     }
 
     inline virtual SciQLopPlotLegendInterface* legend() const noexcept override { return m_legend; }
+
+    void set_theme(SciQLopTheme* theme) override;
+    SciQLopTheme* theme() const override { return m_theme; }
 
     void replot(bool immediate = false) override;
 

--- a/include/SciQLopPlots/SciQLopPlotInterface.hpp
+++ b/include/SciQLopPlots/SciQLopPlotInterface.hpp
@@ -245,17 +245,8 @@ public:
         return nullptr;
     }
 
-    inline virtual void set_theme(SciQLopTheme* theme)
-    {
-        Q_UNUSED(theme);
-        WARN_ABSTRACT_METHOD;
-    }
-
-    inline virtual SciQLopTheme* theme() const
-    {
-        WARN_ABSTRACT_METHOD;
-        return nullptr;
-    }
+    inline virtual void set_theme(SciQLopTheme* theme) { Q_UNUSED(theme); }
+    inline virtual SciQLopTheme* theme() const { return nullptr; }
 
     inline virtual void set_scroll_factor(double factor) noexcept { WARN_ABSTRACT_METHOD; }
 

--- a/include/SciQLopPlots/SciQLopPlotInterface.hpp
+++ b/include/SciQLopPlots/SciQLopPlotInterface.hpp
@@ -34,6 +34,8 @@
 #include <QUuid>
 #include <qcustomplot.h>
 
+class SciQLopTheme;
+
 class SciQLopPlotInterface : public QFrame
 {
 
@@ -238,6 +240,18 @@ public:
     }
 
     inline virtual SciQLopPlotLegendInterface* legend() const noexcept
+    {
+        WARN_ABSTRACT_METHOD;
+        return nullptr;
+    }
+
+    inline virtual void set_theme(SciQLopTheme* theme)
+    {
+        Q_UNUSED(theme);
+        WARN_ABSTRACT_METHOD;
+    }
+
+    inline virtual SciQLopTheme* theme() const
     {
         WARN_ABSTRACT_METHOD;
         return nullptr;

--- a/include/SciQLopPlots/SciQLopTheme.hpp
+++ b/include/SciQLopPlots/SciQLopTheme.hpp
@@ -14,13 +14,15 @@ class SciQLopTheme : public QObject
     // Private constructor from existing QCPTheme
     explicit SciQLopTheme(QCPTheme* theme, QObject* parent = nullptr);
 
+    friend class SciQLopPlot;
+
+    QCPTheme* qcp_theme() const { return m_theme; }
+
 public:
     virtual ~SciQLopTheme() override = default;
 
     static SciQLopTheme* light(QObject* parent = nullptr);
     static SciQLopTheme* dark(QObject* parent = nullptr);
-
-    QCPTheme* qcp_theme() const { return m_theme; }
 
     QColor background() const;
     QColor foreground() const;

--- a/include/SciQLopPlots/SciQLopTheme.hpp
+++ b/include/SciQLopPlots/SciQLopTheme.hpp
@@ -1,0 +1,56 @@
+#pragma once
+#include <QColor>
+#include <QObject>
+#include <QPointer>
+#include <QString>
+#include <theme.h>
+
+class SciQLopTheme : public QObject
+{
+    Q_OBJECT
+
+    QPointer<QCPTheme> m_theme;
+
+    // Private constructor from existing QCPTheme
+    explicit SciQLopTheme(QCPTheme* theme, QObject* parent = nullptr);
+
+public:
+    virtual ~SciQLopTheme() override = default;
+
+    static SciQLopTheme* light(QObject* parent = nullptr);
+    static SciQLopTheme* dark(QObject* parent = nullptr);
+
+    QCPTheme* qcp_theme() const { return m_theme; }
+
+    QColor background() const;
+    QColor foreground() const;
+    QColor grid() const;
+    QColor sub_grid() const;
+    QColor selection() const;
+    QColor legend_background() const;
+    QColor legend_border() const;
+
+    void set_background(const QColor& color);
+    void set_foreground(const QColor& color);
+    void set_grid(const QColor& color);
+    void set_sub_grid(const QColor& color);
+    void set_selection(const QColor& color);
+    void set_legend_background(const QColor& color);
+    void set_legend_border(const QColor& color);
+
+    QString busy_indicator_symbol() const;
+    qreal busy_fade_alpha() const;
+    int busy_show_delay_ms() const;
+    int busy_hide_delay_ms() const;
+
+    void set_busy_indicator_symbol(const QString& symbol);
+    void set_busy_fade_alpha(qreal alpha);
+    void set_busy_show_delay_ms(int ms);
+    void set_busy_hide_delay_ms(int ms);
+
+#ifdef BINDINGS_H
+#define Q_SIGNAL
+signals:
+#endif
+    Q_SIGNAL void changed();
+};

--- a/src/SciQLopMultiPlotPanel.cpp
+++ b/src/SciQLopMultiPlotPanel.cpp
@@ -708,8 +708,6 @@ void SciQLopMultiPlotPanel::set_theme(SciQLopTheme* theme)
     }
 
     m_theme = theme;
-    if (theme)
-        theme->setParent(this);
 
     for (auto& p : plots())
     {

--- a/src/SciQLopMultiPlotPanel.cpp
+++ b/src/SciQLopMultiPlotPanel.cpp
@@ -21,6 +21,7 @@
 ----------------------------------------------------------------------------*/
 #include "SciQLopPlots/SciQLopNDProjectionPlot.hpp"
 #include "SciQLopPlots/SciQLopPlot.hpp"
+#include "SciQLopPlots/SciQLopTheme.hpp"
 #include "SciQLopPlots/SciQLopTimeSeriesPlot.hpp"
 #include "SciQLopPlots/unique_names_factory.hpp"
 
@@ -697,6 +698,38 @@ void SciQLopMultiPlotPanel::_on_item_canceled(QCustomPlot*)
 {
     _clear_preview_spans();
     Q_EMIT span_creation_canceled();
+}
+
+void SciQLopMultiPlotPanel::set_theme(SciQLopTheme* theme)
+{
+    if (m_theme_connection)
+    {
+        disconnect(m_theme_connection);
+        m_theme_connection = {};
+    }
+
+    m_theme = theme;
+    if (theme)
+        theme->setParent(this);
+
+    for (auto& p : plots())
+    {
+        if (auto* sp = dynamic_cast<SciQLopPlot*>(p.data()))
+            sp->set_theme(theme);
+    }
+
+    if (theme)
+    {
+        m_theme_connection = connect(this, &SciQLopMultiPlotPanel::plot_added, this,
+            [this](SciQLopPlotInterface* plot)
+            {
+                if (m_theme)
+                {
+                    if (auto* sp = dynamic_cast<SciQLopPlot*>(plot))
+                        sp->set_theme(m_theme);
+                }
+            });
+    }
 }
 
 void SciQLopMultiPlotPanel::set_span_creation_enabled(bool enabled)

--- a/src/SciQLopMultiPlotPanel.cpp
+++ b/src/SciQLopMultiPlotPanel.cpp
@@ -643,13 +643,12 @@ void SciQLopMultiPlotPanel::_install_span_creator(SciQLopPlot* plot)
     conns.append(connect(qcp, &QCustomPlot::itemCanceled, this,
         [this, qcp]() { _on_item_canceled(qcp); }));
 
-    qcp->setCreationModeEnabled(true);
+    qcp->setCreationModifier(m_span_creation_modifier);
 }
 
 void SciQLopMultiPlotPanel::_uninstall_span_creator(SciQLopPlot* plot)
 {
     auto* qcp = plot->qcp_plot();
-    qcp->setCreationModeEnabled(false);
     qcp->setItemCreator(nullptr);
     qcp->setItemPositioner(nullptr);
     if (auto it = m_per_plot_connections.find(qcp); it != m_per_plot_connections.end())
@@ -776,6 +775,19 @@ void SciQLopMultiPlotPanel::set_span_creation_enabled(bool enabled)
         {
             if (auto* sp = dynamic_cast<SciQLopPlot*>(p.data()))
                 _uninstall_span_creator(sp);
+        }
+    }
+}
+
+void SciQLopMultiPlotPanel::set_span_creation_modifier(Qt::KeyboardModifier modifier)
+{
+    m_span_creation_modifier = modifier;
+    if (m_span_creation_enabled)
+    {
+        for (auto& p : plots())
+        {
+            if (auto* sp = dynamic_cast<SciQLopPlot*>(p.data()))
+                sp->qcp_plot()->setCreationModifier(modifier);
         }
     }
 }

--- a/src/SciQLopMultiPlotPanel.cpp
+++ b/src/SciQLopMultiPlotPanel.cpp
@@ -711,8 +711,8 @@ void SciQLopMultiPlotPanel::set_theme(SciQLopTheme* theme)
 
     for (auto& p : plots())
     {
-        if (auto* sp = dynamic_cast<SciQLopPlot*>(p.data()))
-            sp->set_theme(theme);
+        if (p)
+            p->set_theme(theme);
     }
 
     if (theme)
@@ -720,11 +720,8 @@ void SciQLopMultiPlotPanel::set_theme(SciQLopTheme* theme)
         m_theme_connection = connect(this, &SciQLopMultiPlotPanel::plot_added, this,
             [this](SciQLopPlotInterface* plot)
             {
-                if (m_theme)
-                {
-                    if (auto* sp = dynamic_cast<SciQLopPlot*>(plot))
-                        sp->set_theme(m_theme);
-                }
+                if (m_theme && plot)
+                    plot->set_theme(m_theme);
             });
     }
 }

--- a/src/SciQLopPlot.cpp
+++ b/src/SciQLopPlot.cpp
@@ -499,6 +499,7 @@ void _impl::SciQLopPlot::_ensure_colorscale_is_visible(SciQLopColorMap* cmap)
         m_color_scale->setVisible(true);
         plotLayout()->addElement(0, 1, m_color_scale);
         cmap->colorMap()->setColorScale(m_color_scale);
+        applyTheme();
     }
 }
 
@@ -509,6 +510,7 @@ void _impl::SciQLopPlot::_ensure_colorscale_is_visible(SciQLopHistogram2D* hist)
         m_color_scale->setVisible(true);
         plotLayout()->addElement(0, 1, m_color_scale);
         hist->histogram()->setColorScale(m_color_scale);
+        applyTheme();
     }
 }
 

--- a/src/SciQLopPlot.cpp
+++ b/src/SciQLopPlot.cpp
@@ -20,6 +20,7 @@
 -- Mail : alexis.jeandet@member.fsf.org
 ----------------------------------------------------------------------------*/
 #include "SciQLopPlots/SciQLopPlot.hpp"
+#include "SciQLopPlots/SciQLopTheme.hpp"
 #include "SciQLopPlots/Inspector/Model/Model.hpp"
 #include "SciQLopPlots/Items/SciQLopPlotItem.hpp"
 #include "SciQLopPlots/constants.hpp"
@@ -656,6 +657,24 @@ double SciQLopPlot::scroll_factor() const noexcept
 }
 
 void SciQLopPlot::enable_cursor(bool enable) noexcept { }
+
+void SciQLopPlot::set_theme(SciQLopTheme* theme)
+{
+    if (m_theme)
+        disconnect(m_theme, nullptr, this, nullptr);
+
+    m_theme = theme;
+
+    if (theme && theme->qcp_theme())
+    {
+        m_impl->setTheme(theme->qcp_theme());
+        connect(theme, &QObject::destroyed, this, [this]() { m_impl->setTheme(nullptr); });
+    }
+    else
+    {
+        m_impl->setTheme(nullptr);
+    }
+}
 
 void SciQLopPlot::minimize_margins()
 {

--- a/src/SciQLopTheme.cpp
+++ b/src/SciQLopTheme.cpp
@@ -1,0 +1,51 @@
+#include <SciQLopPlots/SciQLopTheme.hpp>
+
+SciQLopTheme::SciQLopTheme(QCPTheme* theme, QObject* parent)
+    : QObject(parent), m_theme(theme)
+{
+    if (m_theme)
+    {
+        m_theme->setParent(this);
+        connect(m_theme, &QCPTheme::changed, this, &SciQLopTheme::changed);
+    }
+}
+
+SciQLopTheme* SciQLopTheme::light(QObject* parent)
+{
+    return new SciQLopTheme(QCPTheme::light(), parent);
+}
+
+SciQLopTheme* SciQLopTheme::dark(QObject* parent)
+{
+    return new SciQLopTheme(QCPTheme::dark(), parent);
+}
+
+// -- Color getters --
+QColor SciQLopTheme::background() const { return m_theme ? m_theme->background() : QColor(); }
+QColor SciQLopTheme::foreground() const { return m_theme ? m_theme->foreground() : QColor(); }
+QColor SciQLopTheme::grid() const { return m_theme ? m_theme->grid() : QColor(); }
+QColor SciQLopTheme::sub_grid() const { return m_theme ? m_theme->subGrid() : QColor(); }
+QColor SciQLopTheme::selection() const { return m_theme ? m_theme->selection() : QColor(); }
+QColor SciQLopTheme::legend_background() const { return m_theme ? m_theme->legendBackground() : QColor(); }
+QColor SciQLopTheme::legend_border() const { return m_theme ? m_theme->legendBorder() : QColor(); }
+
+// -- Color setters --
+void SciQLopTheme::set_background(const QColor& c) { if (m_theme) m_theme->setBackground(c); }
+void SciQLopTheme::set_foreground(const QColor& c) { if (m_theme) m_theme->setForeground(c); }
+void SciQLopTheme::set_grid(const QColor& c) { if (m_theme) m_theme->setGrid(c); }
+void SciQLopTheme::set_sub_grid(const QColor& c) { if (m_theme) m_theme->setSubGrid(c); }
+void SciQLopTheme::set_selection(const QColor& c) { if (m_theme) m_theme->setSelection(c); }
+void SciQLopTheme::set_legend_background(const QColor& c) { if (m_theme) m_theme->setLegendBackground(c); }
+void SciQLopTheme::set_legend_border(const QColor& c) { if (m_theme) m_theme->setLegendBorder(c); }
+
+// -- Busy indicator getters --
+QString SciQLopTheme::busy_indicator_symbol() const { return m_theme ? m_theme->busyIndicatorSymbol() : QString(); }
+qreal SciQLopTheme::busy_fade_alpha() const { return m_theme ? m_theme->busyFadeAlpha() : 0.3; }
+int SciQLopTheme::busy_show_delay_ms() const { return m_theme ? m_theme->busyShowDelayMs() : 500; }
+int SciQLopTheme::busy_hide_delay_ms() const { return m_theme ? m_theme->busyHideDelayMs() : 500; }
+
+// -- Busy indicator setters --
+void SciQLopTheme::set_busy_indicator_symbol(const QString& s) { if (m_theme) m_theme->setBusyIndicatorSymbol(s); }
+void SciQLopTheme::set_busy_fade_alpha(qreal a) { if (m_theme) m_theme->setBusyFadeAlpha(a); }
+void SciQLopTheme::set_busy_show_delay_ms(int ms) { if (m_theme) m_theme->setBusyShowDelayMs(ms); }
+void SciQLopTheme::set_busy_hide_delay_ms(int ms) { if (m_theme) m_theme->setBusyHideDelayMs(ms); }

--- a/tests/manual-tests/test_theming.py
+++ b/tests/manual-tests/test_theming.py
@@ -60,7 +60,7 @@ def main():
     win.resize(900, 600)
     win.show()
 
-    panel.set_x_range(SciQLopPlotRange(0, 500))
+    panel.set_x_axis_range(SciQLopPlotRange(0, 500))
 
     sys.exit(app.exec())
 

--- a/tests/manual-tests/test_theming.py
+++ b/tests/manual-tests/test_theming.py
@@ -1,0 +1,69 @@
+"""SciQLopPlots Theming Demo — toggle between light and dark themes."""
+import sys
+import numpy as np
+from PySide6.QtWidgets import QApplication, QMainWindow, QVBoxLayout, QWidget, QPushButton, QHBoxLayout
+from PySide6.QtGui import QColor
+
+from SciQLopPlots import (
+    SciQLopMultiPlotPanel, SciQLopTheme,
+    PlotType, SciQLopPlotRange,
+)
+
+
+def sample_data(start, stop):
+    x = np.arange(start, stop, dtype=np.float64)
+    y = np.column_stack([np.sin(x / 50), np.cos(x / 30)])
+    return x, y
+
+
+def main():
+    app = QApplication(sys.argv)
+    win = QMainWindow()
+    central = QWidget()
+    layout = QVBoxLayout(central)
+
+    panel = SciQLopMultiPlotPanel(synchronize_x=False, synchronize_time=True)
+    panel.plot(sample_data, labels=["sin", "cos"], plot_type=PlotType.TimeSeries)
+    panel.plot(sample_data, labels=["sin", "cos"], plot_type=PlotType.TimeSeries)
+
+    dark_theme = SciQLopTheme.dark()
+    light_theme = SciQLopTheme.light()
+    is_dark = [False]
+
+    def toggle():
+        is_dark[0] = not is_dark[0]
+        panel.set_theme(dark_theme if is_dark[0] else light_theme)
+        btn.setText("Switch to Light" if is_dark[0] else "Switch to Dark")
+
+    btn_layout = QHBoxLayout()
+    btn = QPushButton("Switch to Dark")
+    btn.clicked.connect(toggle)
+    btn_layout.addWidget(btn)
+
+    # Per-plot override demo: get the first plot from the panel's plots list
+    custom_theme = SciQLopTheme.dark()
+    custom_theme.set_background(QColor("#1a3a1a"))
+    custom_theme.set_selection(QColor("#00ff88"))
+
+    def apply_custom():
+        plots = panel.plots()
+        if plots:
+            plots[0].set_theme(custom_theme)
+
+    btn2 = QPushButton("Custom Theme on Plot 0")
+    btn2.clicked.connect(apply_custom)
+    btn_layout.addWidget(btn2)
+
+    layout.addLayout(btn_layout)
+    layout.addWidget(panel)
+    win.setCentralWidget(central)
+    win.resize(900, 600)
+    win.show()
+
+    panel.set_x_range(SciQLopPlotRange(0, 500))
+
+    sys.exit(app.exec())
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Adds `SciQLopTheme` wrapper class exposing NeoQCP's `QCPTheme` (7 color roles + busy indicator settings)
- Static factories `SciQLopTheme.light()` / `SciQLopTheme.dark()` with full property customization
- Theme API on `SciQLopPlotInterface` (virtual) and `SciQLopPlot` (concrete), with theme destruction safety via `QPointer` + `destroyed` signal
- Panel-level `SciQLopMultiPlotPanel.set_theme()` propagates to all child plots and auto-applies to newly added plots
- Python bindings with parent ownership transfer annotations
- Also adds configurable keyboard modifier for span creation mode and silences `VPlotsAlign` abstract method warnings

## Test plan

- [x] Verify `from SciQLopPlots import SciQLopTheme` works
- [ ] Run `tests/manual-tests/test_theming.py` — toggle light/dark, apply per-plot custom theme
- [ ] Verify reactive updates: changing a theme property after `set_theme()` updates all plots live

🤖 Generated with [Claude Code](https://claude.com/claude-code)