### PR TITLE
ci: enable unity builds and sccache to reduce build time

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -72,11 +72,14 @@ jobs:
         with:
           path: Qt
           key: qt-${{ matrix.qt_host }}-${{ matrix.arch }}-${{ env.QT_VERSION }}
-      - name: Install ccache (host)
-        if: runner.os != 'Linux'
+      - name: Install ccache (macOS)
+        if: runner.os == 'macOS'
         uses: hendrikmuhs/ccache-action@v1
         with:
           key: ccache-wheels-${{ matrix.os }}-${{ matrix.arch }}
+      - name: Install sccache (Windows)
+        if: runner.os == 'Windows'
+        uses: mozilla-actions/sccache-action@v0.0.7
       - name: Cache ccache (Linux container)
         if: runner.os == 'Linux'
         uses: actions/cache@v4
@@ -94,7 +97,7 @@ jobs:
           PYSIDE_VERSION: ${{ env.PYSIDE_VERSION }}
           QT_VERSION: ${{ env.QT_VERSION }}
           PIP_EXTRA_INDEX_URL: ${{ env.PIP_EXTRA_INDEX_URL }}
-          CIBW_ENVIRONMENT_WINDOWS: PYSIDE_VERSION=${{ env.PYSIDE_VERSION }} PIP_EXTRA_INDEX_URL=${{ env.PIP_EXTRA_INDEX_URL }} PATH="${GITHUB_WORKSPACE}\\Qt\\${{ env.QT_VERSION }}\\msvc2022_64\\bin;$PATH"
+          CIBW_ENVIRONMENT_WINDOWS: PYSIDE_VERSION=${{ env.PYSIDE_VERSION }} PIP_EXTRA_INDEX_URL=${{ env.PIP_EXTRA_INDEX_URL }} PATH="${GITHUB_WORKSPACE}\\Qt\\${{ env.QT_VERSION }}\\msvc2022_64\\bin;$PATH" CC="sccache cl" CXX="sccache cl"
           CIBW_ENVIRONMENT_MACOS: PYSIDE_VERSION=${{ env.PYSIDE_VERSION }} MACOSX_DEPLOYMENT_TARGET='13.3' PATH=/usr/lib/ccache:${{ env.GITHUB_WORKSPACE }}/Qt/${{ env.QT_VERSION }}/macos/bin:$PATH
           CIBW_ENVIRONMENT_LINUX: PYSIDE_VERSION=${{ env.PYSIDE_VERSION }} PIP_EXTRA_INDEX_URL=${{ env.PIP_EXTRA_INDEX_URL }} CC="ccache gcc" CXX="ccache g++" CCACHE_DIR=${{ env.GITHUB_WORKSPACE }}/.ccache PATH=${{ env.GITHUB_WORKSPACE }}/Qt/${{ env.QT_VERSION }}/${{ matrix.qt_dir }}/bin:$PATH LD_LIBRARY_PATH=${{ env.GITHUB_WORKSPACE }}/Qt/${{ env.QT_VERSION }}/${{ matrix.qt_dir }}/lib:$LD_LIBRARY_PATH
           CIBW_BEFORE_BUILD_WINDOWS: >

--- a/SciQLopPlots/meson.build
+++ b/SciQLopPlots/meson.build
@@ -7,6 +7,7 @@ fmt_dep = dependency('fmt', static:true)
 gl_dep = dependency('gl')
 NeoQCP_dep = dependency('NeoQCP', default_options: ['tracy_enable=@0@'.format(get_option('tracy_enable')),
                                                     'unity=on',
+                                                    'with_tests=false',
                                                     ])
 magic_enum_dep = dependency('magic_enum', static:true)
 

--- a/SciQLopPlots/meson.build
+++ b/SciQLopPlots/meson.build
@@ -164,7 +164,7 @@ python_interface_lib = static_library('python_interface',
         '../src/PythonInterface.cpp',
         dependencies : [python3_dep, shiboken_dep, qtdeps, NeoQCP_dep, cpp_utils_dep, fmt_dep, magic_enum_dep],
         include_directories : includes,
-        override_options: ['unity=false'],
+        override_options: ['unity=off'],
 )
 
 sources = moc_files \

--- a/SciQLopPlots/meson.build
+++ b/SciQLopPlots/meson.build
@@ -266,7 +266,7 @@ endif
 sciqlopplots_bindings = python3.extension_module('SciQLopPlotsBindings',
         sources,
         dependencies : [ python3_dep, shiboken_dep, qtdeps, NeoQCP_dep, cpp_utils_dep, gl_dep, fmt_dep, magic_enum_dep] + optional_deps,
-        link_with: [bindings_lib],
+        link_whole: [bindings_lib],
         cpp_args: cpp_args,
         subdir : 'SciQLopPlots',
         install: true,

--- a/SciQLopPlots/meson.build
+++ b/SciQLopPlots/meson.build
@@ -158,10 +158,11 @@ moc_files = qtmod.compile_moc(
 
 resources_files = qtmod.compile_resources(sources : ['../resources/resources.qrc'])
 
-# PythonInterface.cpp uses #pragma push_macro("slots") to handle
-# Qt/Python macro conflicts — incompatible with unity builds.
-python_interface_lib = static_library('python_interface',
-        '../src/PythonInterface.cpp',
+# Shiboken-generated sources and PythonInterface.cpp must be compiled
+# without unity: PySide6 headers reference protected enums that error
+# when merged with other TUs, and PythonInterface.cpp has slots macro conflicts.
+bindings_lib = static_library('sciqlopplots_bindings_impl',
+        sciqlopplots_bindings_src + shiboken_generator_out + ['../src/PythonInterface.cpp'],
         dependencies : [python3_dep, shiboken_dep, qtdeps, NeoQCP_dep, cpp_utils_dep, fmt_dep, magic_enum_dep],
         include_directories : includes,
         override_options: ['unity=off'],
@@ -169,8 +170,6 @@ python_interface_lib = static_library('python_interface',
 
 sources = moc_files \
         + resources_files \
-        + sciqlopplots_bindings_src \
-        + shiboken_generator_out \
         + [
             '../src/Profiling.cpp',
             '../src/SciQLopPlotInterface.cpp',
@@ -267,7 +266,7 @@ endif
 sciqlopplots_bindings = python3.extension_module('SciQLopPlotsBindings',
         sources,
         dependencies : [ python3_dep, shiboken_dep, qtdeps, NeoQCP_dep, cpp_utils_dep, gl_dep, fmt_dep, magic_enum_dep] + optional_deps,
-        link_with: [python_interface_lib],
+        link_with: [bindings_lib],
         cpp_args: cpp_args,
         subdir : 'SciQLopPlots',
         install: true,

--- a/SciQLopPlots/meson.build
+++ b/SciQLopPlots/meson.build
@@ -6,6 +6,7 @@ hedley_dep = dependency('hedley', main : true, fallback : ['hedley', 'hedley_dep
 fmt_dep = dependency('fmt', static:true)
 gl_dep = dependency('gl')
 NeoQCP_dep = dependency('NeoQCP', default_options: ['tracy_enable=@0@'.format(get_option('tracy_enable')),
+                                                    'unity=on',
                                                     ])
 magic_enum_dep = dependency('magic_enum', static:true)
 

--- a/SciQLopPlots/meson.build
+++ b/SciQLopPlots/meson.build
@@ -9,7 +9,7 @@ NeoQCP_dep = dependency('NeoQCP', default_options: ['tracy_enable=@0@'.format(ge
                                                     'unity=on',
                                                     'with_tests=false',
                                                     ])
-magic_enum_dep = dependency('magic_enum', static:true)
+magic_enum_dep = dependency('magic_enum', static:true, default_options: ['test=false'])
 
 qmake_possible_names = ['qmake-qt6','qmake6','qmake']
 pyside_version = '6'

--- a/SciQLopPlots/meson.build
+++ b/SciQLopPlots/meson.build
@@ -158,13 +158,21 @@ moc_files = qtmod.compile_moc(
 
 resources_files = qtmod.compile_resources(sources : ['../resources/resources.qrc'])
 
+# PythonInterface.cpp uses #pragma push_macro("slots") to handle
+# Qt/Python macro conflicts — incompatible with unity builds.
+python_interface_lib = static_library('python_interface',
+        '../src/PythonInterface.cpp',
+        dependencies : [python3_dep, shiboken_dep, qtdeps, NeoQCP_dep, cpp_utils_dep, fmt_dep, magic_enum_dep],
+        include_directories : includes,
+        override_options: ['unity=false'],
+)
+
 sources = moc_files \
         + resources_files \
         + sciqlopplots_bindings_src \
         + shiboken_generator_out \
         + [
             '../src/Profiling.cpp',
-            '../src/PythonInterface.cpp',
             '../src/SciQLopPlotInterface.cpp',
             '../src/SciQLopPlot.cpp',
             '../src/SciQLopPlotLegend.cpp',
@@ -259,6 +267,7 @@ endif
 sciqlopplots_bindings = python3.extension_module('SciQLopPlotsBindings',
         sources,
         dependencies : [ python3_dep, shiboken_dep, qtdeps, NeoQCP_dep, cpp_utils_dep, gl_dep, fmt_dep, magic_enum_dep] + optional_deps,
+        link_with: [python_interface_lib],
         cpp_args: cpp_args,
         subdir : 'SciQLopPlots',
         install: true,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ homepage = "https://github.com/SciQLop/SciQLopPlots"
 
 [tool.meson-python.args]
 install = ['--tags=runtime,python-runtime']
-setup = ['-Doptimization=3', '-Dcpp_std=c++20', '-Dbuildtype=release', '--vsenv']
+setup = ['-Doptimization=3', '-Dcpp_std=c++20', '-Dbuildtype=release', '--vsenv', '--unity=on']
 
 [tool.pytest.ini_options]
 addopts = "--import-mode=importlib"


### PR DESCRIPTION
## Summary

- Enable Meson unity builds (`--unity=on`) for both SciQLopPlots and NeoQCP subproject — merges translation units to eliminate redundant header parsing across ~190 source files
- Switch from ccache to sccache on Windows for native MSVC support
- Keep ccache on macOS and Linux (already working well)

## Expected impact

| Change | Expected saving |
|---|---|
| Unity builds | 30-50% compile time reduction (fewer TUs = less header parsing) |
| sccache on Windows | 50%+ on warm cache (native MSVC support vs ccache) |

## Risk

- Unity builds can surface ODR violations or conflicting `using namespace` across TUs — if so, specific files can be excluded with `override_options: ['unity=false']`
- sccache may need path adjustments in cibuildwheel's environment

## Test plan

- [ ] Watch CI run on all platforms (Linux x86_64, Linux aarch64, Windows, macOS Intel, macOS ARM)
- [ ] Compare build times with previous runs
- [ ] If unity build fails, identify conflicting TUs and exclude them


🤖 Generated with [Claude Code](https://claude.com/claude-code)