### PR TITLE
fix: anchor PyBuffer lifetime in SciQLopLineGraph zero-copy path

### DIFF
--- a/include/SciQLopPlots/Plotables/SciQLopLineGraph.hpp
+++ b/include/SciQLopPlots/Plotables/SciQLopLineGraph.hpp
@@ -26,12 +26,24 @@
 #include "QCPAbstractPlottableWrapper.hpp"
 #include "SciQLopPlots/SciQLopPlotAxis.hpp"
 #include <plottables/plottable-multigraph.h>
+#include <datasource/abstract-multi-datasource.h>
 #include <span>
+#include <memory>
 
 class SciQLopLineGraph : public SQPQCPAbstractPlottableWrapper
 {
     QCPMultiGraph* _multiGraph = nullptr;
-    PyBuffer _x, _y;
+
+    // Lifetime anchor: PyBuffers + data source share lifetime via shared_ptr.
+    // The aliased shared_ptr given to QCPMultiGraph ensures numpy memory stays
+    // alive as long as the async pipeline holds a reference to the source.
+    struct DataHolder
+    {
+        PyBuffer x, y;
+        std::shared_ptr<QCPAbstractMultiDataSource> source;
+    };
+    std::shared_ptr<DataHolder> _dataHolder;
+
     QStringList _pendingLabels;
 
     SciQLopPlotAxis* _keyAxis;

--- a/src/PythonInterface.cpp
+++ b/src/PythonInterface.cpp
@@ -128,12 +128,12 @@ struct DeferredReleaseQueue
         PyGILState_Release(gstate);
     }
 
-    void schedule_drain()
+    // Called with mutex held. Returns true if the caller must invoke
+    // drain() synchronously after releasing the mutex (no event loop).
+    bool schedule_drain_locked()
     {
-        // Already scheduled — nothing to do.
-        // Access under mutex held by the caller.
         if (drain_scheduled)
-            return;
+            return false;
 
         auto* app = QCoreApplication::instance();
         if (app)
@@ -141,26 +141,36 @@ struct DeferredReleaseQueue
             drain_scheduled = true;
             QMetaObject::invokeMethod(
                 app, [this]() { drain(); }, Qt::QueuedConnection);
+            return false;
         }
-        else
-        {
-            // No running event loop (shutdown) — drain synchronously.
-            drain();
-        }
+
+        // No running event loop (startup/shutdown) — caller must
+        // drain synchronously after releasing the mutex.
+        return true;
     }
 
     void defer_decref(PyObject* obj)
     {
-        std::lock_guard<std::mutex> lock(mutex);
-        decrefs.push_back(obj);
-        schedule_drain();
+        bool need_sync_drain = false;
+        {
+            std::lock_guard<std::mutex> lock(mutex);
+            decrefs.push_back(obj);
+            need_sync_drain = schedule_drain_locked();
+        }
+        if (need_sync_drain)
+            drain();
     }
 
     void defer_buffer_release(Py_buffer buf)
     {
-        std::lock_guard<std::mutex> lock(mutex);
-        buffer_releases.push_back(buf);
-        schedule_drain();
+        bool need_sync_drain = false;
+        {
+            std::lock_guard<std::mutex> lock(mutex);
+            buffer_releases.push_back(buf);
+            need_sync_drain = schedule_drain_locked();
+        }
+        if (need_sync_drain)
+            drain();
     }
 };
 

--- a/src/PythonInterface.cpp
+++ b/src/PythonInterface.cpp
@@ -60,6 +60,11 @@ extern "C"
 #define SKIP_PYTHON_INTERFACE_CPP
 #include "SciQLopPlots/Python/PythonInterface.hpp"
 
+#include <QCoreApplication>
+#include <QThread>
+#include <mutex>
+#include <vector>
+
 struct PyAutoScopedGIL
 {
     PyGILState_STATE gstate;
@@ -68,6 +73,104 @@ struct PyAutoScopedGIL
 
     ~PyAutoScopedGIL() { PyGILState_Release(gstate); }
 };
+
+// ---------------------------------------------------------------------------
+// Deferred Python release queue
+//
+// When PyBuffer or PyObjectWrapper instances are destroyed on a non-main
+// thread (e.g. a QThreadPool worker running a NeoQCP async pipeline job),
+// acquiring the GIL can cause severe contention or deadlock with the
+// DataProvider worker thread (which holds the GIL while calling Python)
+// and the main thread (which processes Qt events).
+//
+// Instead of blocking on PyGILState_Ensure from arbitrary threads, we
+// queue the release operations and drain them on the main thread where
+// GIL acquisition is cheap (the main thread is typically the GIL holder
+// when processing Qt events from Python).
+// ---------------------------------------------------------------------------
+namespace
+{
+
+struct DeferredReleaseQueue
+{
+    std::mutex mutex;
+    std::vector<PyObject*> decrefs;
+    std::vector<Py_buffer> buffer_releases;
+    bool drain_scheduled = false;
+
+    static DeferredReleaseQueue& instance()
+    {
+        static DeferredReleaseQueue q;
+        return q;
+    }
+
+    void drain()
+    {
+        std::vector<PyObject*> local_decrefs;
+        std::vector<Py_buffer> local_buffers;
+        {
+            std::lock_guard<std::mutex> lock(mutex);
+            local_decrefs.swap(decrefs);
+            local_buffers.swap(buffer_releases);
+            drain_scheduled = false;
+        }
+
+        if (local_decrefs.empty() && local_buffers.empty())
+            return;
+
+        auto gstate = PyGILState_Ensure();
+        // Release buffers before decrefs: a buffer may hold an internal
+        // reference to the object, so release it first.
+        for (auto& buf : local_buffers)
+            PyBuffer_Release(&buf);
+        for (auto* obj : local_decrefs)
+            Py_DECREF(obj);
+        PyGILState_Release(gstate);
+    }
+
+    void schedule_drain()
+    {
+        // Already scheduled — nothing to do.
+        // Access under mutex held by the caller.
+        if (drain_scheduled)
+            return;
+
+        auto* app = QCoreApplication::instance();
+        if (app)
+        {
+            drain_scheduled = true;
+            QMetaObject::invokeMethod(
+                app, [this]() { drain(); }, Qt::QueuedConnection);
+        }
+        else
+        {
+            // No running event loop (shutdown) — drain synchronously.
+            drain();
+        }
+    }
+
+    void defer_decref(PyObject* obj)
+    {
+        std::lock_guard<std::mutex> lock(mutex);
+        decrefs.push_back(obj);
+        schedule_drain();
+    }
+
+    void defer_buffer_release(Py_buffer buf)
+    {
+        std::lock_guard<std::mutex> lock(mutex);
+        buffer_releases.push_back(buf);
+        schedule_drain();
+    }
+};
+
+inline bool on_main_thread()
+{
+    auto* app = QCoreApplication::instance();
+    return app && QThread::currentThread() == app->thread();
+}
+
+} // anonymous namespace
 
 inline void _inc_ref(PyObject* obj)
 {
@@ -82,19 +185,27 @@ inline void _inc_ref(PyObject* obj)
 
 inline void _dec_ref(PyObject* obj)
 {
-    auto scoped_gil = PyAutoScopedGIL();
+    if (on_main_thread())
+    {
+        auto scoped_gil = PyAutoScopedGIL();
 #ifdef _TRACE_REF_COUNT
-    std::cout << "Dec ref: " << obj << " " << obj->ob_refcnt << std::endl;
-    if (obj->ob_refcnt == 1)
-    {
-        std::cout << "Dec ref, Last ref: " << obj << std::endl;
-    }
-    else if (obj->ob_refcnt > 100)
-    {
-        std::cout << "Dec ref, weird high refcount: " << obj << " " << obj->ob_refcnt << std::endl;
-    }
+        std::cout << "Dec ref: " << obj << " " << obj->ob_refcnt << std::endl;
+        if (obj->ob_refcnt == 1)
+        {
+            std::cout << "Dec ref, Last ref: " << obj << std::endl;
+        }
+        else if (obj->ob_refcnt > 100)
+        {
+            std::cout << "Dec ref, weird high refcount: " << obj << " " << obj->ob_refcnt
+                      << std::endl;
+        }
 #endif
-    Py_DECREF(obj);
+        Py_DECREF(obj);
+    }
+    else
+    {
+        DeferredReleaseQueue::instance().defer_decref(obj);
+    }
 }
 
 struct PyObjectWrapper
@@ -239,8 +350,15 @@ struct _PyBuffer_impl : PyObjectWrapper
     {
         if (this->is_valid)
         {
-            auto scoped_gil = PyAutoScopedGIL();
-            PyBuffer_Release(&this->buffer);
+            if (on_main_thread())
+            {
+                auto scoped_gil = PyAutoScopedGIL();
+                PyBuffer_Release(&this->buffer);
+            }
+            else
+            {
+                DeferredReleaseQueue::instance().defer_buffer_release(this->buffer);
+            }
             this->is_valid = false;
             this->buffer = { 0 };
         }

--- a/src/PythonInterface.cpp
+++ b/src/PythonInterface.cpp
@@ -60,11 +60,6 @@ extern "C"
 #define SKIP_PYTHON_INTERFACE_CPP
 #include "SciQLopPlots/Python/PythonInterface.hpp"
 
-#include <QCoreApplication>
-#include <QThread>
-#include <mutex>
-#include <vector>
-
 struct PyAutoScopedGIL
 {
     PyGILState_STATE gstate;
@@ -73,114 +68,6 @@ struct PyAutoScopedGIL
 
     ~PyAutoScopedGIL() { PyGILState_Release(gstate); }
 };
-
-// ---------------------------------------------------------------------------
-// Deferred Python release queue
-//
-// When PyBuffer or PyObjectWrapper instances are destroyed on a non-main
-// thread (e.g. a QThreadPool worker running a NeoQCP async pipeline job),
-// acquiring the GIL can cause severe contention or deadlock with the
-// DataProvider worker thread (which holds the GIL while calling Python)
-// and the main thread (which processes Qt events).
-//
-// Instead of blocking on PyGILState_Ensure from arbitrary threads, we
-// queue the release operations and drain them on the main thread where
-// GIL acquisition is cheap (the main thread is typically the GIL holder
-// when processing Qt events from Python).
-// ---------------------------------------------------------------------------
-namespace
-{
-
-struct DeferredReleaseQueue
-{
-    std::mutex mutex;
-    std::vector<PyObject*> decrefs;
-    std::vector<Py_buffer> buffer_releases;
-    bool drain_scheduled = false;
-
-    static DeferredReleaseQueue& instance()
-    {
-        static DeferredReleaseQueue q;
-        return q;
-    }
-
-    void drain()
-    {
-        std::vector<PyObject*> local_decrefs;
-        std::vector<Py_buffer> local_buffers;
-        {
-            std::lock_guard<std::mutex> lock(mutex);
-            local_decrefs.swap(decrefs);
-            local_buffers.swap(buffer_releases);
-            drain_scheduled = false;
-        }
-
-        if (local_decrefs.empty() && local_buffers.empty())
-            return;
-
-        auto gstate = PyGILState_Ensure();
-        // Release buffers before decrefs: a buffer may hold an internal
-        // reference to the object, so release it first.
-        for (auto& buf : local_buffers)
-            PyBuffer_Release(&buf);
-        for (auto* obj : local_decrefs)
-            Py_DECREF(obj);
-        PyGILState_Release(gstate);
-    }
-
-    // Called with mutex held. Returns true if the caller must invoke
-    // drain() synchronously after releasing the mutex (no event loop).
-    bool schedule_drain_locked()
-    {
-        if (drain_scheduled)
-            return false;
-
-        auto* app = QCoreApplication::instance();
-        if (app && !QCoreApplication::closingDown())
-        {
-            drain_scheduled = true;
-            QMetaObject::invokeMethod(
-                app, [this]() { drain(); }, Qt::QueuedConnection);
-            return false;
-        }
-
-        // No running event loop or app shutting down — caller must
-        // drain synchronously after releasing the mutex.
-        return true;
-    }
-
-    void defer_decref(PyObject* obj)
-    {
-        bool need_sync_drain = false;
-        {
-            std::lock_guard<std::mutex> lock(mutex);
-            decrefs.push_back(obj);
-            need_sync_drain = schedule_drain_locked();
-        }
-        if (need_sync_drain)
-            drain();
-    }
-
-    void defer_buffer_release(Py_buffer buf)
-    {
-        bool need_sync_drain = false;
-        {
-            std::lock_guard<std::mutex> lock(mutex);
-            buffer_releases.push_back(buf);
-            need_sync_drain = schedule_drain_locked();
-        }
-        if (need_sync_drain)
-            drain();
-    }
-};
-
-inline bool on_main_thread()
-{
-    auto* app = QCoreApplication::instance();
-    return app && QThread::currentThread() == app->thread();
-}
-
-} // anonymous namespace
 
 inline void _inc_ref(PyObject* obj)
 {
@@ -195,27 +82,19 @@ inline void _inc_ref(PyObject* obj)
 
 inline void _dec_ref(PyObject* obj)
 {
-    if (on_main_thread())
-    {
-        auto scoped_gil = PyAutoScopedGIL();
+    auto scoped_gil = PyAutoScopedGIL();
 #ifdef _TRACE_REF_COUNT
-        std::cout << "Dec ref: " << obj << " " << obj->ob_refcnt << std::endl;
-        if (obj->ob_refcnt == 1)
-        {
-            std::cout << "Dec ref, Last ref: " << obj << std::endl;
-        }
-        else if (obj->ob_refcnt > 100)
-        {
-            std::cout << "Dec ref, weird high refcount: " << obj << " " << obj->ob_refcnt
-                      << std::endl;
-        }
-#endif
-        Py_DECREF(obj);
-    }
-    else
+    std::cout << "Dec ref: " << obj << " " << obj->ob_refcnt << std::endl;
+    if (obj->ob_refcnt == 1)
     {
-        DeferredReleaseQueue::instance().defer_decref(obj);
+        std::cout << "Dec ref, Last ref: " << obj << std::endl;
     }
+    else if (obj->ob_refcnt > 100)
+    {
+        std::cout << "Dec ref, weird high refcount: " << obj << " " << obj->ob_refcnt << std::endl;
+    }
+#endif
+    Py_DECREF(obj);
 }
 
 struct PyObjectWrapper
@@ -360,15 +239,8 @@ struct _PyBuffer_impl : PyObjectWrapper
     {
         if (this->is_valid)
         {
-            if (on_main_thread())
-            {
-                auto scoped_gil = PyAutoScopedGIL();
-                PyBuffer_Release(&this->buffer);
-            }
-            else
-            {
-                DeferredReleaseQueue::instance().defer_buffer_release(this->buffer);
-            }
+            auto scoped_gil = PyAutoScopedGIL();
+            PyBuffer_Release(&this->buffer);
             this->is_valid = false;
             this->buffer = { 0 };
         }

--- a/src/PythonInterface.cpp
+++ b/src/PythonInterface.cpp
@@ -136,7 +136,7 @@ struct DeferredReleaseQueue
             return false;
 
         auto* app = QCoreApplication::instance();
-        if (app)
+        if (app && !QCoreApplication::closingDown())
         {
             drain_scheduled = true;
             QMetaObject::invokeMethod(
@@ -144,7 +144,7 @@ struct DeferredReleaseQueue
             return false;
         }
 
-        // No running event loop (startup/shutdown) — caller must
+        // No running event loop or app shutting down — caller must
         // drain synchronously after releasing the mutex.
         return true;
     }

--- a/src/SciQLopLineGraph.cpp
+++ b/src/SciQLopLineGraph.cpp
@@ -20,6 +20,7 @@
 -- Mail : alexis.jeandet@member.fsf.org
 ----------------------------------------------------------------------------*/
 #include "SciQLopPlots/Plotables/SciQLopLineGraph.hpp"
+#include <datasource/soa-multi-datasource.h>
 #include <vector>
 
 void SciQLopLineGraph::create_graphs(const QStringList& labels)
@@ -76,9 +77,6 @@ void SciQLopLineGraph::set_data(PyBuffer x, PyBuffer y)
     if (x.format_code() != 'd')
         throw std::runtime_error("Keys (x) must be float64");
 
-    _x = x;
-    _y = y;
-
     const auto* keys = static_cast<const double*>(x.raw_data());
     const int n = static_cast<int>(x.flat_size());
 
@@ -89,13 +87,21 @@ void SciQLopLineGraph::set_data(PyBuffer x, PyBuffer y)
         if (y.ndim() == 1)
         {
             std::vector<std::span<const V>> columns{std::span<const V>(values, n)};
-            _multiGraph->viewData<double, V>(std::span<const double>(keys, n), std::move(columns));
+            auto source = std::make_shared<
+                QCPSoAMultiDataSource<std::span<const double>, std::span<const V>>>(
+                std::span<const double>(keys, n), std::move(columns));
+            _dataHolder = std::make_shared<DataHolder>(DataHolder{x, y, source});
+            auto aliased
+                = std::shared_ptr<QCPAbstractMultiDataSource>(_dataHolder, source.get());
+            _multiGraph->setDataSource(std::move(aliased));
         }
         else
         {
             const auto n_cols = y.size(1);
             if (y.row_major())
             {
+                // Row-major: data must be transposed — copies are made,
+                // so the source owns its memory and no lifetime anchor is needed.
                 std::vector<std::vector<V>> owned_columns(n_cols);
                 for (std::size_t col = 0; col < n_cols; ++col)
                 {
@@ -109,15 +115,22 @@ void SciQLopLineGraph::set_data(PyBuffer x, PyBuffer y)
                 for (auto& col : owned_columns)
                     cols_move.push_back(std::move(col));
                 _multiGraph->setData(std::move(owned_keys), std::move(cols_move));
+                _dataHolder = std::make_shared<DataHolder>(DataHolder{x, y, nullptr});
             }
             else
             {
+                // Column-major: zero-copy spans — anchor PyBuffers via aliased shared_ptr.
                 std::vector<std::span<const V>> columns;
                 columns.reserve(n_cols);
                 for (std::size_t col = 0; col < n_cols; ++col)
                     columns.emplace_back(values + col * n, n);
-                _multiGraph->viewData<double, V>(
+                auto source = std::make_shared<
+                    QCPSoAMultiDataSource<std::span<const double>, std::span<const V>>>(
                     std::span<const double>(keys, n), std::move(columns));
+                _dataHolder = std::make_shared<DataHolder>(DataHolder{x, y, source});
+                auto aliased
+                    = std::shared_ptr<QCPAbstractMultiDataSource>(_dataHolder, source.get());
+                _multiGraph->setDataSource(std::move(aliased));
             }
         }
     });
@@ -150,7 +163,9 @@ void SciQLopLineGraph::set_data(PyBuffer x, PyBuffer y)
 
 QList<PyBuffer> SciQLopLineGraph::data() const noexcept
 {
-    return {_x, _y};
+    if (_dataHolder)
+        return {_dataHolder->x, _dataHolder->y};
+    return {};
 }
 
 void SciQLopLineGraph::set_x_axis(SciQLopPlotAxisInterface* axis) noexcept

--- a/src/SciQLopLineGraph.cpp
+++ b/src/SciQLopLineGraph.cpp
@@ -100,8 +100,8 @@ void SciQLopLineGraph::set_data(PyBuffer x, PyBuffer y)
             const auto n_cols = y.size(1);
             if (y.row_major())
             {
-                // Row-major: data must be transposed — copies are made,
-                // so the source owns its memory and no lifetime anchor is needed.
+                // Row-major: data is copied (transposed), so QCP owns its memory.
+                // _dataHolder still populated for the data() accessor API.
                 std::vector<std::vector<V>> owned_columns(n_cols);
                 for (std::size_t col = 0; col < n_cols; ++col)
                 {


### PR DESCRIPTION
## Summary
- Fixes `SciQLopLineGraph` to use an aliased `shared_ptr` lifetime anchor pattern (same as `SciQLopSingleLineGraph` and `SciQLopColorMap`), preventing use-after-free when numpy memory is reclaimed while NeoQCP async pipeline workers still reference span-backed data sources

## What changed
- `SciQLopLineGraph` now wraps PyBuffers + data source in a `DataHolder` struct tied together via `shared_ptr`
- The aliased `shared_ptr` given to `QCPMultiGraph::setDataSource()` ensures numpy memory stays alive as long as the async pipeline holds a reference
- Removed the deferred GIL release queue — the macOS slowdown is more likely caused by expensive per-tick font metrics in NeoQCP (CoreText overhead), not GIL contention

## Test plan
- [ ] Verify data is correctly displayed after multiple rapid `set_data` calls on `SciQLopLineGraph`
- [ ] Verify no Python object leaks by checking refcounts remain stable over time

🤖 Generated with [Claude Code](https://claude.com/claude-code)