### PR TITLE
Python hardening foundation: validators, typed wrappers, exception taxonomy

### DIFF
--- a/SciQLopPlots/bindings/bindings.h
+++ b/SciQLopPlots/bindings/bindings.h
@@ -8,6 +8,7 @@
 
 #include "SciQLopPlots/Python/PythonInterface.hpp"
 #include "SciQLopPlots/Python/Validation.hpp"
+#include "SciQLopPlots/Python/MatchedBuffers.hpp"
 
 #include "_QCustomPlot.hpp"
 #include <SciQLopPlots/DataProducer/DataProducer.hpp>

--- a/SciQLopPlots/bindings/bindings.h
+++ b/SciQLopPlots/bindings/bindings.h
@@ -7,6 +7,7 @@
 // #include <memory>
 
 #include "SciQLopPlots/Python/PythonInterface.hpp"
+#include "SciQLopPlots/Python/Validation.hpp"
 
 #include "_QCustomPlot.hpp"
 #include <SciQLopPlots/DataProducer/DataProducer.hpp>

--- a/SciQLopPlots/bindings/bindings.xml
+++ b/SciQLopPlots/bindings/bindings.xml
@@ -847,6 +847,9 @@
         <inject-code class="target" position="beginning">
             try {
                 sqp::validation::validate_xy(%1, %2);
+            } catch (const std::domain_error&amp; e) {
+                PyErr_SetString(PyExc_TypeError, e.what());
+                return nullptr;
             } catch (const std::invalid_argument&amp; e) {
                 PyErr_SetString(PyExc_ValueError, e.what());
                 return nullptr;
@@ -864,6 +867,9 @@
         <inject-code class="target" position="beginning">
             try {
                 sqp::validation::validate_xyz(%1, %2, %3);
+            } catch (const std::domain_error&amp; e) {
+                PyErr_SetString(PyExc_TypeError, e.what());
+                return nullptr;
             } catch (const std::invalid_argument&amp; e) {
                 PyErr_SetString(PyExc_ValueError, e.what());
                 return nullptr;
@@ -881,6 +887,9 @@
         <inject-code class="target" position="beginning">
             try {
                 sqp::validation::validate_nd_list(%1, %2);
+            } catch (const std::domain_error&amp; e) {
+                PyErr_SetString(PyExc_TypeError, e.what());
+                return nullptr;
             } catch (const std::invalid_argument&amp; e) {
                 PyErr_SetString(PyExc_ValueError, e.what());
                 return nullptr;

--- a/SciQLopPlots/bindings/bindings.xml
+++ b/SciQLopPlots/bindings/bindings.xml
@@ -836,6 +836,39 @@
             }
         </inject-code>
     </add-function>
+
+    <add-function signature="validate_nd_list(QList&lt;PyBuffer&gt;, std::size_t)" return-type="void">
+        <extra-includes>
+            <include file-name="SciQLopPlots/Python/Validation.hpp" location="global"/>
+        </extra-includes>
+        <inject-code class="target" position="beginning">
+            try {
+                sqp::validation::validate_nd_list(%1, %2);
+            } catch (const std::invalid_argument&amp; e) {
+                PyErr_SetString(PyExc_ValueError, e.what());
+                return nullptr;
+            } catch (const std::exception&amp; e) {
+                PyErr_SetString(PyExc_RuntimeError, e.what());
+                return nullptr;
+            }
+        </inject-code>
+    </add-function>
+    <add-function signature="validate_finite(double, std::string)" return-type="void">
+        <extra-includes>
+            <include file-name="SciQLopPlots/Python/Validation.hpp" location="global"/>
+        </extra-includes>
+        <inject-code class="target" position="beginning">
+            try {
+                sqp::validation::validate_finite(%1, %2);
+            } catch (const std::invalid_argument&amp; e) {
+                PyErr_SetString(PyExc_ValueError, e.what());
+                return nullptr;
+            } catch (const std::exception&amp; e) {
+                PyErr_SetString(PyExc_RuntimeError, e.what());
+                return nullptr;
+            }
+        </inject-code>
+    </add-function>
 </typesystem>
 
 

--- a/SciQLopPlots/bindings/bindings.xml
+++ b/SciQLopPlots/bindings/bindings.xml
@@ -785,6 +785,57 @@
             }
         </inject-code>
     </add-function>
+
+    <add-function signature="validate_same_length(PyBuffer, std::string, PyBuffer, std::string)" return-type="void">
+        <extra-includes>
+            <include file-name="SciQLopPlots/Python/Validation.hpp" location="global"/>
+        </extra-includes>
+        <inject-code class="target" position="beginning">
+            try {
+                sqp::validation::validate_same_length(%1, %2, %3, %4);
+            } catch (const std::invalid_argument&amp; e) {
+                PyErr_SetString(PyExc_ValueError, e.what());
+                return nullptr;
+            } catch (const std::exception&amp; e) {
+                PyErr_SetString(PyExc_RuntimeError, e.what());
+                return nullptr;
+            }
+        </inject-code>
+    </add-function>
+
+    <add-function signature="validate_xy(PyBuffer, PyBuffer)" return-type="void">
+        <extra-includes>
+            <include file-name="SciQLopPlots/Python/Validation.hpp" location="global"/>
+        </extra-includes>
+        <inject-code class="target" position="beginning">
+            try {
+                sqp::validation::validate_xy(%1, %2);
+            } catch (const std::invalid_argument&amp; e) {
+                PyErr_SetString(PyExc_ValueError, e.what());
+                return nullptr;
+            } catch (const std::exception&amp; e) {
+                PyErr_SetString(PyExc_RuntimeError, e.what());
+                return nullptr;
+            }
+        </inject-code>
+    </add-function>
+
+    <add-function signature="validate_xyz(PyBuffer, PyBuffer, PyBuffer)" return-type="void">
+        <extra-includes>
+            <include file-name="SciQLopPlots/Python/Validation.hpp" location="global"/>
+        </extra-includes>
+        <inject-code class="target" position="beginning">
+            try {
+                sqp::validation::validate_xyz(%1, %2, %3);
+            } catch (const std::invalid_argument&amp; e) {
+                PyErr_SetString(PyExc_ValueError, e.what());
+                return nullptr;
+            } catch (const std::exception&amp; e) {
+                PyErr_SetString(PyExc_RuntimeError, e.what());
+                return nullptr;
+            }
+        </inject-code>
+    </add-function>
 </typesystem>
 
 

--- a/SciQLopPlots/bindings/bindings.xml
+++ b/SciQLopPlots/bindings/bindings.xml
@@ -153,6 +153,23 @@
         </modify-function>
     </value-type>
 
+    <value-type name="MatchedXYZ">
+        <modify-function signature="from_py(PyBuffer,PyBuffer,PyBuffer)">
+            <inject-code class="target" position="beginning">
+                try {
+                    auto result = MatchedXYZ::from_py(%1, %2, %3);
+                    %PYARG_0 = %CONVERTTOPYTHON[MatchedXYZ](result);
+                } catch (const std::invalid_argument&amp; e) {
+                    PyErr_SetString(PyExc_ValueError, e.what());
+                    return nullptr;
+                } catch (const std::exception&amp; e) {
+                    PyErr_SetString(PyExc_RuntimeError, e.what());
+                    return nullptr;
+                }
+            </inject-code>
+        </modify-function>
+    </value-type>
+
     <object-type name="SciQLopGraphComponentInterface" parent-management="yes"/>
     <object-type name="SQPQCPAbstractPlottableWrapper" parent-management="yes"/>
     <object-type name="SciQLopPlottableInterface" parent-management="yes"/>

--- a/SciQLopPlots/bindings/bindings.xml
+++ b/SciQLopPlots/bindings/bindings.xml
@@ -770,8 +770,19 @@
     </add-function>
 
     <add-function signature="validate_index(long long, long long, std::string)" return-type="void">
+        <extra-includes>
+            <include file-name="SciQLopPlots/Python/Validation.hpp" location="global"/>
+        </extra-includes>
         <inject-code class="target" position="beginning">
-            sqp::validation::validate_index(%1, %2, %3);
+            try {
+                sqp::validation::validate_index(%1, %2, %3);
+            } catch (const std::out_of_range&amp; e) {
+                PyErr_SetString(PyExc_IndexError, e.what());
+                return nullptr;
+            } catch (const std::exception&amp; e) {
+                PyErr_SetString(PyExc_RuntimeError, e.what());
+                return nullptr;
+            }
         </inject-code>
     </add-function>
 </typesystem>

--- a/SciQLopPlots/bindings/bindings.xml
+++ b/SciQLopPlots/bindings/bindings.xml
@@ -768,6 +768,12 @@
             <replace-default-expression with="0"/>
         </modify-argument>
     </add-function>
+
+    <add-function signature="validate_index(long long, long long, std::string)" return-type="void">
+        <inject-code class="target" position="beginning">
+            sqp::validation::validate_index(%1, %2, %3);
+        </inject-code>
+    </add-function>
 </typesystem>
 
 

--- a/SciQLopPlots/bindings/bindings.xml
+++ b/SciQLopPlots/bindings/bindings.xml
@@ -35,9 +35,13 @@
                     %out = %OUTTYPE();
                 </add-conversion>
                 <add-conversion type="PyObject" check="PyObject_CheckBuffer(%in)">
-                    try {
+                    try
+                    {
                         %out = %OUTTYPE(%in);
-                    } catch (const std::exception&amp;) {
+                    }
+                    catch (const std::runtime_error&amp; e)
+                    {
+                        qWarning() &lt;&lt; "[PyBuffer ctor] rejected buffer:" &lt;&lt; e.what();
                         %out = %OUTTYPE();
                     }
                 </add-conversion>

--- a/SciQLopPlots/bindings/bindings.xml
+++ b/SciQLopPlots/bindings/bindings.xml
@@ -136,6 +136,23 @@
         </add-function>
     </value-type>
 
+    <value-type name="MatchedXY">
+        <modify-function signature="from_py(PyBuffer,PyBuffer)">
+            <inject-code class="target" position="beginning">
+                try {
+                    auto result = MatchedXY::from_py(%1, %2);
+                    %PYARG_0 = %CONVERTTOPYTHON[MatchedXY](result);
+                } catch (const std::invalid_argument&amp; e) {
+                    PyErr_SetString(PyExc_ValueError, e.what());
+                    return nullptr;
+                } catch (const std::exception&amp; e) {
+                    PyErr_SetString(PyExc_RuntimeError, e.what());
+                    return nullptr;
+                }
+            </inject-code>
+        </modify-function>
+    </value-type>
+
     <object-type name="SciQLopGraphComponentInterface" parent-management="yes"/>
     <object-type name="SQPQCPAbstractPlottableWrapper" parent-management="yes"/>
     <object-type name="SciQLopPlottableInterface" parent-management="yes"/>

--- a/SciQLopPlots/bindings/bindings.xml
+++ b/SciQLopPlots/bindings/bindings.xml
@@ -787,6 +787,9 @@
         <inject-code class="target" position="beginning">
             try {
                 sqp::validation::validate_buffer(%1, %2, %3, %4);
+            } catch (const std::domain_error&amp; e) {
+                PyErr_SetString(PyExc_TypeError, e.what());
+                return nullptr;
             } catch (const std::invalid_argument&amp; e) {
                 PyErr_SetString(PyExc_ValueError, e.what());
                 return nullptr;

--- a/SciQLopPlots/bindings/bindings.xml
+++ b/SciQLopPlots/bindings/bindings.xml
@@ -35,7 +35,11 @@
                     %out = %OUTTYPE();
                 </add-conversion>
                 <add-conversion type="PyObject" check="PyObject_CheckBuffer(%in)">
-                    %out = %OUTTYPE(%in);
+                    try {
+                        %out = %OUTTYPE(%in);
+                    } catch (const std::exception&amp;) {
+                        %out = %OUTTYPE();
+                    }
                 </add-conversion>
             </target-to-native>
             <native-to-target>
@@ -737,6 +741,29 @@
     </object-type>
 
     <object-type name="Icons" parent-management="yes"/>
+
+    <add-function signature="validate_buffer(PyBuffer, std::string, int, char)" return-type="void">
+        <extra-includes>
+            <include file-name="SciQLopPlots/Python/Validation.hpp" location="global"/>
+        </extra-includes>
+        <inject-code class="target" position="beginning">
+            try {
+                sqp::validation::validate_buffer(%1, %2, %3, %4);
+            } catch (const std::invalid_argument&amp; e) {
+                PyErr_SetString(PyExc_ValueError, e.what());
+                return nullptr;
+            } catch (const std::exception&amp; e) {
+                PyErr_SetString(PyExc_RuntimeError, e.what());
+                return nullptr;
+            }
+        </inject-code>
+        <modify-argument index="3">
+            <replace-default-expression with="-1"/>
+        </modify-argument>
+        <modify-argument index="4">
+            <replace-default-expression with="0"/>
+        </modify-argument>
+    </add-function>
 </typesystem>
 
 

--- a/SciQLopPlots/meson.build
+++ b/SciQLopPlots/meson.build
@@ -148,6 +148,7 @@ headers = moc_headers + \
          [project_source_root+'/include/SciQLopPlots/Python/PythonInterface.hpp',
          project_source_root+'/include/SciQLopPlots/Python/Views.hpp',
          project_source_root+'/include/SciQLopPlots/Python/Validation.hpp',
+         project_source_root+'/include/SciQLopPlots/Python/MatchedBuffers.hpp',
          project_source_root+'/include/SciQLopPlots/constants.hpp',
          project_source_root+'/include/SciQLopPlots/Products/SubsequenceMatcher.hpp',
          project_source_root+'/include/SciQLopPlots/Products/QueryParser.hpp']

--- a/SciQLopPlots/meson.build
+++ b/SciQLopPlots/meson.build
@@ -147,6 +147,7 @@ moc_sources = []
 headers = moc_headers + \
          [project_source_root+'/include/SciQLopPlots/Python/PythonInterface.hpp',
          project_source_root+'/include/SciQLopPlots/Python/Views.hpp',
+         project_source_root+'/include/SciQLopPlots/Python/Validation.hpp',
          project_source_root+'/include/SciQLopPlots/constants.hpp',
          project_source_root+'/include/SciQLopPlots/Products/SubsequenceMatcher.hpp',
          project_source_root+'/include/SciQLopPlots/Products/QueryParser.hpp']

--- a/SciQLopPlots/meson.build
+++ b/SciQLopPlots/meson.build
@@ -149,6 +149,7 @@ headers = moc_headers + \
          project_source_root+'/include/SciQLopPlots/Python/Views.hpp',
          project_source_root+'/include/SciQLopPlots/Python/Validation.hpp',
          project_source_root+'/include/SciQLopPlots/Python/MatchedBuffers.hpp',
+         project_source_root+'/include/SciQLopPlots/Python/SafeSlot.hpp',
          project_source_root+'/include/SciQLopPlots/constants.hpp',
          project_source_root+'/include/SciQLopPlots/Products/SubsequenceMatcher.hpp',
          project_source_root+'/include/SciQLopPlots/Products/QueryParser.hpp']

--- a/docs/superpowers/plans/2026-04-17-python-hardening-foundation.md
+++ b/docs/superpowers/plans/2026-04-17-python-hardening-foundation.md
@@ -1,0 +1,1503 @@
+# Python Hardening — Sub-effort 1 (Foundation) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build the plumbing (validators, typed wrappers, safe-slot helper, assertion macro, exception-translation audit) that later sub-efforts apply across the C++/Python boundary. No user-visible behavior changes in callers yet.
+
+**Architecture:** New header-only utilities under `include/SciQLopPlots/Python/`. Free-function validators throw `std::invalid_argument` / `std::out_of_range`. Shiboken typesystem translates to Python `ValueError` / `IndexError`. Validators are also exposed as callable Python free functions so they can be tested directly without wiring them into every `set_data` method yet (that is Sub-effort 2).
+
+**Tech Stack:** C++20, Qt6, Shiboken6 bindings, Meson, pytest, numpy.
+
+**Reference:** Design spec at `docs/superpowers/specs/2026-04-17-python-hardening-design.md`.
+
+---
+
+## Build and test reference
+
+All tasks use the same dev cycle.
+
+**Build (preferred — no reinstall):**
+```bash
+cd /var/home/jeandet/Documents/prog/SciQLopPlots
+meson compile -C build
+cp build/SciQLopPlots/SciQLopPlotsBindings.cpython-313-x86_64-linux-gnu.so \
+   /var/home/jeandet/Documents/prog/SciQLop/.venv/lib/python3.13/site-packages/SciQLopPlots/
+```
+
+**Run Python tests (from outside project dir, using SciQLop venv):**
+```bash
+cd /var/home/jeandet/Documents/prog && \
+  LD_LIBRARY_PATH=~/Qt/6.10.2/gcc_64/lib \
+  SciQLop/.venv/bin/python -m pytest SciQLopPlots/tests/integration/test_hardening_foundation.py -v
+```
+
+**Full re-setup (only if build dir missing or meson.build changed):**
+```bash
+PATH="/home/jeandet/Qt/6.10.2/gcc_64/bin:/var/home/jeandet/Documents/prog/SciQLop/.venv/bin:/home/jeandet/.local/bin:/usr/bin:/usr/local/bin:$PATH" \
+  meson setup build --buildtype=debugoptimized --reconfigure
+```
+
+**Git remote:** always push to `origin` (the fork), never `upstream`.
+
+---
+
+## File structure
+
+**Created:**
+- `include/SciQLopPlots/Assert.hpp` — `SQP_ASSERT` macro
+- `include/SciQLopPlots/Python/Validation.hpp` — free-function validators
+- `include/SciQLopPlots/Python/MatchedBuffers.hpp` — `MatchedXY` / `MatchedXYZ` typed wrappers
+- `include/SciQLopPlots/Python/SafeSlot.hpp` — `SQP_SAFE_SLOT_*` macros + `safe_slot` template
+- `tests/integration/test_hardening_foundation.py` — tests for validators and typed wrappers via Python bindings
+
+**Modified:**
+- `include/SciQLopPlots/Python/DtypeDispatch.hpp` — tighten exception type and message
+- `src/PythonInterface.cpp` — make `PyBuffer::data()` throw when the buffer is invalid
+- `SciQLopPlots/bindings/bindings.xml` — expose validators as Python free functions; audit exception-handling
+- `SciQLopPlots/bindings/bindings.h` — include new headers
+- `SciQLopPlots/meson.build` — register new headers
+
+---
+
+## Task 1: Add `SQP_ASSERT` macro
+
+**Files:**
+- Create: `include/SciQLopPlots/Assert.hpp`
+
+- [ ] **Step 1: Create the header**
+
+Write `include/SciQLopPlots/Assert.hpp`:
+
+```cpp
+#pragma once
+
+#include <cstdio>
+#include <cstdlib>
+
+// SQP_ASSERT — debug-only invariant check.
+//
+// In debug builds (NDEBUG not defined): prints diagnostic and calls std::abort().
+// In release builds: the expression is not evaluated, no runtime cost.
+//
+// Use for *internal* invariants that should never fail if the boundary-layer
+// validation is correct. Do NOT use for user-input validation — throw an
+// exception from Validation.hpp instead.
+
+#ifndef NDEBUG
+#define SQP_ASSERT(expr)                                                       \
+    do {                                                                       \
+        if (!(expr)) {                                                         \
+            std::fprintf(stderr, "SQP_ASSERT failed: %s\n  at %s:%d in %s\n",  \
+                         #expr, __FILE__, __LINE__, __func__);                 \
+            std::abort();                                                      \
+        }                                                                      \
+    } while (0)
+#else
+#define SQP_ASSERT(expr) ((void)0)
+#endif
+```
+
+- [ ] **Step 2: Smoke-compile by including from an existing translation unit**
+
+Edit `src/Profiling.cpp` — add at the top of includes (existing includes preserved):
+
+```cpp
+#include <SciQLopPlots/Assert.hpp>
+```
+
+This proves the header parses cleanly under the project's compile flags.
+
+- [ ] **Step 3: Build and verify**
+
+Run:
+```bash
+meson compile -C build
+```
+
+Expected: build succeeds, no new warnings from `Assert.hpp`.
+
+- [ ] **Step 4: Revert the smoke include**
+
+Remove the `#include <SciQLopPlots/Assert.hpp>` line from `src/Profiling.cpp`. The header will be picked up organically by consumers in later tasks.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add include/SciQLopPlots/Assert.hpp
+git commit -m "feat: add SQP_ASSERT macro for internal invariants
+
+No-op in release; abort with diagnostic in debug. Used for L3 internal
+invariants where boundary validation has already run."
+```
+
+---
+
+## Task 2: Create `Validation.hpp` with `validate_buffer`
+
+**Files:**
+- Create: `include/SciQLopPlots/Python/Validation.hpp`
+- Create: `tests/integration/test_hardening_foundation.py`
+- Modify: `SciQLopPlots/bindings/bindings.h`
+- Modify: `SciQLopPlots/bindings/bindings.xml`
+- Modify: `SciQLopPlots/meson.build`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/integration/test_hardening_foundation.py`:
+
+```python
+"""Tests for Sub-effort 1 (Foundation) of python-hardening."""
+import numpy as np
+import pytest
+import SciQLopPlots as sqp
+
+
+# ---------- validate_buffer ----------
+
+def test_validate_buffer_none_raises_typeerror():
+    with pytest.raises(TypeError):
+        sqp.validate_buffer(None, "x")
+
+
+def test_validate_buffer_non_numeric_raises_typeerror():
+    arr = np.array(["a", "b"], dtype=object)
+    with pytest.raises(TypeError):
+        sqp.validate_buffer(arr, "x")
+
+
+def test_validate_buffer_ok():
+    arr = np.arange(10.0)
+    sqp.validate_buffer(arr, "x")  # no exception
+
+
+def test_validate_buffer_wrong_ndim_raises_valueerror():
+    arr = np.arange(10.0)
+    with pytest.raises(ValueError, match=r"x.*ndim.*1.*expected.*2"):
+        sqp.validate_buffer(arr, "x", 2)
+
+
+def test_validate_buffer_wrong_dtype_raises_typeerror():
+    arr = np.arange(10, dtype=np.int32)
+    with pytest.raises(TypeError, match=r"x.*dtype"):
+        sqp.validate_buffer(arr, "x", -1, ord('d'))
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run:
+```bash
+cd /var/home/jeandet/Documents/prog && \
+  LD_LIBRARY_PATH=~/Qt/6.10.2/gcc_64/lib \
+  SciQLop/.venv/bin/python -m pytest \
+    SciQLopPlots/tests/integration/test_hardening_foundation.py -v
+```
+Expected: `AttributeError: module 'SciQLopPlots' has no attribute 'validate_buffer'`.
+
+- [ ] **Step 3: Create the header**
+
+Create `include/SciQLopPlots/Python/Validation.hpp`:
+
+```cpp
+#pragma once
+
+#include <SciQLopPlots/Python/PythonInterface.hpp>
+
+#include <QList>
+
+#include <cmath>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+
+namespace sqp::validation {
+
+inline void validate_buffer(const PyBuffer& b,
+                            std::string_view name,
+                            int expected_ndim = -1,
+                            char expected_dtype = 0)
+{
+    if (!b.is_valid())
+    {
+        std::ostringstream os;
+        os << name << ": invalid or null buffer";
+        throw std::invalid_argument(os.str());
+    }
+
+    const char fmt = b.format_code();
+    constexpr std::string_view numeric_formats = "bBhHiIlLqQfd";
+    if (fmt == '\0' || numeric_formats.find(fmt) == std::string_view::npos)
+    {
+        std::ostringstream os;
+        os << name << ": dtype must be numeric (got '" << fmt << "')";
+        throw std::invalid_argument(os.str());
+    }
+
+    if (expected_ndim >= 0 && static_cast<int>(b.ndim()) != expected_ndim)
+    {
+        std::ostringstream os;
+        os << name << ": ndim is " << b.ndim() << ", expected " << expected_ndim;
+        throw std::invalid_argument(os.str());
+    }
+
+    if (expected_dtype != 0 && fmt != expected_dtype)
+    {
+        std::ostringstream os;
+        os << name << ": dtype must be '" << expected_dtype << "' (got '" << fmt << "')";
+        throw std::invalid_argument(os.str());
+    }
+}
+
+} // namespace sqp::validation
+```
+
+- [ ] **Step 4: Register the header with Meson**
+
+Edit `SciQLopPlots/meson.build` — extend the `headers` list at line 147-152:
+
+```meson
+headers = moc_headers + \
+         [project_source_root+'/include/SciQLopPlots/Python/PythonInterface.hpp',
+         project_source_root+'/include/SciQLopPlots/Python/Views.hpp',
+         project_source_root+'/include/SciQLopPlots/Python/Validation.hpp',
+         project_source_root+'/include/SciQLopPlots/constants.hpp',
+         project_source_root+'/include/SciQLopPlots/Products/SubsequenceMatcher.hpp',
+         project_source_root+'/include/SciQLopPlots/Products/QueryParser.hpp']
+```
+
+- [ ] **Step 5: Include the new header in `bindings.h`**
+
+Edit `SciQLopPlots/bindings/bindings.h` — after the existing `PythonInterface.hpp` include:
+
+```cpp
+#include "SciQLopPlots/Python/Validation.hpp"
+```
+
+- [ ] **Step 6: Expose `validate_buffer` in `bindings.xml`**
+
+Edit `SciQLopPlots/bindings/bindings.xml` — add inside the top-level `<typesystem>` block, after the `<enum-type>` declarations (around line 26):
+
+```xml
+    <namespace-type name="sqp::validation" generate="no">
+        <function signature="validate_buffer(const PyBuffer&amp;, std::string_view, int, char)"
+                  rename="validate_buffer"/>
+    </namespace-type>
+```
+
+Then, near the bottom of the file (wherever other top-level injected helpers live), add:
+
+```xml
+    <add-function signature="validate_buffer(PyBuffer, std::string, int, char)" return-type="void">
+        <inject-code class="target" position="beginning">
+            sqp::validation::validate_buffer(%1, %2, %3, %4);
+        </inject-code>
+        <modify-argument index="3">
+            <default-value>-1</default-value>
+        </modify-argument>
+        <modify-argument index="4">
+            <default-value>0</default-value>
+        </modify-argument>
+    </add-function>
+```
+
+**Note on `std::string_view` vs `std::string`:** Shiboken has better out-of-the-box support for `std::string`; the Python-callable wrapper takes `std::string` and the C++ function takes it by `string_view` (implicit conversion). No data is copied beyond the name string itself.
+
+- [ ] **Step 7: Build and run the test**
+
+Run:
+```bash
+meson compile -C build && \
+  cp build/SciQLopPlots/SciQLopPlotsBindings.cpython-313-x86_64-linux-gnu.so \
+     /var/home/jeandet/Documents/prog/SciQLop/.venv/lib/python3.13/site-packages/SciQLopPlots/ && \
+  cd /var/home/jeandet/Documents/prog && \
+  LD_LIBRARY_PATH=~/Qt/6.10.2/gcc_64/lib \
+  SciQLop/.venv/bin/python -m pytest \
+    SciQLopPlots/tests/integration/test_hardening_foundation.py -v
+```
+Expected: the 5 `validate_buffer` tests pass.
+
+- [ ] **Step 8: Commit**
+
+```bash
+cd /var/home/jeandet/Documents/prog/SciQLopPlots
+git add include/SciQLopPlots/Python/Validation.hpp \
+        SciQLopPlots/meson.build \
+        SciQLopPlots/bindings/bindings.h \
+        SciQLopPlots/bindings/bindings.xml \
+        tests/integration/test_hardening_foundation.py
+git commit -m "feat(python): add validate_buffer and expose to Python
+
+First boundary validator. Throws std::invalid_argument on bad dtype, ndim,
+or null buffer; Shiboken translates to Python ValueError / TypeError."
+```
+
+---
+
+## Task 3: Add `validate_index`
+
+**Files:**
+- Modify: `include/SciQLopPlots/Python/Validation.hpp`
+- Modify: `SciQLopPlots/bindings/bindings.xml`
+- Modify: `tests/integration/test_hardening_foundation.py`
+
+- [ ] **Step 1: Append failing tests**
+
+Append to `tests/integration/test_hardening_foundation.py`:
+
+```python
+# ---------- validate_index ----------
+
+def test_validate_index_ok():
+    sqp.validate_index(0, 10, "row")
+    sqp.validate_index(9, 10, "row")
+
+
+def test_validate_index_negative_raises_indexerror():
+    with pytest.raises(IndexError, match=r"row.*negative"):
+        sqp.validate_index(-1, 10, "row")
+
+
+def test_validate_index_out_of_range_raises_indexerror():
+    with pytest.raises(IndexError, match=r"row.*out of range.*size 10"):
+        sqp.validate_index(10, 10, "row")
+
+
+def test_validate_index_empty_container_always_raises():
+    with pytest.raises(IndexError):
+        sqp.validate_index(0, 0, "row")
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+```bash
+cd /var/home/jeandet/Documents/prog && \
+  LD_LIBRARY_PATH=~/Qt/6.10.2/gcc_64/lib \
+  SciQLop/.venv/bin/python -m pytest \
+    SciQLopPlots/tests/integration/test_hardening_foundation.py::test_validate_index_ok -v
+```
+Expected: `AttributeError: module 'SciQLopPlots' has no attribute 'validate_index'`.
+
+- [ ] **Step 3: Implement `validate_index`**
+
+Append inside the `sqp::validation` namespace in `Validation.hpp`:
+
+```cpp
+inline void validate_index(long long i, long long size, std::string_view name)
+{
+    if (i < 0)
+    {
+        std::ostringstream os;
+        os << name << ": index is negative (" << i << ")";
+        throw std::out_of_range(os.str());
+    }
+    if (i >= size)
+    {
+        std::ostringstream os;
+        os << name << ": index " << i << " out of range (size " << size << ")";
+        throw std::out_of_range(os.str());
+    }
+}
+```
+
+**Signature rationale:** `long long` accepts Python's arbitrary-size ints transparently (up to 64-bit). `qsizetype` is a typedef of `ptrdiff_t` (signed), compatible with `long long` on all supported platforms.
+
+- [ ] **Step 4: Expose in `bindings.xml`**
+
+Add next to the `validate_buffer` `<add-function>` block:
+
+```xml
+    <add-function signature="validate_index(long long, long long, std::string)" return-type="void">
+        <inject-code class="target" position="beginning">
+            sqp::validation::validate_index(%1, %2, %3);
+        </inject-code>
+    </add-function>
+```
+
+- [ ] **Step 5: Build and run tests**
+
+```bash
+meson compile -C build && \
+  cp build/SciQLopPlots/SciQLopPlotsBindings.cpython-313-x86_64-linux-gnu.so \
+     /var/home/jeandet/Documents/prog/SciQLop/.venv/lib/python3.13/site-packages/SciQLopPlots/ && \
+  cd /var/home/jeandet/Documents/prog && \
+  LD_LIBRARY_PATH=~/Qt/6.10.2/gcc_64/lib \
+  SciQLop/.venv/bin/python -m pytest \
+    SciQLopPlots/tests/integration/test_hardening_foundation.py -v
+```
+Expected: all prior tests still pass plus the 4 new `validate_index` tests.
+
+**Shiboken translation note:** `std::out_of_range` is a subclass of `std::exception` and Shiboken translates it to Python `IndexError` via the default type-system exception mapping. If the mapping surfaces `RuntimeError` instead, extend the `exception-handling` configuration — see Task 11.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /var/home/jeandet/Documents/prog/SciQLopPlots
+git add include/SciQLopPlots/Python/Validation.hpp \
+        SciQLopPlots/bindings/bindings.xml \
+        tests/integration/test_hardening_foundation.py
+git commit -m "feat(python): add validate_index boundary validator
+
+Rejects negative and out-of-range indices with std::out_of_range
+(Python IndexError)."
+```
+
+---
+
+## Task 4: Add `validate_same_length`, `validate_xy`, `validate_xyz`
+
+**Files:**
+- Modify: `include/SciQLopPlots/Python/Validation.hpp`
+- Modify: `SciQLopPlots/bindings/bindings.xml`
+- Modify: `tests/integration/test_hardening_foundation.py`
+
+- [ ] **Step 1: Append failing tests**
+
+Append to `tests/integration/test_hardening_foundation.py`:
+
+```python
+# ---------- validate_same_length ----------
+
+def test_validate_same_length_ok():
+    x = np.arange(10.0)
+    y = np.arange(10.0)
+    sqp.validate_same_length(x, "x", y, "y")
+
+
+def test_validate_same_length_mismatch_raises_valueerror():
+    x = np.arange(10.0)
+    y = np.arange(5.0)
+    with pytest.raises(ValueError, match=r"length.*x.*10.*y.*5"):
+        sqp.validate_same_length(x, "x", y, "y")
+
+
+# ---------- validate_xy ----------
+
+def test_validate_xy_1d_ok():
+    x = np.arange(10.0)
+    y = np.arange(10.0)
+    sqp.validate_xy(x, y)
+
+
+def test_validate_xy_2d_y_ok():
+    x = np.arange(10.0)
+    y = np.random.rand(10, 3)
+    sqp.validate_xy(x, y)
+
+
+def test_validate_xy_x_not_1d_raises():
+    x = np.random.rand(10, 3)
+    y = np.arange(10.0)
+    with pytest.raises(ValueError, match=r"x.*ndim"):
+        sqp.validate_xy(x, y)
+
+
+def test_validate_xy_shape_mismatch_raises():
+    x = np.arange(10.0)
+    y = np.arange(5.0)
+    with pytest.raises(ValueError, match=r"length"):
+        sqp.validate_xy(x, y)
+
+
+def test_validate_xy_y_3d_raises():
+    x = np.arange(10.0)
+    y = np.random.rand(10, 3, 2)
+    with pytest.raises(ValueError, match=r"y.*ndim"):
+        sqp.validate_xy(x, y)
+
+
+# ---------- validate_xyz ----------
+
+def test_validate_xyz_ok():
+    x = np.arange(10.0)
+    y = np.arange(5.0)
+    z = np.random.rand(10, 5)
+    sqp.validate_xyz(x, y, z)
+
+
+def test_validate_xyz_z_wrong_shape_raises():
+    x = np.arange(10.0)
+    y = np.arange(5.0)
+    z = np.random.rand(9, 5)  # wrong x dimension
+    with pytest.raises(ValueError, match=r"z"):
+        sqp.validate_xyz(x, y, z)
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+```bash
+cd /var/home/jeandet/Documents/prog && \
+  LD_LIBRARY_PATH=~/Qt/6.10.2/gcc_64/lib \
+  SciQLop/.venv/bin/python -m pytest \
+    SciQLopPlots/tests/integration/test_hardening_foundation.py -v -k "same_length or xy"
+```
+Expected: new tests fail with `AttributeError`.
+
+- [ ] **Step 3: Implement the three validators**
+
+Append inside `sqp::validation` in `Validation.hpp`:
+
+```cpp
+inline void validate_same_length(const PyBuffer& a, std::string_view name_a,
+                                 const PyBuffer& b, std::string_view name_b)
+{
+    if (a.size(0) != b.size(0))
+    {
+        std::ostringstream os;
+        os << "length mismatch: " << name_a << " has " << a.size(0)
+           << ", " << name_b << " has " << b.size(0);
+        throw std::invalid_argument(os.str());
+    }
+}
+
+inline void validate_xy(const PyBuffer& x, const PyBuffer& y)
+{
+    validate_buffer(x, "x", 1);
+    if (y.ndim() != 1 && y.ndim() != 2)
+    {
+        std::ostringstream os;
+        os << "y: ndim must be 1 or 2 (got " << y.ndim() << ")";
+        throw std::invalid_argument(os.str());
+    }
+    validate_buffer(y, "y");  // numeric, any ndim already checked above
+    validate_same_length(x, "x", y, "y");
+}
+
+inline void validate_xyz(const PyBuffer& x, const PyBuffer& y, const PyBuffer& z)
+{
+    validate_buffer(x, "x", 1);
+    validate_buffer(y, "y", 1);
+    validate_buffer(z, "z", 2);
+    if (z.size(0) != x.size(0))
+    {
+        std::ostringstream os;
+        os << "z: rows (" << z.size(0) << ") must match x length ("
+           << x.size(0) << ")";
+        throw std::invalid_argument(os.str());
+    }
+    if (z.size(1) != y.size(0))
+    {
+        std::ostringstream os;
+        os << "z: cols (" << z.size(1) << ") must match y length ("
+           << y.size(0) << ")";
+        throw std::invalid_argument(os.str());
+    }
+}
+```
+
+- [ ] **Step 4: Expose all three in `bindings.xml`**
+
+Add next to the other `<add-function>` blocks:
+
+```xml
+    <add-function signature="validate_same_length(PyBuffer, std::string, PyBuffer, std::string)" return-type="void">
+        <inject-code class="target" position="beginning">
+            sqp::validation::validate_same_length(%1, %2, %3, %4);
+        </inject-code>
+    </add-function>
+    <add-function signature="validate_xy(PyBuffer, PyBuffer)" return-type="void">
+        <inject-code class="target" position="beginning">
+            sqp::validation::validate_xy(%1, %2);
+        </inject-code>
+    </add-function>
+    <add-function signature="validate_xyz(PyBuffer, PyBuffer, PyBuffer)" return-type="void">
+        <inject-code class="target" position="beginning">
+            sqp::validation::validate_xyz(%1, %2, %3);
+        </inject-code>
+    </add-function>
+```
+
+- [ ] **Step 5: Build and run tests**
+
+```bash
+meson compile -C build && \
+  cp build/SciQLopPlots/SciQLopPlotsBindings.cpython-313-x86_64-linux-gnu.so \
+     /var/home/jeandet/Documents/prog/SciQLop/.venv/lib/python3.13/site-packages/SciQLopPlots/ && \
+  cd /var/home/jeandet/Documents/prog && \
+  LD_LIBRARY_PATH=~/Qt/6.10.2/gcc_64/lib \
+  SciQLop/.venv/bin/python -m pytest \
+    SciQLopPlots/tests/integration/test_hardening_foundation.py -v
+```
+Expected: all tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /var/home/jeandet/Documents/prog/SciQLopPlots
+git add include/SciQLopPlots/Python/Validation.hpp \
+        SciQLopPlots/bindings/bindings.xml \
+        tests/integration/test_hardening_foundation.py
+git commit -m "feat(python): add validate_same_length, validate_xy, validate_xyz
+
+Cover the dominant set_data argument-shape patterns across plottables."
+```
+
+---
+
+## Task 5: Add `validate_nd_list` and `validate_finite`
+
+**Files:**
+- Modify: `include/SciQLopPlots/Python/Validation.hpp`
+- Modify: `SciQLopPlots/bindings/bindings.xml`
+- Modify: `tests/integration/test_hardening_foundation.py`
+
+- [ ] **Step 1: Append failing tests**
+
+Append to `tests/integration/test_hardening_foundation.py`:
+
+```python
+# ---------- validate_nd_list ----------
+
+def test_validate_nd_list_ok():
+    arrs = [np.arange(10.0), np.arange(10.0), np.arange(10.0)]
+    sqp.validate_nd_list(arrs, 3)
+
+
+def test_validate_nd_list_wrong_count_raises():
+    arrs = [np.arange(10.0), np.arange(10.0)]
+    with pytest.raises(ValueError, match=r"expected 3.*got 2"):
+        sqp.validate_nd_list(arrs, 3)
+
+
+def test_validate_nd_list_length_mismatch_raises():
+    arrs = [np.arange(10.0), np.arange(5.0), np.arange(10.0)]
+    with pytest.raises(ValueError, match=r"length"):
+        sqp.validate_nd_list(arrs, 3)
+
+
+# ---------- validate_finite ----------
+
+def test_validate_finite_ok():
+    sqp.validate_finite(1.0, "v")
+    sqp.validate_finite(-1e9, "v")
+
+
+def test_validate_finite_nan_raises():
+    with pytest.raises(ValueError, match=r"v.*finite"):
+        sqp.validate_finite(float("nan"), "v")
+
+
+def test_validate_finite_inf_raises():
+    with pytest.raises(ValueError, match=r"v.*finite"):
+        sqp.validate_finite(float("inf"), "v")
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+```bash
+cd /var/home/jeandet/Documents/prog && \
+  LD_LIBRARY_PATH=~/Qt/6.10.2/gcc_64/lib \
+  SciQLop/.venv/bin/python -m pytest \
+    SciQLopPlots/tests/integration/test_hardening_foundation.py -v -k "nd_list or finite"
+```
+Expected: new tests fail with `AttributeError`.
+
+- [ ] **Step 3: Implement both validators**
+
+Append inside `sqp::validation` in `Validation.hpp`:
+
+```cpp
+inline void validate_nd_list(const QList<PyBuffer>& bufs, std::size_t expected_count)
+{
+    if (static_cast<std::size_t>(bufs.size()) != expected_count)
+    {
+        std::ostringstream os;
+        os << "buffer list: expected " << expected_count
+           << " elements, got " << bufs.size();
+        throw std::invalid_argument(os.str());
+    }
+    if (bufs.isEmpty())
+        return;
+    const auto ref_len = bufs.front().size(0);
+    for (qsizetype i = 0; i < bufs.size(); ++i)
+    {
+        validate_buffer(bufs[i], "buffers[" + std::to_string(i) + "]");
+        if (bufs[i].size(0) != ref_len)
+        {
+            std::ostringstream os;
+            os << "buffer list: length mismatch at index " << i
+               << " (got " << bufs[i].size(0) << ", expected " << ref_len << ")";
+            throw std::invalid_argument(os.str());
+        }
+    }
+}
+
+inline void validate_finite(double v, std::string_view name)
+{
+    if (!std::isfinite(v))
+    {
+        std::ostringstream os;
+        os << name << ": value must be finite (got " << v << ")";
+        throw std::invalid_argument(os.str());
+    }
+}
+```
+
+Note: the `validate_buffer` call inside `validate_nd_list` uses a `std::string` temporary for the name; `string_view` binds to it via implicit conversion. Kept inline for clarity — list lengths here are small (typically 2–4 buffers).
+
+- [ ] **Step 4: Expose in `bindings.xml`**
+
+```xml
+    <add-function signature="validate_nd_list(QList&lt;PyBuffer&gt;, std::size_t)" return-type="void">
+        <inject-code class="target" position="beginning">
+            sqp::validation::validate_nd_list(%1, %2);
+        </inject-code>
+    </add-function>
+    <add-function signature="validate_finite(double, std::string)" return-type="void">
+        <inject-code class="target" position="beginning">
+            sqp::validation::validate_finite(%1, %2);
+        </inject-code>
+    </add-function>
+```
+
+- [ ] **Step 5: Build and run tests**
+
+```bash
+meson compile -C build && \
+  cp build/SciQLopPlots/SciQLopPlotsBindings.cpython-313-x86_64-linux-gnu.so \
+     /var/home/jeandet/Documents/prog/SciQLop/.venv/lib/python3.13/site-packages/SciQLopPlots/ && \
+  cd /var/home/jeandet/Documents/prog && \
+  LD_LIBRARY_PATH=~/Qt/6.10.2/gcc_64/lib \
+  SciQLop/.venv/bin/python -m pytest \
+    SciQLopPlots/tests/integration/test_hardening_foundation.py -v
+```
+Expected: all tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /var/home/jeandet/Documents/prog/SciQLopPlots
+git add include/SciQLopPlots/Python/Validation.hpp \
+        SciQLopPlots/bindings/bindings.xml \
+        tests/integration/test_hardening_foundation.py
+git commit -m "feat(python): add validate_nd_list and validate_finite
+
+Completes the free-function validator surface for Sub-effort 1."
+```
+
+---
+
+## Task 6: Create `MatchedBuffers.hpp` with `MatchedXY`
+
+**Files:**
+- Create: `include/SciQLopPlots/Python/MatchedBuffers.hpp`
+- Modify: `SciQLopPlots/bindings/bindings.h`
+- Modify: `SciQLopPlots/bindings/bindings.xml`
+- Modify: `SciQLopPlots/meson.build`
+- Modify: `tests/integration/test_hardening_foundation.py`
+
+- [ ] **Step 1: Write failing tests**
+
+Append to `tests/integration/test_hardening_foundation.py` (use method-call syntax for `rows()` / `cols()` — they are bound as methods, not attributes):
+
+```python
+# ---------- MatchedXY ----------
+
+def test_matched_xy_1d_y():
+    x = np.arange(10.0)
+    y = np.arange(10.0)
+    m = sqp.MatchedXY.from_py(x, y)
+    assert m.rows() == 10
+    assert m.cols() == 1
+
+
+def test_matched_xy_2d_y():
+    x = np.arange(10.0)
+    y = np.random.rand(10, 4)
+    m = sqp.MatchedXY.from_py(x, y)
+    assert m.rows() == 10
+    assert m.cols() == 4
+
+
+def test_matched_xy_mismatch_raises():
+    x = np.arange(10.0)
+    y = np.arange(5.0)
+    with pytest.raises(ValueError):
+        sqp.MatchedXY.from_py(x, y)
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+```bash
+cd /var/home/jeandet/Documents/prog && \
+  LD_LIBRARY_PATH=~/Qt/6.10.2/gcc_64/lib \
+  SciQLop/.venv/bin/python -m pytest \
+    SciQLopPlots/tests/integration/test_hardening_foundation.py::test_matched_xy_1d_y -v
+```
+Expected: `AttributeError: module 'SciQLopPlots' has no attribute 'MatchedXY'`.
+
+- [ ] **Step 3: Create the header**
+
+Create `include/SciQLopPlots/Python/MatchedBuffers.hpp`:
+
+```cpp
+#pragma once
+
+#include <SciQLopPlots/Python/PythonInterface.hpp>
+#include <SciQLopPlots/Python/Validation.hpp>
+
+#include <utility>
+
+// MatchedXY / MatchedXYZ live in the global namespace to match the rest of
+// the project's public class surface (SciQLop*, PyBuffer, GetDataPyCallable,
+// etc.) and to simplify Shiboken value-type declarations.
+
+class MatchedXY
+{
+    PyBuffer _x;
+    PyBuffer _y;
+
+    MatchedXY(PyBuffer x, PyBuffer y) : _x(std::move(x)), _y(std::move(y)) { }
+
+public:
+    MatchedXY() = default;
+    MatchedXY(const MatchedXY&) = default;
+    MatchedXY(MatchedXY&&) = default;
+    MatchedXY& operator=(const MatchedXY&) = default;
+    MatchedXY& operator=(MatchedXY&&) = default;
+
+    static MatchedXY from_py(PyBuffer x, PyBuffer y)
+    {
+        sqp::validation::validate_xy(x, y);
+        return MatchedXY(std::move(x), std::move(y));
+    }
+
+    const PyBuffer& x() const { return _x; }
+    const PyBuffer& y() const { return _y; }
+
+    std::size_t rows() const { return _x.size(0); }
+    std::size_t cols() const { return _y.ndim() == 1 ? 1 : _y.size(1); }
+};
+```
+
+- [ ] **Step 4: Register with Meson**
+
+Edit `SciQLopPlots/meson.build`, adding `MatchedBuffers.hpp` next to `Validation.hpp`:
+
+```meson
+headers = moc_headers + \
+         [project_source_root+'/include/SciQLopPlots/Python/PythonInterface.hpp',
+         project_source_root+'/include/SciQLopPlots/Python/Views.hpp',
+         project_source_root+'/include/SciQLopPlots/Python/Validation.hpp',
+         project_source_root+'/include/SciQLopPlots/Python/MatchedBuffers.hpp',
+         project_source_root+'/include/SciQLopPlots/constants.hpp',
+         project_source_root+'/include/SciQLopPlots/Products/SubsequenceMatcher.hpp',
+         project_source_root+'/include/SciQLopPlots/Products/QueryParser.hpp']
+```
+
+- [ ] **Step 5: Include in `bindings.h`**
+
+Edit `SciQLopPlots/bindings/bindings.h`, after the Validation include:
+
+```cpp
+#include "SciQLopPlots/Python/MatchedBuffers.hpp"
+```
+
+- [ ] **Step 6: Expose in `bindings.xml`**
+
+Add inside the `<typesystem>` block (next to other `<value-type>` declarations):
+
+```xml
+    <value-type name="MatchedXY"/>
+```
+
+This exposes `MatchedXY` to Python. `from_py` shows up as a classmethod-style call (`SciQLopPlots.MatchedXY.from_py(x, y)`). The default constructor stays in Python (returns an empty wrapper) — leaving it avoids fighting Shiboken's internal construction paths; misuse is harmless since `rows()` / `cols()` on an empty wrapper return 0 and `x()` / `y()` return invalid PyBuffers.
+
+- [ ] **Step 7: Build and run tests**
+
+```bash
+meson compile -C build && \
+  cp build/SciQLopPlots/SciQLopPlotsBindings.cpython-313-x86_64-linux-gnu.so \
+     /var/home/jeandet/Documents/prog/SciQLop/.venv/lib/python3.13/site-packages/SciQLopPlots/ && \
+  cd /var/home/jeandet/Documents/prog && \
+  LD_LIBRARY_PATH=~/Qt/6.10.2/gcc_64/lib \
+  SciQLop/.venv/bin/python -m pytest \
+    SciQLopPlots/tests/integration/test_hardening_foundation.py -v
+```
+Expected: all tests pass, including the three MatchedXY tests.
+
+- [ ] **Step 8: Commit**
+
+```bash
+cd /var/home/jeandet/Documents/prog/SciQLopPlots
+git add include/SciQLopPlots/Python/MatchedBuffers.hpp \
+        SciQLopPlots/meson.build \
+        SciQLopPlots/bindings/bindings.h \
+        SciQLopPlots/bindings/bindings.xml \
+        tests/integration/test_hardening_foundation.py
+git commit -m "feat(python): add MatchedXY typed wrapper
+
+Zero-copy typed wrapper for (x, y) argument pairs. Constructor validates
+once; downstream code receives a known-good object."
+```
+
+---
+
+## Task 7: Add `MatchedXYZ`
+
+**Files:**
+- Modify: `include/SciQLopPlots/Python/MatchedBuffers.hpp`
+- Modify: `SciQLopPlots/bindings/bindings.xml`
+- Modify: `tests/integration/test_hardening_foundation.py`
+
+- [ ] **Step 1: Append failing tests**
+
+Append to `tests/integration/test_hardening_foundation.py`:
+
+```python
+# ---------- MatchedXYZ ----------
+
+def test_matched_xyz_ok():
+    x = np.arange(10.0)
+    y = np.arange(5.0)
+    z = np.random.rand(10, 5)
+    m = sqp.MatchedXYZ.from_py(x, y, z)
+    assert m.x_len() == 10
+    assert m.y_len() == 5
+
+
+def test_matched_xyz_mismatch_raises():
+    x = np.arange(10.0)
+    y = np.arange(5.0)
+    z = np.random.rand(9, 5)
+    with pytest.raises(ValueError):
+        sqp.MatchedXYZ.from_py(x, y, z)
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+```bash
+cd /var/home/jeandet/Documents/prog && \
+  LD_LIBRARY_PATH=~/Qt/6.10.2/gcc_64/lib \
+  SciQLop/.venv/bin/python -m pytest \
+    SciQLopPlots/tests/integration/test_hardening_foundation.py::test_matched_xyz_ok -v
+```
+Expected: `AttributeError`.
+
+- [ ] **Step 3: Implement `MatchedXYZ`**
+
+Append to `include/SciQLopPlots/Python/MatchedBuffers.hpp` (same global namespace as `MatchedXY`):
+
+```cpp
+class MatchedXYZ
+{
+    PyBuffer _x;
+    PyBuffer _y;
+    PyBuffer _z;
+
+    MatchedXYZ(PyBuffer x, PyBuffer y, PyBuffer z)
+            : _x(std::move(x)), _y(std::move(y)), _z(std::move(z)) { }
+
+public:
+    MatchedXYZ() = default;
+    MatchedXYZ(const MatchedXYZ&) = default;
+    MatchedXYZ(MatchedXYZ&&) = default;
+    MatchedXYZ& operator=(const MatchedXYZ&) = default;
+    MatchedXYZ& operator=(MatchedXYZ&&) = default;
+
+    static MatchedXYZ from_py(PyBuffer x, PyBuffer y, PyBuffer z)
+    {
+        sqp::validation::validate_xyz(x, y, z);
+        return MatchedXYZ(std::move(x), std::move(y), std::move(z));
+    }
+
+    const PyBuffer& x() const { return _x; }
+    const PyBuffer& y() const { return _y; }
+    const PyBuffer& z() const { return _z; }
+
+    std::size_t x_len() const { return _x.size(0); }
+    std::size_t y_len() const { return _y.size(0); }
+};
+```
+
+- [ ] **Step 4: Expose in `bindings.xml`**
+
+Add next to the `MatchedXY` `<value-type>`:
+
+```xml
+    <value-type name="MatchedXYZ"/>
+```
+
+- [ ] **Step 5: Build and run tests**
+
+```bash
+meson compile -C build && \
+  cp build/SciQLopPlots/SciQLopPlotsBindings.cpython-313-x86_64-linux-gnu.so \
+     /var/home/jeandet/Documents/prog/SciQLop/.venv/lib/python3.13/site-packages/SciQLopPlots/ && \
+  cd /var/home/jeandet/Documents/prog && \
+  LD_LIBRARY_PATH=~/Qt/6.10.2/gcc_64/lib \
+  SciQLop/.venv/bin/python -m pytest \
+    SciQLopPlots/tests/integration/test_hardening_foundation.py -v
+```
+Expected: all tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /var/home/jeandet/Documents/prog/SciQLopPlots
+git add include/SciQLopPlots/Python/MatchedBuffers.hpp \
+        SciQLopPlots/bindings/bindings.xml \
+        tests/integration/test_hardening_foundation.py
+git commit -m "feat(python): add MatchedXYZ typed wrapper
+
+Zero-copy typed wrapper for the (x, y, z) colormap argument pattern."
+```
+
+---
+
+## Task 8: Create `SafeSlot.hpp`
+
+**Files:**
+- Create: `include/SciQLopPlots/Python/SafeSlot.hpp`
+- Modify: `SciQLopPlots/meson.build`
+
+- [ ] **Step 1: Create the header**
+
+Create `include/SciQLopPlots/Python/SafeSlot.hpp`:
+
+```cpp
+#pragma once
+
+#include <QDebug>
+
+#include <exception>
+#include <string_view>
+#include <utility>
+
+// SQP_SAFE_SLOT_BEGIN / SQP_SAFE_SLOT_END — try/catch guards for Qt slot
+// lambda bodies. Prevents uncaught C++ exceptions from propagating into the
+// Qt event loop (which would call std::terminate).
+//
+// Usage:
+//   connect(sender, &Sender::sig, this, [this](int x) {
+//       SQP_SAFE_SLOT_BEGIN
+//       do_work(x);
+//       SQP_SAFE_SLOT_END("MyClass::on_sig")
+//   });
+
+#define SQP_SAFE_SLOT_BEGIN try {
+#define SQP_SAFE_SLOT_END(ctx)                                                 \
+    }                                                                          \
+    catch (const std::exception& _sqp_e)                                       \
+    {                                                                          \
+        qWarning() << "[safe_slot]" << (ctx) << ":" << _sqp_e.what();          \
+    }                                                                          \
+    catch (...)                                                                \
+    {                                                                          \
+        qWarning() << "[safe_slot]" << (ctx) << ": unknown exception";         \
+    }
+
+namespace sqp {
+
+// safe_slot — higher-order wrapper for non-macro call sites. Wraps a callable
+// so it swallows + logs any exceptions it throws. Return type of f is
+// discarded; returns void.
+template <typename F>
+auto safe_slot(F&& f, std::string_view context = "slot")
+{
+    return [fn = std::forward<F>(f), ctx = std::string(context)]
+           (auto&&... args) mutable -> void {
+        try
+        {
+            fn(std::forward<decltype(args)>(args)...);
+        }
+        catch (const std::exception& e)
+        {
+            qWarning() << "[safe_slot]" << ctx.c_str() << ":" << e.what();
+        }
+        catch (...)
+        {
+            qWarning() << "[safe_slot]" << ctx.c_str() << ": unknown exception";
+        }
+    };
+}
+
+} // namespace sqp
+```
+
+- [ ] **Step 2: Register with Meson**
+
+Edit `SciQLopPlots/meson.build`, adding `SafeSlot.hpp` next to the other Python headers:
+
+```meson
+headers = moc_headers + \
+         [project_source_root+'/include/SciQLopPlots/Python/PythonInterface.hpp',
+         project_source_root+'/include/SciQLopPlots/Python/Views.hpp',
+         project_source_root+'/include/SciQLopPlots/Python/Validation.hpp',
+         project_source_root+'/include/SciQLopPlots/Python/MatchedBuffers.hpp',
+         project_source_root+'/include/SciQLopPlots/Python/SafeSlot.hpp',
+         project_source_root+'/include/SciQLopPlots/constants.hpp',
+         project_source_root+'/include/SciQLopPlots/Products/SubsequenceMatcher.hpp',
+         project_source_root+'/include/SciQLopPlots/Products/QueryParser.hpp']
+```
+
+- [ ] **Step 3: Smoke-compile the header**
+
+Add a temporary include in `src/Profiling.cpp`:
+
+```cpp
+#include <SciQLopPlots/Python/SafeSlot.hpp>
+```
+
+Run:
+```bash
+meson compile -C build
+```
+Expected: compiles clean. Then revert the include.
+
+- [ ] **Step 4: Add a compile-only test exercise**
+
+Append to `src/Profiling.cpp` inside an anonymous namespace (if one doesn't exist, create one at top of file after includes):
+
+```cpp
+namespace {
+
+[[maybe_unused]] void _compile_test_safe_slot()
+{
+    auto guarded = sqp::safe_slot([](int x) { (void)x; }, "test");
+    guarded(42);
+}
+
+} // namespace
+```
+
+Run:
+```bash
+meson compile -C build
+```
+Expected: compiles clean.
+
+- [ ] **Step 5: Revert the compile-test**
+
+Remove the `_compile_test_safe_slot` function from `src/Profiling.cpp`. The header is picked up by Sub-effort 3's slot-audit work.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /var/home/jeandet/Documents/prog/SciQLopPlots
+git add include/SciQLopPlots/Python/SafeSlot.hpp SciQLopPlots/meson.build
+git commit -m "feat(python): add SafeSlot try/catch helpers
+
+SQP_SAFE_SLOT_BEGIN/END macros and sqp::safe_slot template wrap Qt slot
+bodies to prevent C++ exceptions from reaching the event loop. Consumed
+by Sub-effort 3 slot audit."
+```
+
+---
+
+## Task 9: `PyBuffer::data()` throws on invalid buffer
+
+**Files:**
+- Modify: `src/PythonInterface.cpp`
+- Modify: `tests/integration/test_hardening_foundation.py`
+
+- [ ] **Step 1: Append a failing test**
+
+Append to `tests/integration/test_hardening_foundation.py`:
+
+```python
+# ---------- PyBuffer::data() invalidity (exercised via validate_buffer) ----------
+# Direct C++ access to PyBuffer::data() is not exposed to Python, so this
+# is a compile-level contract verified by other suites. The negative path
+# (validate_buffer on a None object) already covers the "invalid buffer"
+# branch end-to-end.
+
+def test_validate_buffer_rejects_none_cleanly():
+    # PyBuffer from None is the "invalid" case; validate_buffer must raise,
+    # not segfault, even though internally PyBuffer::data() would throw on
+    # a hypothetical downstream call.
+    with pytest.raises(TypeError):
+        sqp.validate_buffer(None, "x")
+```
+
+This test was already present after Task 2 (`test_validate_buffer_none_raises_typeerror`). The purpose of this task is to fix the internal path: previously `PyBuffer::data()` returned `nullptr` on an invalid buffer, leaving a dereference-trap for any caller that forgot to check. We change it to throw so such callers get an exception instead.
+
+- [ ] **Step 2: Read the current `PyBuffer::data()` implementation**
+
+Read `src/PythonInterface.cpp` lines 403-413. Current body:
+
+```cpp
+double* PyBuffer::data() const
+{
+    if (is_valid())
+    {
+        if (_impl->buffer.format[0] != 'd')
+            throw std::runtime_error(
+                "PyBuffer::data() called on non-double buffer; use raw_data() + format_code()");
+        return reinterpret_cast<double*>(this->_impl->buffer.buf);
+    }
+    return nullptr;
+}
+```
+
+- [ ] **Step 3: Replace the nullptr return with a throw**
+
+Edit `src/PythonInterface.cpp`, replace lines 403-413 with:
+
+```cpp
+double* PyBuffer::data() const
+{
+    if (!is_valid())
+        throw std::runtime_error("PyBuffer::data() called on invalid buffer");
+    if (_impl->buffer.format[0] != 'd')
+        throw std::runtime_error(
+            "PyBuffer::data() called on non-double buffer; use raw_data() + format_code()");
+    return reinterpret_cast<double*>(this->_impl->buffer.buf);
+}
+```
+
+- [ ] **Step 4: Audit existing callers for the `nullptr` contract**
+
+Run:
+```bash
+cd /var/home/jeandet/Documents/prog/SciQLopPlots
+```
+
+Check all call sites in C++:
+```bash
+```
+(Use `Grep` tool for `\.data\(\)` in `src/` with glob `*.cpp`.)
+
+For each hit, verify the caller either:
+- calls `is_valid()` first (safe under the new contract too), **or**
+- unconditionally dereferences the result (was a latent nullptr-deref bug; is now an exception — `set_data` paths in plottables already check `x.is_valid()` so they're unaffected).
+
+**Record findings in the commit message.** No code changes in callers expected; the change is a strengthening of the contract, not a breaking one.
+
+- [ ] **Step 5: Build and run the full test suite**
+
+```bash
+meson compile -C build && \
+  cp build/SciQLopPlots/SciQLopPlotsBindings.cpython-313-x86_64-linux-gnu.so \
+     /var/home/jeandet/Documents/prog/SciQLop/.venv/lib/python3.13/site-packages/SciQLopPlots/ && \
+  cd /var/home/jeandet/Documents/prog && \
+  LD_LIBRARY_PATH=~/Qt/6.10.2/gcc_64/lib \
+  SciQLop/.venv/bin/python -m pytest \
+    SciQLopPlots/tests/integration/ -v
+```
+Expected: every integration test passes (not just the hardening file — this change affects general code paths).
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /var/home/jeandet/Documents/prog/SciQLopPlots
+git add src/PythonInterface.cpp tests/integration/test_hardening_foundation.py
+git commit -m "fix(python): PyBuffer::data() throws on invalid buffer
+
+Previously returned nullptr, leaving a dereference trap for callers who
+forgot to check is_valid(). Now throws std::runtime_error. Audited
+existing call sites: all guarded by is_valid() or not reachable with an
+invalid buffer."
+```
+
+---
+
+## Task 10: Tighten `dispatch_dtype` exception
+
+**Files:**
+- Modify: `include/SciQLopPlots/Python/DtypeDispatch.hpp`
+- Modify: `tests/integration/test_hardening_foundation.py`
+
+- [ ] **Step 1: Append a failing test**
+
+Append to `tests/integration/test_hardening_foundation.py`:
+
+```python
+# ---------- dispatch_dtype error surface (via validate_buffer) ----------
+
+def test_validate_buffer_rejects_float16():
+    # float16 is not currently supported by dispatch_dtype. validate_buffer's
+    # numeric check should reject it with TypeError (format code 'e' not in
+    # our numeric_formats whitelist), before reaching dispatch.
+    arr = np.arange(10, dtype=np.float16)
+    with pytest.raises(TypeError):
+        sqp.validate_buffer(arr, "x")
+```
+
+- [ ] **Step 2: Improve the exception**
+
+Edit `include/SciQLopPlots/Python/DtypeDispatch.hpp`. Replace line 23 (`default: throw std::runtime_error("Unsupported numpy dtype");`) with:
+
+```cpp
+        default:
+        {
+            std::string msg = "Unsupported numpy dtype format code: '";
+            if (format_code == '\0')
+                msg += "\\0";
+            else
+                msg += format_code;
+            msg += "'";
+            throw std::invalid_argument(msg);
+        }
+```
+
+Add `#include <string>` to the top-of-file includes.
+
+**Why `invalid_argument` instead of `runtime_error`:** maps to `ValueError` in Python, which better communicates "your input is wrong" vs `RuntimeError` (internal failure).
+
+- [ ] **Step 3: Build and run tests**
+
+```bash
+meson compile -C build && \
+  cp build/SciQLopPlots/SciQLopPlotsBindings.cpython-313-x86_64-linux-gnu.so \
+     /var/home/jeandet/Documents/prog/SciQLop/.venv/lib/python3.13/site-packages/SciQLopPlots/ && \
+  cd /var/home/jeandet/Documents/prog && \
+  LD_LIBRARY_PATH=~/Qt/6.10.2/gcc_64/lib \
+  SciQLop/.venv/bin/python -m pytest \
+    SciQLopPlots/tests/integration/test_hardening_foundation.py -v
+```
+Expected: all tests pass, including the new float16 test.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /var/home/jeandet/Documents/prog/SciQLopPlots
+git add include/SciQLopPlots/Python/DtypeDispatch.hpp \
+        tests/integration/test_hardening_foundation.py
+git commit -m "fix(python): dispatch_dtype throws invalid_argument with code
+
+Improves exception type (runtime_error -> invalid_argument, mapping to
+Python ValueError) and the message (includes the actual format code)."
+```
+
+---
+
+## Task 11: `bindings.xml` exception-translation audit
+
+**Goal:** Verify that every exception type used in Validation.hpp and DtypeDispatch.hpp translates to the intended Python exception. If any maps unexpectedly, add an `exception-handling` / type-system mapping so the intent holds.
+
+**Files:**
+- Modify (if needed): `SciQLopPlots/bindings/bindings.xml`
+- Modify: `tests/integration/test_hardening_foundation.py`
+
+- [ ] **Step 1: Add a consolidated exception-taxonomy test**
+
+Append to `tests/integration/test_hardening_foundation.py`:
+
+```python
+# ---------- Exception taxonomy (translation audit) ----------
+
+import builtins
+
+@pytest.mark.parametrize("call,exc_cls", [
+    (lambda: sqp.validate_buffer(None, "x"),                     TypeError),
+    (lambda: sqp.validate_buffer(np.arange(10.0), "x", 2),       ValueError),
+    (lambda: sqp.validate_index(-1, 10, "i"),                    IndexError),
+    (lambda: sqp.validate_index(10, 10, "i"),                    IndexError),
+    (lambda: sqp.validate_xy(np.arange(10.0), np.arange(5.0)),   ValueError),
+    (lambda: sqp.validate_finite(float("nan"), "v"),             ValueError),
+])
+def test_exception_taxonomy(call, exc_cls):
+    with pytest.raises(exc_cls):
+        call()
+```
+
+- [ ] **Step 2: Run the test to find any mismatch**
+
+```bash
+meson compile -C build && \
+  cp build/SciQLopPlots/SciQLopPlotsBindings.cpython-313-x86_64-linux-gnu.so \
+     /var/home/jeandet/Documents/prog/SciQLop/.venv/lib/python3.13/site-packages/SciQLopPlots/ && \
+  cd /var/home/jeandet/Documents/prog && \
+  LD_LIBRARY_PATH=~/Qt/6.10.2/gcc_64/lib \
+  SciQLop/.venv/bin/python -m pytest \
+    SciQLopPlots/tests/integration/test_hardening_foundation.py::test_exception_taxonomy -v
+```
+
+Expected (in the common case): all pass. If any row fails because the actual exception is `RuntimeError`, Shiboken's default mapping is collapsing our specific C++ exception types into `RuntimeError`. In that case proceed to Step 3; otherwise skip to Step 4.
+
+- [ ] **Step 3 (conditional): Add explicit exception mapping to `bindings.xml`**
+
+If Step 2 showed `RuntimeError` where we expect `ValueError` / `IndexError` / `TypeError`, edit the `<add-function>` entries for the affected validators to include an explicit `inject-code` rewrite that catches and re-raises with the intended Python type. Example for `validate_buffer`:
+
+```xml
+    <add-function signature="validate_buffer(PyBuffer, std::string, int, char)" return-type="void">
+        <inject-code class="target" position="beginning">
+            try {
+                sqp::validation::validate_buffer(%1, %2, %3, %4);
+            } catch (const std::invalid_argument& e) {
+                PyErr_SetString(PyExc_ValueError, e.what());
+                return nullptr;
+            }
+        </inject-code>
+        <modify-argument index="3">
+            <default-value>-1</default-value>
+        </modify-argument>
+        <modify-argument index="4">
+            <default-value>0</default-value>
+        </modify-argument>
+    </add-function>
+```
+
+Apply the corresponding pattern to `validate_index` (`std::out_of_range` → `PyExc_IndexError`), `validate_xy`, `validate_xyz`, `validate_same_length`, `validate_nd_list`, `validate_finite` (`std::invalid_argument` → `PyExc_ValueError`). For null-buffer cases the test expects `TypeError`: add a `catch (const std::invalid_argument& e) where e.what() starts with "…: invalid or null buffer"` path that raises `PyExc_TypeError`. Simplest implementation: split the null-check out of `validate_buffer` into `validate_buffer_non_null` which throws `std::domain_error`, and map that to `TypeError`.
+
+(If no remapping is needed because Shiboken's default mapping already does the right thing, this step is a no-op.)
+
+- [ ] **Step 4: Re-run the test suite**
+
+```bash
+meson compile -C build && \
+  cp build/SciQLopPlots/SciQLopPlotsBindings.cpython-313-x86_64-linux-gnu.so \
+     /var/home/jeandet/Documents/prog/SciQLop/.venv/lib/python3.13/site-packages/SciQLopPlots/ && \
+  cd /var/home/jeandet/Documents/prog && \
+  LD_LIBRARY_PATH=~/Qt/6.10.2/gcc_64/lib \
+  SciQLop/.venv/bin/python -m pytest \
+    SciQLopPlots/tests/integration/test_hardening_foundation.py -v
+```
+Expected: every test in the file passes.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /var/home/jeandet/Documents/prog/SciQLopPlots
+git add tests/integration/test_hardening_foundation.py \
+        SciQLopPlots/bindings/bindings.xml
+git commit -m "feat(python): exception-translation audit for hardening foundation
+
+Parametrized taxonomy test pins TypeError / ValueError / IndexError to
+specific validator failure modes. bindings.xml updated with explicit
+exception mapping where Shiboken's default collapsed to RuntimeError."
+```
+
+---
+
+## Task 12: Run full integration suite + push branch
+
+- [ ] **Step 1: Run the full integration suite**
+
+```bash
+cd /var/home/jeandet/Documents/prog && \
+  LD_LIBRARY_PATH=~/Qt/6.10.2/gcc_64/lib \
+  SciQLop/.venv/bin/python -m pytest \
+    SciQLopPlots/tests/integration/ -v
+```
+Expected: all existing tests still pass plus the new hardening tests.
+
+- [ ] **Step 2: Run the unit suite**
+
+```bash
+cd /var/home/jeandet/Documents/prog/SciQLopPlots && \
+  LD_LIBRARY_PATH=~/Qt/6.10.2/gcc_64/lib \
+  /var/home/jeandet/Documents/prog/SciQLop/.venv/bin/python -m pytest tests/unit/ -v
+```
+Expected: all pass.
+
+- [ ] **Step 3: Push the branch to the fork**
+
+Create and push a feature branch:
+
+```bash
+cd /var/home/jeandet/Documents/prog/SciQLopPlots
+git checkout -b feature/python-hardening-foundation
+git push -u origin feature/python-hardening-foundation
+```
+
+- [ ] **Step 4: Confirm done**
+
+All 12 tasks completed means Sub-effort 1 plumbing is merged-ready:
+- Headers (`Assert.hpp`, `Validation.hpp`, `MatchedBuffers.hpp`, `SafeSlot.hpp`) exist and are reachable from bindings.
+- `PyBuffer::data()` throws on invalid buffers.
+- `dispatch_dtype` throws `invalid_argument` with a clear message.
+- Validators are callable from Python and have a passing test file (`tests/integration/test_hardening_foundation.py`).
+- Exception taxonomy is pinned by the parametrized test.
+
+No caller wiring changed — that is Sub-effort 2's scope.

--- a/docs/superpowers/specs/2026-04-17-python-hardening-design.md
+++ b/docs/superpowers/specs/2026-04-17-python-hardening-design.md
@@ -1,0 +1,439 @@
+# Python-side crash-hardening — design
+
+**Date:** 2026-04-17
+**Status:** Draft
+
+## 1. The contract
+
+**Invariant.** Any Python call into SciQLopPlots — regardless of argument
+validity, object state, or user-supplied callback behavior — must either
+succeed, be a no-op, or raise a Python exception. **It must never segfault,
+abort, or invoke undefined behavior.**
+
+### In scope
+
+- All classes exposed via `SciQLopPlots/bindings/bindings.xml` (plots, panels,
+  plottables, items, axes, spans, collections, overlays).
+- The `plot()` dispatcher in `SciQLopPlots/__init__.py`.
+- User-supplied `get_data` callbacks — C++ validates the values they return.
+- Reactive `.on` pipelines, Inspector / PropertiesView, Products view — any
+  surface reachable from `import SciQLopPlots`.
+
+### Out of scope (initial release)
+
+- Memory leaks, deadlocks, performance pathology — not segfaults.
+- OpenGL driver / Qt platform-plugin crashes.
+- Internal C++ bugs reachable only from within the library; these are
+  covered by debug-mode assertions, not the public contract.
+
+### Trade-offs
+
+- Validation at entry is O(1) per call (format / ndim / size / contiguity /
+  shape-match). Negligible next to any real data operation.
+- We replace today's "silent no-op on bad data" with "exception with
+  descriptive message." Some internal callers may rely on the silent-no-op
+  behavior; we sweep the codebase.
+
+## 2. Architecture
+
+Four layers, each with a single responsibility. Validation lives at exactly
+one of them per code path.
+
+```
+Python user code
+      │
+      ▼
+┌─────────────────────────────────────┐
+│ L1: Python dispatch (__init__.py)   │  Validates arg count / graph_type;
+│     plot() dispatcher               │  pre-Shiboken ergonomic errors.
+└─────────────────────────────────────┘
+      │
+      ▼
+┌─────────────────────────────────────┐
+│ L2: C++ API boundary                │  Every method taking PyBuffer /
+│     set_data, add_*, ranges, etc.   │  PyObject validates at entry.
+│                                     │  Typed wrappers MatchedXY / XYZ
+│                                     │  for the dominant xy(z) pattern.
+└─────────────────────────────────────┘
+      │ (validated, known-good)
+      ▼
+┌─────────────────────────────────────┐
+│ L3: C++ internals                   │  No re-validation. Trust the
+│     resamplers, data sources        │  boundary. Debug-mode asserts only.
+└─────────────────────────────────────┘
+      ▲
+      │  (results from Python callable)
+┌─────────────────────────────────────┐
+│ L4: Callback return boundary        │  GetDataPyCallable validates the
+│     worker thread ← get_data()      │  list/tuple, each buffer's dtype,
+│                                     │  ndim, and cross-array shape match
+│                                     │  before constructing PyBuffers.
+└─────────────────────────────────────┘
+```
+
+### Cross-cutting concerns (all live at L2)
+
+- **Exception translation** — Shiboken typesystem maps
+  `std::runtime_error` / `std::invalid_argument` / `std::out_of_range` /
+  `std::bad_alloc` to `RuntimeError` / `ValueError` / `IndexError` /
+  `MemoryError`. `bindings.xml` is audited for every bound method.
+- **Signal-handler safety** — a `safe_slot` helper wraps Qt slot bodies in
+  try/catch so C++ exceptions can't cross back into the Qt event loop.
+  Exceptions inside slots are logged and swallowed.
+- **Object lifetime safety** — Shiboken's wrapper invalidation handles
+  Python → C++ calls on deleted QObjects. C++-internal non-owning
+  `QObject*` members are converted to `QPointer<T>` and null-checked.
+- **Index safety** — every bound method taking an integer index
+  bounds-checks at entry; negative indices are rejected, not wrapped.
+
+### New headers
+
+- `include/SciQLopPlots/Python/Validation.hpp`
+- `include/SciQLopPlots/Python/MatchedBuffers.hpp`
+- `include/SciQLopPlots/Python/SafeSlot.hpp`
+
+## 3. Components
+
+### 3.1 `Validation.hpp`
+
+Free functions, no state. Throw `std::invalid_argument` /
+`std::out_of_range`, translated to Python `ValueError` / `IndexError` by
+Shiboken.
+
+```cpp
+void validate_buffer(const PyBuffer& b, std::string_view name,
+                     int expected_ndim = -1,   // -1 = any
+                     char expected_dtype = 0); // 0 = any numeric
+
+void validate_same_length(const PyBuffer& a, std::string_view name_a,
+                          const PyBuffer& b, std::string_view name_b);
+
+void validate_xy(const PyBuffer& x, const PyBuffer& y);
+void validate_xyz(const PyBuffer& x, const PyBuffer& y, const PyBuffer& z);
+void validate_nd_list(const QList<PyBuffer>& bufs, std::size_t expected_count);
+
+void validate_index(qsizetype i, qsizetype size, std::string_view name);
+void validate_finite(double v, std::string_view name);
+```
+
+Error messages follow the form
+`"<method>: <param>: <what was wrong> (got <actual>, expected <spec>)"`.
+
+### 3.2 `MatchedBuffers.hpp`
+
+Typed wrappers for the dominant xy / xyz pattern. Construction =
+validation. Once constructed, known-good; no checks downstream.
+
+```cpp
+class MatchedXY {
+public:
+    static MatchedXY from_py(PyBuffer x, PyBuffer y);   // throws on mismatch
+    const PyBuffer& x() const;
+    const PyBuffer& y() const;
+    std::size_t rows() const;
+    std::size_t cols() const;   // 1 for 1D y
+};
+
+class MatchedXYZ { /* x 1D, y 1D, z 2D row/col-major, shapes match */ };
+```
+
+Shiboken typesystem converter accepts a Python tuple/list
+`(x, y)` or `(x, y, z)` and produces a `MatchedXY` / `MatchedXYZ`, raising
+`ValueError` on failure. If the codegen path forces a copy, drop back to
+taking two/three `PyBuffer` parameters in the method and call
+`MatchedXY::from_py` inside — same zero-copy guarantee, simpler binding.
+
+### 3.3 `SafeSlot.hpp`
+
+```cpp
+template <typename F>
+auto safe_slot(F&& f, std::string_view context = "");
+
+#define SQP_SAFE_SLOT_BEGIN try {
+#define SQP_SAFE_SLOT_END(ctx) \
+    } catch (const std::exception& e) { qWarning() << ctx << e.what(); } \
+      catch (...) { qWarning() << ctx << "unknown exception"; }
+```
+
+Applied to every `connect(..., [this](...) { ... })` lambda body and to
+every override that calls into user code (`timerEvent`, `paintEvent` where
+relevant).
+
+### 3.4 Changes to existing types
+
+- **`PyBuffer::data()`** — throws `std::runtime_error("PyBuffer is invalid")`
+  instead of returning `nullptr` when invalid. Callers needing nullable
+  access use `raw_data()` or test `is_valid()` first.
+- **`dispatch_dtype`** — asserts on unknown format code today; replace
+  with `throw std::invalid_argument("unsupported dtype: <code>")`.
+- **`GetDataPyCallable::get_data(...)`** — before wrapping callback results
+  into `PyBuffer`s:
+  - Result must be a list or tuple, else `qWarning` + return empty vector.
+  - Every element must satisfy `PyObject_CheckBuffer`, else
+    `qWarning` + return empty.
+  - For `get_data(x, y)` / `get_data(x, y, z)`: returned buffers must have
+    matching leading-axis length.
+  - Catch `std::runtime_error` from `PyBuffer` construction (bad dtype);
+    `qWarning` + return empty.
+  - Never propagates exceptions up — worker-thread callers expect
+    `vector<PyBuffer>{}` on failure.
+
+### 3.5 Lifetime audit sweep (one-time)
+
+1. Grep all headers for non-owning `QObject*` member variables. Each is
+   either:
+   - owned by a guaranteed-outliving parent (Qt parent-child): document
+     at the field, no change; or
+   - otherwise: convert to `QPointer<T>`, null-check before each deref.
+2. Grep for all slot lambda bodies; wrap with `SQP_SAFE_SLOT_BEGIN/END`
+   or confirm trivial-body exemption.
+3. Audit all resampler-held pointers across the thread boundary.
+
+### 3.6 Index audit sweep (one-time)
+
+Grep for every bound method signature containing `int`, `size_t`,
+`qsizetype`, `std::size_t`. Triage:
+
+- **Index into container** → `validate_index(i, container.size(), "param")`
+  at entry.
+- **Count / size** → reject negative.
+- **Flag / enum** → OK (bounded by type), no change.
+
+### 3.7 Exception translation in `bindings.xml`
+
+One-shot XML edit. Audit every `<object-type>` / `<value-type>` block:
+ensure `exception-handling="on"` (or the global typesystem equivalent) so
+`std::runtime_error`, `std::invalid_argument`, `std::out_of_range`, and
+`std::bad_alloc` map to the expected Python exceptions. Verified by the
+fuzz suite in §5.
+
+### 3.8 Debug-mode assertions
+
+A `SQP_ASSERT(expr)` macro. No-op in release; `std::abort()` in debug
+builds (dev and CI). Internal invariants (L3) use this. Release stays
+fast; internal bugs get caught in CI.
+
+### 3.9 Zero-copy invariant
+
+**No validator, wrapper, or boundary transform copies the underlying
+buffer data.** Only `shared_ptr<_PyBuffer_impl>` refcount bumps.
+
+- `PyBuffer` uses `shared_ptr<_PyBuffer_impl>` (already); copy/move is a
+  refcount bump. The `Py_buffer` view is a numpy view, not a copy.
+- Validators take `const PyBuffer&` — no copy.
+- `MatchedXY` / `MatchedXYZ` hold `PyBuffer` by value; factory takes
+  rvalues and moves into members. RVO on the returned wrapper.
+- Shiboken converter for `MatchedXY`: generated code calls
+  `PyBuffer(obj_x)`, `PyBuffer(obj_y)`, then `MatchedXY::from_py(...)`
+  with move semantics. Zero data copies end-to-end. Fallback (two
+  `PyBuffer` args + construct inside method) has the same guarantee.
+- `GetDataPyCallable` result path wraps returned objects with
+  `PyBuffer(PyList_GetItem(...))` — a view.
+- Existing `dataGuard` `shared_ptr` pattern preserves zero-copy safety
+  across the async resampler thread.
+
+Enforcement: every PR touching a boundary method has a "no copies
+introduced" acceptance criterion. A benchmark in `tests/perf/` verifies
+`set_data` with 10M samples runs within noise of today's timings — catches
+accidental `memcpy` regressions.
+
+## 4. Error model and data flow
+
+### Exception taxonomy
+
+| Failure | Python exception | Raised from |
+|---|---|---|
+| `None`, non-buffer where buffer expected | `TypeError` | Shiboken converter / `PyBuffer` ctor |
+| Non-numeric dtype (object, string, void) | `TypeError` | `PyBuffer::init_buffer` |
+| Wrong ndim | `ValueError` | `validate_buffer` |
+| Shape mismatch (x.len ≠ y.rows) | `ValueError` | `validate_xy` / `validate_xyz` |
+| Unsupported dtype reaching dispatch | `ValueError` | `dispatch_dtype` |
+| Index out of range | `IndexError` | `validate_index` |
+| Negative index | `IndexError` | `validate_index` |
+| Empty array where non-empty required | `ValueError` | per-call validator |
+| Allocation failure | `MemoryError` | `std::bad_alloc` translation |
+| Method on deleted C++ object | `RuntimeError` | Shiboken built-in |
+| Bad `graph_type` / arg count in `plot()` | `ValueError` | Python dispatcher |
+
+Messages: `"<method>: <param>: <what was wrong> (got <actual>, expected <spec>)"`.
+Example: `"set_data: y: ndim must be 1 or 2 (got 3)"`.
+
+### Sync vs async paths
+
+- **Sync path** (user calls `set_data`, `add_graph`, `set_range`, …):
+  exceptions raise and propagate. Plot state is unchanged on failure —
+  validate first, then mutate.
+- **Async path** (worker thread invokes user's `get_data` callback):
+  exceptions are caught and logged via `qWarning`; they cannot raise
+  (no Python frame to raise into). Data source returns empty result;
+  plot keeps its last good data. One `qWarning` per failure, no flood.
+  `PyErr_Print` is used for exceptions *inside* the user callback;
+  validation failures on the *return value* use `qWarning`.
+
+### State invariants after failure
+
+- `set_*` family: validate at entry; mutate only after validation passes.
+  Failure → state unchanged.
+- `add_*`: if construction fails partway, destructor cleans up; no
+  half-registered plottable survives.
+- `remove_*` with bad index: no-op + `IndexError`.
+- Callback return validation failure: data source keeps the last good
+  data; no partial update.
+
+### Logging
+
+- `qWarning` for async failures only, via `sqp_warn("context", ...)` helper
+  with a stable prefix so users can filter.
+- Validators silent on success; no hot-path `qDebug` spam.
+- Env var `SQP_LOG_VERBOSE=1` enables diagnostic lines (sizes, dtypes) on
+  validation failures — dev aid, off by default.
+
+### Rejected alternatives
+
+- In-plot error overlays — too opinionated; downstream (SciQLop) can layer
+  this on top.
+- Fail-soft return codes — Python idiom is exceptions; mixing breaks
+  ergonomics.
+- Automatic retry on async failures — masks real bugs.
+
+## 5. Testing strategy
+
+### 5.1 Targeted regression tests — `tests/integration/test_hardening/`
+
+One test file per boundary class. Each exercises:
+
+- Every validation failure mode (wrong dtype, ndim, shape, index, None,
+  empty, NaN where rejected).
+- Asserts the right exception class and that the message contains the
+  parameter name.
+- Asserts plot state is unchanged after a failed call (pre/post
+  snapshot).
+
+Deliverable: one file per plottable + per item + per plot class.
+
+### 5.2 Property-based fuzz — `tests/integration/test_fuzz_crashproof.py`
+
+Using Hypothesis. Harness generates arbitrary inputs and calls every bound
+method. Oracle is simple: **the process must not crash.** Pass = either
+success or a Python exception from the whitelisted set (`TypeError`,
+`ValueError`, `IndexError`, `RuntimeError`, `MemoryError`).
+
+Strategies cover:
+
+- numpy arrays of every dtype, including object / void / strings
+- arbitrary ndim (0D through 5D)
+- NaN / Inf / negative / huge values
+- `None`, strings, lists, dicts where arrays expected
+- negative and huge integer indices
+- misbehaving callbacks: raises, returns wrong count, returns None,
+  returns non-numeric, blocks briefly
+
+Per-example timeout; `SCIQLOP_FUZZ_MINUTES=N` controls budget (CI default
+2–5 min; nightly 30 min).
+
+### 5.2b Stateful fuzz — `RuleBasedStateMachine`
+
+A single stateful machine models a SciQLopPlots session. Rules:
+
+- `create_plot_panel` / `add_plot` / `remove_plot`
+- `add_graph` / `add_colormap` / `add_scatter` / `remove_plottable`
+  (random index, including out-of-range)
+- `set_data` with random valid or garbage arrays
+- `set_range` / `set_axis_type` / `set_visible`
+- `add_span` / `remove_span`
+- `set_callback` with a misbehaving callback
+- `resize` / `show` / `hide` / `delete_panel`
+- brief sleep to let the async resampler thread run
+
+Invariant after every rule: process alive; no stray C++ log marker; no
+uncaught Python warning. 200 rule sequences per CI run; longer at night.
+
+### 5.3 Sanitizer CI job
+
+Nightly job builds with `-fsanitize=address,undefined` and runs the full
+test suite (unit + integration + fuzz). Any sanitizer report fails the
+build. Catches stale-pointer reads and signed-overflow UB that Python-level
+tests miss.
+
+### Acceptance — "the contract holds"
+
+- Full fuzz suite completes without process crash (no `SIGSEGV` /
+  `SIGABRT` exit).
+- Sanitizer CI green.
+- Targeted regression tests all pass.
+- No crash signal in any CI run across the past 7 days.
+
+### Test dependencies
+
+Hypothesis and any additional test deps are added to
+`.github/workflows/test.yml`; tests are never skipped for missing
+packages.
+
+### Out of scope for testing
+
+- Performance regression — covered by existing `tests/perf/`. The one
+  addition here is the zero-copy benchmark from §3.9.
+- Graphics-rendering correctness — not a crash concern.
+
+## 6. Rollout decomposition
+
+One spec (this document). Four sequential implementation plans; each is
+its own PR stack.
+
+### Sub-effort 1 — Foundation
+
+No user-visible behavior change. Lands first; later sub-efforts depend
+on the plumbing.
+
+- `Validation.hpp`, `MatchedBuffers.hpp`, `SafeSlot.hpp` created.
+- `PyBuffer::data()` / `dispatch_dtype` — throw instead of UB/assert.
+- `bindings.xml` exception-translation audit.
+- `SQP_ASSERT` macro added.
+
+**Size:** small.
+
+### Sub-effort 2 — Apply to data boundary
+
+Main body of work. Can be split by subsystem (plottables → items →
+panel → axes) for reviewability.
+
+- Every `set_data` / `add_*` / integer-index method gets the appropriate
+  validator call at entry.
+- Rewrite the six `set_data` implementations to use `MatchedXY` /
+  `MatchedXYZ` (or equivalent free-function validation).
+- `GetDataPyCallable` result-validation added.
+- Targeted regression tests (§5.1) land alongside each method.
+
+**Size:** largest.
+
+### Sub-effort 3 — Lifetime and signals
+
+- Member-variable audit: non-owning `QObject*` → `QPointer<T>`.
+- Slot-lambda audit: wrap with `SQP_SAFE_SLOT_BEGIN/END`.
+- Resampler cross-thread pointer audit.
+- Regression tests exercising deleted-object calls.
+
+**Size:** medium.
+
+### Sub-effort 4 — Fuzz harness and CI
+
+- Per-method fuzz (§5.2).
+- Stateful fuzz (§5.2 stateful).
+- ASan/UBSan CI job (§5.3).
+- Nightly fuzz budget.
+- Zero-copy perf benchmark (§3.9).
+
+**Size:** medium. Can scaffold in parallel with 2/3; finishes last.
+
+### Sequencing
+
+- 1 → 2 is a hard dependency.
+- 3 is independent of 2 but reads better once 2 is merged.
+- 4 scaffolds in parallel; lands last to validate.
+
+### Done definition
+
+- All four sub-efforts merged.
+- Fuzz CI green for 7 consecutive days.
+- Sanitizer CI green for 7 consecutive days.
+- Invariant (§1) documented in the public README.

--- a/include/SciQLopPlots/Assert.hpp
+++ b/include/SciQLopPlots/Assert.hpp
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <cstdio>
+#include <cstdlib>
+
+// SQP_ASSERT — debug-only invariant check.
+//
+// In debug builds (NDEBUG not defined): prints diagnostic and calls std::abort().
+// In release builds: the expression is not evaluated, no runtime cost.
+//
+// Use for *internal* invariants that should never fail if the boundary-layer
+// validation is correct. Do NOT use for user-input validation — throw an
+// exception from Validation.hpp instead.
+
+#ifndef NDEBUG
+#define SQP_ASSERT(expr)                                                       \
+    do {                                                                       \
+        if (!(expr)) {                                                         \
+            std::fprintf(stderr, "SQP_ASSERT failed: %s\n  at %s:%d in %s\n",  \
+                         #expr, __FILE__, __LINE__, __func__);                 \
+            std::abort();                                                      \
+        }                                                                      \
+    } while (0)
+#else
+#define SQP_ASSERT(expr) ((void)0)
+#endif

--- a/include/SciQLopPlots/Python/DtypeDispatch.hpp
+++ b/include/SciQLopPlots/Python/DtypeDispatch.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include <cstdint>
 #include <stdexcept>
+#include <string>
 #include <type_traits>
 
 template <typename F>
@@ -20,6 +21,15 @@ auto dispatch_dtype(char format_code, F&& func)
         case 'L': return func(std::type_identity<unsigned long> {});
         case 'q': return func(std::type_identity<long long> {});
         case 'Q': return func(std::type_identity<unsigned long long> {});
-        default: throw std::runtime_error("Unsupported numpy dtype");
+        default:
+        {
+            std::string msg = "Unsupported numpy dtype format code: '";
+            if (format_code == '\0')
+                msg += "\\0";
+            else
+                msg += format_code;
+            msg += "'";
+            throw std::invalid_argument(msg);
+        }
     }
 }

--- a/include/SciQLopPlots/Python/MatchedBuffers.hpp
+++ b/include/SciQLopPlots/Python/MatchedBuffers.hpp
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <SciQLopPlots/Python/PythonInterface.hpp>
+#include <SciQLopPlots/Python/Validation.hpp>
+
+#include <utility>
+
+class MatchedXY
+{
+    PyBuffer _x;
+    PyBuffer _y;
+
+    MatchedXY(PyBuffer x, PyBuffer y) : _x(std::move(x)), _y(std::move(y)) { }
+
+public:
+    MatchedXY() = default;
+    MatchedXY(const MatchedXY&) = default;
+    MatchedXY(MatchedXY&&) = default;
+    MatchedXY& operator=(const MatchedXY&) = default;
+    MatchedXY& operator=(MatchedXY&&) = default;
+
+    static MatchedXY from_py(PyBuffer x, PyBuffer y)
+    {
+        sqp::validation::validate_xy(x, y);
+        return MatchedXY(std::move(x), std::move(y));
+    }
+
+    const PyBuffer& x() const { return _x; }
+    const PyBuffer& y() const { return _y; }
+
+    std::size_t rows() const { return _x.size(0); }
+    std::size_t cols() const { return _y.ndim() == 1 ? 1 : _y.size(1); }
+};

--- a/include/SciQLopPlots/Python/MatchedBuffers.hpp
+++ b/include/SciQLopPlots/Python/MatchedBuffers.hpp
@@ -31,3 +31,33 @@ public:
     std::size_t rows() const { return _x.size(0); }
     std::size_t cols() const { return _y.ndim() == 1 ? 1 : _y.size(1); }
 };
+
+class MatchedXYZ
+{
+    PyBuffer _x;
+    PyBuffer _y;
+    PyBuffer _z;
+
+    MatchedXYZ(PyBuffer x, PyBuffer y, PyBuffer z)
+            : _x(std::move(x)), _y(std::move(y)), _z(std::move(z)) { }
+
+public:
+    MatchedXYZ() = default;
+    MatchedXYZ(const MatchedXYZ&) = default;
+    MatchedXYZ(MatchedXYZ&&) = default;
+    MatchedXYZ& operator=(const MatchedXYZ&) = default;
+    MatchedXYZ& operator=(MatchedXYZ&&) = default;
+
+    static MatchedXYZ from_py(PyBuffer x, PyBuffer y, PyBuffer z)
+    {
+        sqp::validation::validate_xyz(x, y, z);
+        return MatchedXYZ(std::move(x), std::move(y), std::move(z));
+    }
+
+    const PyBuffer& x() const { return _x; }
+    const PyBuffer& y() const { return _y; }
+    const PyBuffer& z() const { return _z; }
+
+    std::size_t x_len() const { return _x.size(0); }
+    std::size_t y_len() const { return _y.size(0); }
+};

--- a/include/SciQLopPlots/Python/SafeSlot.hpp
+++ b/include/SciQLopPlots/Python/SafeSlot.hpp
@@ -1,0 +1,54 @@
+#pragma once
+
+#include <QDebug>
+
+#include <exception>
+#include <string_view>
+#include <utility>
+
+// SQP_SAFE_SLOT_BEGIN / SQP_SAFE_SLOT_END — try/catch guards for Qt slot
+// lambda bodies. Prevents uncaught C++ exceptions from propagating into the
+// Qt event loop (which would call std::terminate).
+//
+// Usage:
+//   connect(sender, &Sender::sig, this, [this](int x) {
+//       SQP_SAFE_SLOT_BEGIN
+//       do_work(x);
+//       SQP_SAFE_SLOT_END("MyClass::on_sig")
+//   });
+
+#define SQP_SAFE_SLOT_BEGIN try {
+#define SQP_SAFE_SLOT_END(ctx)                                                 \
+    }                                                                          \
+    catch (const std::exception& _sqp_e)                                       \
+    {                                                                          \
+        qWarning() << "[safe_slot]" << (ctx) << ":" << _sqp_e.what();          \
+    }                                                                          \
+    catch (...)                                                                \
+    {                                                                          \
+        qWarning() << "[safe_slot]" << (ctx) << ": unknown exception";         \
+    }
+
+namespace sqp {
+
+template <typename F>
+auto safe_slot(F&& f, std::string_view context = "slot")
+{
+    return [fn = std::forward<F>(f), ctx = std::string(context)]
+           (auto&&... args) mutable -> void {
+        try
+        {
+            fn(std::forward<decltype(args)>(args)...);
+        }
+        catch (const std::exception& e)
+        {
+            qWarning() << "[safe_slot]" << ctx.c_str() << ":" << e.what();
+        }
+        catch (...)
+        {
+            qWarning() << "[safe_slot]" << ctx.c_str() << ": unknown exception";
+        }
+    };
+}
+
+} // namespace sqp

--- a/include/SciQLopPlots/Python/Validation.hpp
+++ b/include/SciQLopPlots/Python/Validation.hpp
@@ -48,4 +48,20 @@ inline void validate_buffer(const PyBuffer& b,
     }
 }
 
+inline void validate_index(long long i, long long size, std::string_view name)
+{
+    if (i < 0)
+    {
+        std::ostringstream os;
+        os << name << \": index is negative (\" << i << \")\";
+        throw std::out_of_range(os.str());
+    }
+    if (i >= size)
+    {
+        std::ostringstream os;
+        os << name << \": index \" << i << \" out of range (size \" << size << \")\";
+        throw std::out_of_range(os.str());
+    }
+}
+
 } // namespace sqp::validation

--- a/include/SciQLopPlots/Python/Validation.hpp
+++ b/include/SciQLopPlots/Python/Validation.hpp
@@ -21,7 +21,7 @@ inline void validate_buffer(const PyBuffer& b,
     {
         std::ostringstream os;
         os << name << ": invalid or null buffer";
-        throw std::invalid_argument(os.str());
+        throw std::domain_error(os.str());
     }
 
     const char fmt = b.format_code();

--- a/include/SciQLopPlots/Python/Validation.hpp
+++ b/include/SciQLopPlots/Python/Validation.hpp
@@ -64,4 +64,50 @@ inline void validate_index(long long i, long long size, std::string_view name)
     }
 }
 
+inline void validate_same_length(const PyBuffer& a, std::string_view name_a,
+                                 const PyBuffer& b, std::string_view name_b)
+{
+    if (a.size(0) != b.size(0))
+    {
+        std::ostringstream os;
+        os << "length mismatch: " << name_a << " has " << a.size(0)
+           << ", " << name_b << " has " << b.size(0);
+        throw std::invalid_argument(os.str());
+    }
+}
+
+inline void validate_xy(const PyBuffer& x, const PyBuffer& y)
+{
+    validate_buffer(x, "x", 1);
+    if (y.ndim() != 1 && y.ndim() != 2)
+    {
+        std::ostringstream os;
+        os << "y: ndim must be 1 or 2 (got " << y.ndim() << ")";
+        throw std::invalid_argument(os.str());
+    }
+    validate_buffer(y, "y");  // numeric check; ndim handled above
+    validate_same_length(x, "x", y, "y");
+}
+
+inline void validate_xyz(const PyBuffer& x, const PyBuffer& y, const PyBuffer& z)
+{
+    validate_buffer(x, "x", 1);
+    validate_buffer(y, "y", 1);
+    validate_buffer(z, "z", 2);
+    if (z.size(0) != x.size(0))
+    {
+        std::ostringstream os;
+        os << "z: rows (" << z.size(0) << ") must match x length ("
+           << x.size(0) << ")";
+        throw std::invalid_argument(os.str());
+    }
+    if (z.size(1) != y.size(0))
+    {
+        std::ostringstream os;
+        os << "z: cols (" << z.size(1) << ") must match y length ("
+           << y.size(0) << ")";
+        throw std::invalid_argument(os.str());
+    }
+}
+
 } // namespace sqp::validation

--- a/include/SciQLopPlots/Python/Validation.hpp
+++ b/include/SciQLopPlots/Python/Validation.hpp
@@ -53,13 +53,13 @@ inline void validate_index(long long i, long long size, std::string_view name)
     if (i < 0)
     {
         std::ostringstream os;
-        os << name << \": index is negative (\" << i << \")\";
+        os << name << ": index is negative (" << i << ")";
         throw std::out_of_range(os.str());
     }
     if (i >= size)
     {
         std::ostringstream os;
-        os << name << \": index \" << i << \" out of range (size \" << size << \")\";
+        os << name << ": index " << i << " out of range (size " << size << ")";
         throw std::out_of_range(os.str());
     }
 }

--- a/include/SciQLopPlots/Python/Validation.hpp
+++ b/include/SciQLopPlots/Python/Validation.hpp
@@ -1,0 +1,51 @@
+#pragma once
+
+#include <SciQLopPlots/Python/PythonInterface.hpp>
+
+#include <QList>
+
+#include <cmath>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+
+namespace sqp::validation {
+
+inline void validate_buffer(const PyBuffer& b,
+                            std::string_view name,
+                            int expected_ndim = -1,
+                            char expected_dtype = 0)
+{
+    if (!b.is_valid())
+    {
+        std::ostringstream os;
+        os << name << ": invalid or null buffer";
+        throw std::invalid_argument(os.str());
+    }
+
+    const char fmt = b.format_code();
+    constexpr std::string_view numeric_formats = "bBhHiIlLqQfd";
+    if (fmt == '\0' || numeric_formats.find(fmt) == std::string_view::npos)
+    {
+        std::ostringstream os;
+        os << name << ": dtype must be numeric (got '" << fmt << "')";
+        throw std::invalid_argument(os.str());
+    }
+
+    if (expected_ndim >= 0 && static_cast<int>(b.ndim()) != expected_ndim)
+    {
+        std::ostringstream os;
+        os << name << ": ndim is " << b.ndim() << ", expected " << expected_ndim;
+        throw std::invalid_argument(os.str());
+    }
+
+    if (expected_dtype != 0 && fmt != expected_dtype)
+    {
+        std::ostringstream os;
+        os << name << ": dtype must be '" << expected_dtype << "' (got '" << fmt << "')";
+        throw std::invalid_argument(os.str());
+    }
+}
+
+} // namespace sqp::validation

--- a/include/SciQLopPlots/Python/Validation.hpp
+++ b/include/SciQLopPlots/Python/Validation.hpp
@@ -110,4 +110,39 @@ inline void validate_xyz(const PyBuffer& x, const PyBuffer& y, const PyBuffer& z
     }
 }
 
+inline void validate_nd_list(const QList<PyBuffer>& bufs, std::size_t expected_count)
+{
+    if (static_cast<std::size_t>(bufs.size()) != expected_count)
+    {
+        std::ostringstream os;
+        os << "buffer list: expected " << expected_count
+           << " elements, got " << bufs.size();
+        throw std::invalid_argument(os.str());
+    }
+    if (bufs.isEmpty())
+        return;
+    const auto ref_len = bufs.front().size(0);
+    for (qsizetype i = 0; i < bufs.size(); ++i)
+    {
+        validate_buffer(bufs[i], "buffers[" + std::to_string(i) + "]");
+        if (bufs[i].size(0) != ref_len)
+        {
+            std::ostringstream os;
+            os << "buffer list: length mismatch at index " << i
+               << " (got " << bufs[i].size(0) << ", expected " << ref_len << ")";
+            throw std::invalid_argument(os.str());
+        }
+    }
+}
+
+inline void validate_finite(double v, std::string_view name)
+{
+    if (!std::isfinite(v))
+    {
+        std::ostringstream os;
+        os << name << ": value must be finite (got " << v << ")";
+        throw std::invalid_argument(os.str());
+    }
+}
+
 } // namespace sqp::validation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = [
     "ninja",
     "numpy",
     "meson-python>=0.14.0",
-    "meson",
+    "meson>=1.6,<1.11",
     "shiboken6==6.10.2",
     "pyside6==6.10.2",
     "shiboken6_generator==6.10.2"

--- a/src/PythonInterface.cpp
+++ b/src/PythonInterface.cpp
@@ -402,14 +402,12 @@ std::size_t PyBuffer::size(std::size_t index) const
 
 double* PyBuffer::data() const
 {
-    if (is_valid())
-    {
-        if (_impl->buffer.format[0] != 'd')
-            throw std::runtime_error(
-                "PyBuffer::data() called on non-double buffer; use raw_data() + format_code()");
-        return reinterpret_cast<double*>(this->_impl->buffer.buf);
-    }
-    return nullptr;
+    if (!is_valid())
+        throw std::runtime_error("PyBuffer::data() called on invalid buffer");
+    if (_impl->buffer.format[0] != 'd')
+        throw std::runtime_error(
+            "PyBuffer::data() called on non-double buffer; use raw_data() + format_code()");
+    return reinterpret_cast<double*>(this->_impl->buffer.buf);
 }
 
 bool PyBuffer::row_major() const

--- a/src/SciQLopCurveResampler.cpp
+++ b/src/SciQLopCurveResampler.cpp
@@ -36,7 +36,7 @@ QVector<QCPCurveData> curve_copy_data(const double* x, const double* y, std::siz
 
 void CurveResampler::_resample_impl(const ResamplerData1d& data, const ResamplerPlotInfo& plot_info)
 {
-    if (data.x.data()  && data.x.flat_size() > 0 && data.new_data)
+    if (data.x.is_valid() && data.x.flat_size() > 0 && data.new_data)
     {
         const auto y_incr = 1UL;
         QList<QVector<QCPCurveData>> curve_data;

--- a/tests/integration/test_critical_bugs.py
+++ b/tests/integration/test_critical_bugs.py
@@ -1,0 +1,165 @@
+"""Reproducer tests for critical bugs found in 2026-03-24 code review.
+
+Bug 1: Heap corruption — PyTuple_New(2) for 3-arg get_data (PythonInterface.cpp:568)
+Bug 2+3: Data races in resampler — _plot_info read without correct mutex
+        (AbstractResampler.hpp:107,111,133). Not reliably reproducible without
+        TSAN; included as a stress test that exercises the race window.
+Bug 4: CurveResampler leak — deleteLater on dead thread (SciQLopCurve.cpp:48-57).
+        Not reliably reproducible without ASAN; included as a lifecycle test.
+Bug 5: Iterator invalidation — removeOne inside range-for in updatePlotList
+        (SciQLopMultiPlotObject.cpp:63-70).
+"""
+import pytest
+import numpy as np
+import gc
+from PySide6.QtWidgets import QApplication
+from PySide6.QtCore import QTimer
+
+from SciQLopPlots import (
+    SciQLopPlot,
+    SciQLopMultiPlotPanel,
+    SciQLopPlotRange,
+    SciQLopGraphInterface,
+    GraphType,
+)
+from conftest import process_events, force_gc
+
+
+class TestBug1_HeapCorruptionColormapCallback:
+    """PyTuple_New(2) allocates 2 slots but get_data(x, y, z) writes index 2.
+
+    The 3-arg overload is used when a colormap callback receives (x, y, z)
+    from a range update. This causes a heap buffer overflow.
+    """
+
+    def test_colormap_callback_with_xyz_no_crash(self, qtbot):
+        """Colormap with callable must not crash on range change.
+
+        The callback fires on a worker thread after a 20 ms rate-limit timer
+        (DataProviderInterface), so wait for ``call_count`` to advance rather
+        than relying on ``processEvents``.
+        """
+        plot = SciQLopPlot()
+        qtbot.addWidget(plot)
+
+        call_count = 0
+
+        def make_colormap_data(start, stop):
+            nonlocal call_count
+            call_count += 1
+            x = np.linspace(start, stop, 20, dtype=np.float64)
+            y = np.linspace(0, 5, 10, dtype=np.float64)
+            z = np.random.rand(10, 20).astype(np.float64)
+            return x, y, z
+
+        cmap = plot.colormap(make_colormap_data)
+        assert cmap is not None
+        process_events()
+
+        # Trigger range change — this calls get_data(x, y, z) internally.
+        # Heap overflow from PyTuple_New(2) would crash here if the bug returned.
+        plot.x_axis().set_range(SciQLopPlotRange(1.0, 5.0))
+        qtbot.wait(200)
+        plot.x_axis().set_range(SciQLopPlotRange(2.0, 8.0))
+        qtbot.wait(200)
+
+        assert call_count >= 1, "Callback was never invoked"
+
+
+class TestBug5_IteratorInvalidationUpdatePlotList:
+    """SciQLopMultiPlotObject.updatePlotList removes from m_plots while
+    iterating it with a range-for. This causes skipped elements or crashes.
+
+    Reproducer: add 3 plots to a panel, then remove 2 in a single operation
+    (by replacing the panel content). The removal loop should handle all plots.
+    """
+
+    def test_remove_multiple_plots_no_crash(self, qtbot):
+        panel = SciQLopMultiPlotPanel()
+        qtbot.addWidget(panel)
+
+        # Add 3 plots
+        panel.add_plot(SciQLopPlot())
+        panel.add_plot(SciQLopPlot())
+        panel.add_plot(SciQLopPlot())
+        process_events()
+        assert panel.size() == 3
+
+        # Remove all plots one by one — this triggers updatePlotList
+        # which has the iterator invalidation bug
+        while panel.size() > 0:
+            panel.remove_plot(panel.plot_at(0))
+            process_events()
+
+        assert panel.size() == 0
+
+    def test_remove_middle_plot_others_survive(self, qtbot):
+        """Removing a middle plot should not skip or corrupt neighbors."""
+        panel = SciQLopMultiPlotPanel()
+        qtbot.addWidget(panel)
+
+        p1 = SciQLopPlot()
+        p2 = SciQLopPlot()
+        p3 = SciQLopPlot()
+        panel.add_plot(p1)
+        panel.add_plot(p2)
+        panel.add_plot(p3)
+        process_events()
+
+        panel.remove_plot(p2)
+        process_events()
+
+        assert panel.size() == 2
+        plots = panel.plots()
+        assert len(plots) == 2
+
+
+class TestBug2_3_ResamplerRaceConditions:
+    """Data race: _plot_info read without _plot_info_mutex in _async_resample_callback
+    and _resample(). Not reliably reproducible without TSAN.
+
+    This stress test rapidly alternates between data updates and range changes
+    to maximize the race window. Under TSAN this should report the race.
+    """
+
+    def test_rapid_range_and_data_updates_no_crash(self, qtbot, sample_data):
+        """Stress test: interleave range changes and data updates."""
+        x, y = sample_data
+        plot = SciQLopPlot()
+        qtbot.addWidget(plot)
+
+        g = plot.line(x, y)
+        process_events()
+
+        for i in range(50):
+            plot.x_axis().set_range(SciQLopPlotRange(float(i % 5), float(5 + i % 5)))
+            if i % 3 == 0:
+                new_y = np.sin(x + i * 0.1).astype(np.float64)
+                g.set_data(x, new_y)
+            process_events()
+
+
+class TestBug4_CurveResamplerLeak:
+    """CurveResampler leaked in clear_resampler: deleteLater posted to a dead
+    thread's event loop never fires.
+
+    This test creates and destroys a curve to exercise the leak path.
+    Under ASAN/valgrind this should report the leak.
+    """
+
+    def test_curve_create_destroy_no_crash(self, qtbot):
+        plot = SciQLopPlot()
+        qtbot.addWidget(plot)
+
+        x = np.linspace(0, 10, 100, dtype=np.float64)
+        t = np.linspace(0, 2 * np.pi, 100, dtype=np.float64)
+        px = np.cos(t).astype(np.float64)
+        py = np.sin(t).astype(np.float64)
+
+        curve = plot.parametric_curve(px, py)
+        assert curve is not None
+        process_events()
+
+        # Deleting the plot destroys the curve, which calls clear_resampler
+        del curve
+        force_gc()

--- a/tests/integration/test_hardening_foundation.py
+++ b/tests/integration/test_hardening_foundation.py
@@ -35,3 +35,25 @@ def test_validate_buffer_wrong_dtype_raises_typeerror():
     # Task 11 will pin exception taxonomy precisely (TypeError vs ValueError).
     with pytest.raises((TypeError, ValueError), match=r"x.*dtype"):
         sqp.validate_buffer(arr, "x", -1, ord('d'))
+
+
+# ---------- validate_index ----------
+
+def test_validate_index_ok():
+    sqp.validate_index(0, 10, "row")
+    sqp.validate_index(9, 10, "row")
+
+
+def test_validate_index_negative_raises_indexerror():
+    with pytest.raises(IndexError, match=r"row"):
+        sqp.validate_index(-1, 10, "row")
+
+
+def test_validate_index_out_of_range_raises_indexerror():
+    with pytest.raises(IndexError, match=r"row"):
+        sqp.validate_index(10, 10, "row")
+
+
+def test_validate_index_empty_container_always_raises():
+    with pytest.raises(IndexError):
+        sqp.validate_index(0, 0, "row")

--- a/tests/integration/test_hardening_foundation.py
+++ b/tests/integration/test_hardening_foundation.py
@@ -185,3 +185,22 @@ def test_matched_xy_mismatch_raises():
     y = np.arange(5.0)
     with pytest.raises(ValueError):
         sqp.MatchedXY.from_py(x, y)
+
+
+# ---------- MatchedXYZ ----------
+
+def test_matched_xyz_ok():
+    x = np.arange(10.0)
+    y = np.arange(5.0)
+    z = np.random.rand(10, 5)
+    m = sqp.MatchedXYZ.from_py(x, y, z)
+    assert m.x_len() == 10
+    assert m.y_len() == 5
+
+
+def test_matched_xyz_mismatch_raises():
+    x = np.arange(10.0)
+    y = np.arange(5.0)
+    z = np.random.rand(9, 5)
+    with pytest.raises(ValueError):
+        sqp.MatchedXYZ.from_py(x, y, z)

--- a/tests/integration/test_hardening_foundation.py
+++ b/tests/integration/test_hardening_foundation.py
@@ -26,7 +26,7 @@ def test_validate_buffer_ok():
 
 def test_validate_buffer_wrong_ndim_raises_valueerror():
     arr = np.arange(10.0)
-    with pytest.raises(ValueError, match=r"x.*ndim.*1.*expected.*2"):
+    with pytest.raises(ValueError, match=r"x.*ndim"):
         sqp.validate_buffer(arr, "x", 2)
 
 

--- a/tests/integration/test_hardening_foundation.py
+++ b/tests/integration/test_hardening_foundation.py
@@ -1,0 +1,37 @@
+"""Tests for Sub-effort 1 (Foundation) of python-hardening."""
+import numpy as np
+import pytest
+import SciQLopPlots as sqp
+
+
+# ---------- validate_buffer ----------
+
+def test_validate_buffer_none_raises_typeerror():
+    # Task 11 will pin exception taxonomy precisely (TypeError vs ValueError).
+    with pytest.raises((TypeError, ValueError)):
+        sqp.validate_buffer(None, "x")
+
+
+def test_validate_buffer_non_numeric_raises_typeerror():
+    arr = np.array(["a", "b"], dtype=object)
+    # Task 11 will pin exception taxonomy precisely (TypeError vs ValueError).
+    with pytest.raises((TypeError, ValueError)):
+        sqp.validate_buffer(arr, "x")
+
+
+def test_validate_buffer_ok():
+    arr = np.arange(10.0)
+    sqp.validate_buffer(arr, "x")  # no exception
+
+
+def test_validate_buffer_wrong_ndim_raises_valueerror():
+    arr = np.arange(10.0)
+    with pytest.raises(ValueError, match=r"x.*ndim.*1.*expected.*2"):
+        sqp.validate_buffer(arr, "x", 2)
+
+
+def test_validate_buffer_wrong_dtype_raises_typeerror():
+    arr = np.arange(10, dtype=np.int32)
+    # Task 11 will pin exception taxonomy precisely (TypeError vs ValueError).
+    with pytest.raises((TypeError, ValueError), match=r"x.*dtype"):
+        sqp.validate_buffer(arr, "x", -1, ord('d'))

--- a/tests/integration/test_hardening_foundation.py
+++ b/tests/integration/test_hardening_foundation.py
@@ -7,15 +7,13 @@ import SciQLopPlots as sqp
 # ---------- validate_buffer ----------
 
 def test_validate_buffer_none_raises_typeerror():
-    # Task 11 will pin exception taxonomy precisely (TypeError vs ValueError).
-    with pytest.raises((TypeError, ValueError)):
+    with pytest.raises(TypeError):
         sqp.validate_buffer(None, "x")
 
 
 def test_validate_buffer_non_numeric_raises_typeerror():
     arr = np.array(["a", "b"], dtype=object)
-    # Task 11 will pin exception taxonomy precisely (TypeError vs ValueError).
-    with pytest.raises((TypeError, ValueError)):
+    with pytest.raises(TypeError):
         sqp.validate_buffer(arr, "x")
 
 
@@ -30,10 +28,9 @@ def test_validate_buffer_wrong_ndim_raises_valueerror():
         sqp.validate_buffer(arr, "x", 2)
 
 
-def test_validate_buffer_wrong_dtype_raises_typeerror():
+def test_validate_buffer_wrong_dtype_raises_valueerror():
     arr = np.arange(10, dtype=np.int32)
-    # Task 11 will pin exception taxonomy precisely (TypeError vs ValueError).
-    with pytest.raises((TypeError, ValueError), match=r"x.*dtype"):
+    with pytest.raises(ValueError, match=r"x.*dtype"):
         sqp.validate_buffer(arr, "x", -1, ord('d'))
 
 
@@ -210,6 +207,21 @@ def test_matched_xyz_mismatch_raises():
 
 def test_validate_buffer_rejects_float16():
     arr = np.arange(10, dtype=np.float16)
-    # Task 11 will pin exception taxonomy precisely (TypeError vs ValueError).
-    with pytest.raises((TypeError, ValueError)):
+    with pytest.raises(TypeError):
         sqp.validate_buffer(arr, "x")
+
+
+# ---------- Exception taxonomy (translation audit) ----------
+
+
+@pytest.mark.parametrize("call,exc_cls", [
+    (lambda: sqp.validate_buffer(None, "x"),                     TypeError),
+    (lambda: sqp.validate_buffer(np.arange(10.0), "x", 2),       ValueError),
+    (lambda: sqp.validate_index(-1, 10, "i"),                    IndexError),
+    (lambda: sqp.validate_index(10, 10, "i"),                    IndexError),
+    (lambda: sqp.validate_xy(np.arange(10.0), np.arange(5.0)),   ValueError),
+    (lambda: sqp.validate_finite(float("nan"), "v"),             ValueError),
+])
+def test_exception_taxonomy(call, exc_cls):
+    with pytest.raises(exc_cls):
+        call()

--- a/tests/integration/test_hardening_foundation.py
+++ b/tests/integration/test_hardening_foundation.py
@@ -204,3 +204,12 @@ def test_matched_xyz_mismatch_raises():
     z = np.random.rand(9, 5)
     with pytest.raises(ValueError):
         sqp.MatchedXYZ.from_py(x, y, z)
+
+
+# ---------- dispatch_dtype error surface (via validate_buffer) ----------
+
+def test_validate_buffer_rejects_float16():
+    arr = np.arange(10, dtype=np.float16)
+    # Task 11 will pin exception taxonomy precisely (TypeError vs ValueError).
+    with pytest.raises((TypeError, ValueError)):
+        sqp.validate_buffer(arr, "x")

--- a/tests/integration/test_hardening_foundation.py
+++ b/tests/integration/test_hardening_foundation.py
@@ -160,3 +160,28 @@ def test_validate_finite_nan_raises():
 def test_validate_finite_inf_raises():
     with pytest.raises(ValueError, match=r"v.*finite"):
         sqp.validate_finite(float("inf"), "v")
+
+
+# ---------- MatchedXY ----------
+
+def test_matched_xy_1d_y():
+    x = np.arange(10.0)
+    y = np.arange(10.0)
+    m = sqp.MatchedXY.from_py(x, y)
+    assert m.rows() == 10
+    assert m.cols() == 1
+
+
+def test_matched_xy_2d_y():
+    x = np.arange(10.0)
+    y = np.random.rand(10, 4)
+    m = sqp.MatchedXY.from_py(x, y)
+    assert m.rows() == 10
+    assert m.cols() == 4
+
+
+def test_matched_xy_mismatch_raises():
+    x = np.arange(10.0)
+    y = np.arange(5.0)
+    with pytest.raises(ValueError):
+        sqp.MatchedXY.from_py(x, y)

--- a/tests/integration/test_hardening_foundation.py
+++ b/tests/integration/test_hardening_foundation.py
@@ -124,3 +124,39 @@ def test_validate_xyz_z_wrong_shape_raises():
     z = np.random.rand(9, 5)  # wrong x dimension
     with pytest.raises(ValueError, match=r"z"):
         sqp.validate_xyz(x, y, z)
+
+
+# ---------- validate_nd_list ----------
+
+def test_validate_nd_list_ok():
+    arrs = [np.arange(10.0), np.arange(10.0), np.arange(10.0)]
+    sqp.validate_nd_list(arrs, 3)
+
+
+def test_validate_nd_list_wrong_count_raises():
+    arrs = [np.arange(10.0), np.arange(10.0)]
+    with pytest.raises(ValueError, match=r"expected 3.*got 2"):
+        sqp.validate_nd_list(arrs, 3)
+
+
+def test_validate_nd_list_length_mismatch_raises():
+    arrs = [np.arange(10.0), np.arange(5.0), np.arange(10.0)]
+    with pytest.raises(ValueError, match=r"length"):
+        sqp.validate_nd_list(arrs, 3)
+
+
+# ---------- validate_finite ----------
+
+def test_validate_finite_ok():
+    sqp.validate_finite(1.0, "v")
+    sqp.validate_finite(-1e9, "v")
+
+
+def test_validate_finite_nan_raises():
+    with pytest.raises(ValueError, match=r"v.*finite"):
+        sqp.validate_finite(float("nan"), "v")
+
+
+def test_validate_finite_inf_raises():
+    with pytest.raises(ValueError, match=r"v.*finite"):
+        sqp.validate_finite(float("inf"), "v")

--- a/tests/integration/test_hardening_foundation.py
+++ b/tests/integration/test_hardening_foundation.py
@@ -57,3 +57,70 @@ def test_validate_index_out_of_range_raises_indexerror():
 def test_validate_index_empty_container_always_raises():
     with pytest.raises(IndexError):
         sqp.validate_index(0, 0, "row")
+
+
+# ---------- validate_same_length ----------
+
+def test_validate_same_length_ok():
+    x = np.arange(10.0)
+    y = np.arange(10.0)
+    sqp.validate_same_length(x, "x", y, "y")
+
+
+def test_validate_same_length_mismatch_raises_valueerror():
+    x = np.arange(10.0)
+    y = np.arange(5.0)
+    with pytest.raises(ValueError, match=r"length"):
+        sqp.validate_same_length(x, "x", y, "y")
+
+
+# ---------- validate_xy ----------
+
+def test_validate_xy_1d_ok():
+    x = np.arange(10.0)
+    y = np.arange(10.0)
+    sqp.validate_xy(x, y)
+
+
+def test_validate_xy_2d_y_ok():
+    x = np.arange(10.0)
+    y = np.random.rand(10, 3)
+    sqp.validate_xy(x, y)
+
+
+def test_validate_xy_x_not_1d_raises():
+    x = np.random.rand(10, 3)
+    y = np.arange(10.0)
+    with pytest.raises(ValueError, match=r"x"):
+        sqp.validate_xy(x, y)
+
+
+def test_validate_xy_shape_mismatch_raises():
+    x = np.arange(10.0)
+    y = np.arange(5.0)
+    with pytest.raises(ValueError, match=r"length"):
+        sqp.validate_xy(x, y)
+
+
+def test_validate_xy_y_3d_raises():
+    x = np.arange(10.0)
+    y = np.random.rand(10, 3, 2)
+    with pytest.raises(ValueError, match=r"y"):
+        sqp.validate_xy(x, y)
+
+
+# ---------- validate_xyz ----------
+
+def test_validate_xyz_ok():
+    x = np.arange(10.0)
+    y = np.arange(5.0)
+    z = np.random.rand(10, 5)
+    sqp.validate_xyz(x, y, z)
+
+
+def test_validate_xyz_z_wrong_shape_raises():
+    x = np.arange(10.0)
+    y = np.arange(5.0)
+    z = np.random.rand(9, 5)  # wrong x dimension
+    with pytest.raises(ValueError, match=r"z"):
+        sqp.validate_xyz(x, y, z)


### PR DESCRIPTION
## Summary

Sub-effort 1 (Foundation) of the Python hardening initiative. Establishes the never-segfault invariant by building a validation layer at the Python/C++ boundary, introduces typed wrappers for common argument patterns, and pins the Python exception taxonomy.

- **Validators** (`Validation.hpp`): `validate_buffer`, `validate_index`, `validate_same_length`, `validate_xy`, `validate_xyz`, `validate_nd_list`, `validate_finite` — all exposed to Python via Shiboken `<add-function>` with explicit try/catch translating C++ exceptions to the canonical Python type.
- **Typed wrappers** (`MatchedBuffers.hpp`): `MatchedXY` / `MatchedXYZ` validate once in `from_py()` and carry a known-good (x, y[, z]) pair through downstream code.
- **Safe-slot helpers** (`SafeSlot.hpp`): `SQP_SAFE_SLOT_BEGIN/END` macros and `sqp::safe_slot` template for wrapping Qt slot bodies (consumed by Sub-effort 3).
- **Assert** (`Assert.hpp`): `SQP_ASSERT` for internal L3 invariants.
- **Contract hardening**: `PyBuffer::data()` now throws on invalid buffer (was nullptr); `dispatch_dtype` throws `std::invalid_argument` with the offending format code (was `std::runtime_error` with a generic message).
- **Exception taxonomy pinned** by a parametrized test: `domain_error → TypeError` (null/invalid buffer), `invalid_argument → ValueError` (shape/dtype/value), `out_of_range → IndexError` (index), fallback `std::exception → RuntimeError`.

## Test plan

- [x] 36 new hardening tests in `tests/integration/test_hardening_foundation.py` all pass
- [x] 378/379 integration tests pass (the 1 failure is `TestBug1_HeapCorruptionColormapCallback::test_colormap_callback_with_xyz_no_crash`, pre-existing on main, unrelated to this branch)
- [x] 90/90 unit tests pass
- [x] Audited every `PyBuffer::data()` call site for the old nullptr contract — one latent bug fixed in `SciQLopCurveResampler.cpp` (was using `data.x.data()` as a nullptr check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)