### PR TITLE
fix: smooth drag panning on Linux/Wayland

### DIFF
--- a/include/SciQLopPlots/SciQLopPlot.hpp
+++ b/include/SciQLopPlots/SciQLopPlot.hpp
@@ -53,6 +53,7 @@ class SciQLopPlot : public QCustomPlot
     QList<SciQLopPlotAxis*> m_axes;
     bool m_replot_pending = false;
     QElapsedTimer m_drag_throttle_timer;
+    bool m_suppress_range_signals = false;
 
     QList<SciQLopPlottableInterface*> m_plottables;
     SciQLopColorMap* m_color_map = nullptr;

--- a/include/SciQLopPlots/SciQLopPlot.hpp
+++ b/include/SciQLopPlots/SciQLopPlot.hpp
@@ -34,6 +34,7 @@
 #include "SciQLopPlots/SciQLopOverlay.hpp"
 #include "SciQLopPlots/SciQLopTheme.hpp"
 #include "SciQLopPlots/enums.hpp"
+#include <QElapsedTimer>
 #include <QPointF>
 #include <optional>
 #include <qcustomplot.h>
@@ -51,6 +52,7 @@ class SciQLopPlot : public QCustomPlot
     QCPColorScale* m_color_scale = nullptr;
     QList<SciQLopPlotAxis*> m_axes;
     bool m_replot_pending = false;
+    QElapsedTimer m_drag_throttle_timer;
 
     QList<SciQLopPlottableInterface*> m_plottables;
     SciQLopColorMap* m_color_map = nullptr;

--- a/src/SciQLopPlot.cpp
+++ b/src/SciQLopPlot.cpp
@@ -74,16 +74,16 @@ SciQLopPlot::SciQLopPlot(QWidget* parent) : QCustomPlot { parent }
     connect(this, &QCustomPlot::legendDoubleClick, this, &SciQLopPlot::_legend_double_clicked);
     connect(this->xAxis, QOverload<const QCPRange&>::of(&QCPAxis::rangeChanged), this,
             [this](const QCPRange& range)
-            { Q_EMIT x_axis_range_changed({ range.lower, range.upper }); });
+            { if (!m_suppress_range_signals) Q_EMIT x_axis_range_changed({ range.lower, range.upper }); });
     connect(this->xAxis2, QOverload<const QCPRange&>::of(&QCPAxis::rangeChanged), this,
             [this](const QCPRange& range)
-            { Q_EMIT x2_axis_range_changed({ range.lower, range.upper }); });
+            { if (!m_suppress_range_signals) Q_EMIT x2_axis_range_changed({ range.lower, range.upper }); });
     connect(this->yAxis, QOverload<const QCPRange&>::of(&QCPAxis::rangeChanged), this,
             [this](const QCPRange& range)
-            { Q_EMIT y_axis_range_changed({ range.lower, range.upper }); });
+            { if (!m_suppress_range_signals) Q_EMIT y_axis_range_changed({ range.lower, range.upper }); });
     connect(this->yAxis2, QOverload<const QCPRange&>::of(&QCPAxis::rangeChanged), this,
             [this](const QCPRange& range)
-            { Q_EMIT y2_axis_range_changed({ range.lower, range.upper }); });
+            { if (!m_suppress_range_signals) Q_EMIT y2_axis_range_changed({ range.lower, range.upper }); });
 
     m_color_scale = new QCPColorScale(this);
     m_color_scale->setVisible(false);
@@ -93,7 +93,7 @@ SciQLopPlot::SciQLopPlot(QWidget* parent) : QCustomPlot { parent }
 
     connect(m_color_scale->axis(), QOverload<const QCPRange&>::of(&QCPAxis::rangeChanged), this,
             [this](const QCPRange& range)
-            { Q_EMIT z_axis_range_changed({ range.lower, range.upper }); });
+            { if (!m_suppress_range_signals) Q_EMIT z_axis_range_changed({ range.lower, range.upper }); });
 
     this->m_axes.append(new SciQLopPlotAxis(this->xAxis, this, false, "X Axis"));
     this->m_axes.append(new SciQLopPlotAxis(this->yAxis, this, false, "Y Axis"));
@@ -240,16 +240,18 @@ void SciQLopPlot::mouseMoveEvent(QMouseEvent* event)
 {
     if (event->buttons() != Qt::NoButton)
     {
-        // Throttle drag events — Linux/Wayland can deliver 1000+ mouse
-        // events/sec which saturates the event loop with rangeChanged
-        // signal chains.  Cap at ~120 Hz to match macOS-like behavior.
-        if (m_drag_throttle_timer.isValid() && m_drag_throttle_timer.elapsed() < 8)
-        {
-            event->accept();
-            return;
-        }
-        m_drag_throttle_timer.start();
+        // Every drag event goes to QCustomPlot so axes move smoothly and
+        // NeoQCP redraws from its L2 cache.  The expensive SciQLopPlots
+        // signal chain (AxisSynchronizer, data pipelines) is suppressed
+        // between throttle ticks (~120 Hz) to avoid saturating the event
+        // loop on Linux/Wayland (1000+ Hz raw mouse rate).
+        const bool throttled = m_drag_throttle_timer.isValid()
+            && m_drag_throttle_timer.elapsed() < 8;
+        if (!throttled)
+            m_drag_throttle_timer.start();
+        m_suppress_range_signals = throttled;
         QCustomPlot::mouseMoveEvent(event);
+        m_suppress_range_signals = false;
         return;
     }
     QCustomPlot::mouseMoveEvent(event);

--- a/src/SciQLopPlot.cpp
+++ b/src/SciQLopPlot.cpp
@@ -238,6 +238,20 @@ void SciQLopPlot::mousePressEvent(QMouseEvent* event)
 
 void SciQLopPlot::mouseMoveEvent(QMouseEvent* event)
 {
+    if (event->buttons() != Qt::NoButton)
+    {
+        // Throttle drag events — Linux/Wayland can deliver 1000+ mouse
+        // events/sec which saturates the event loop with rangeChanged
+        // signal chains.  Cap at ~120 Hz to match macOS-like behavior.
+        if (m_drag_throttle_timer.isValid() && m_drag_throttle_timer.elapsed() < 8)
+        {
+            event->accept();
+            return;
+        }
+        m_drag_throttle_timer.start();
+        QCustomPlot::mouseMoveEvent(event);
+        return;
+    }
     QCustomPlot::mouseMoveEvent(event);
     _update_mouse_cursor(event);
     _update_tracer(event->pos());


### PR DESCRIPTION
## Summary
- Throttle drag mouse events to ~120 Hz to match macOS-like coalescing (Linux/Wayland delivers 1000+ Hz raw)
- Between throttle ticks, suppress the expensive SciQLopPlots signal chain (AxisSynchronizer, data pipelines) while still letting every event through to QCustomPlot — axes move smoothly and NeoQCP redraws from its L2 cache
- No impact on macOS (already coalesced) or on wheel zoom (separate path)

## Test plan
- [ ] Drag-pan on Linux/Wayland — should be smooth, not jumpy
- [ ] Drag-pan on macOS — no regression
- [ ] Wheel zoom — no regression
- [ ] Multi-plot sync during drag (AxisSynchronizer still fires at throttled rate)
- [ ] Function graph data pipeline still updates during drag

🤖 Generated with [Claude Code](https://claude.com/claude-code)