### PR TITLE
feat: Histogram2D as a first-class graph type

### DIFF
--- a/SciQLopPlots/__init__.py
+++ b/SciQLopPlots/__init__.py
@@ -54,14 +54,30 @@ def _reject_waterfall_kwargs(kwargs, graph_type):
             f"got graph_type={graph_type!r}")
 
 
+_HISTOGRAM2D_KWARGS = ("key_bins", "value_bins")
+
+
+def _reject_histogram2d_kwargs(kwargs, graph_type):
+    stray = [k for k in _HISTOGRAM2D_KWARGS if k in kwargs]
+    if stray:
+        raise TypeError(
+            f"{', '.join(stray)} kwarg(s) only apply to GraphType.Histogram2D, "
+            f"got graph_type={graph_type!r}")
+
+
 def _patch_sciqlop_plot(cls):
     def plot_func(self, callback, graph_type=None, **kwargs):
         kwargs = {k: v for k, v in kwargs.items() if v is not None}
         if graph_type == GraphType.Waterfall:
+            _reject_histogram2d_kwargs(kwargs, graph_type)
             wf_kwargs = _pop_waterfall_kwargs(kwargs)
             wf = cls.waterfall(self, callback, **kwargs)
             return _apply_waterfall_kwargs(wf, **wf_kwargs)
+        if graph_type == GraphType.Histogram2D:
+            _reject_waterfall_kwargs(kwargs, graph_type)
+            return cls.histogram2d(self, callback, **kwargs)
         _reject_waterfall_kwargs(kwargs, graph_type)
+        _reject_histogram2d_kwargs(kwargs, graph_type)
         if graph_type == GraphType.ParametricCurve:
             return cls.parametric_curve(self, callback, **kwargs)
         elif graph_type == GraphType.Line:
@@ -77,15 +93,21 @@ def _patch_sciqlop_plot(cls):
         kwargs = _merge_kwargs(kwargs, name=name, labels=labels, colors=colors)
         if (graph_type == GraphType.ParametricCurve) and (len(args) in (1, 2, 4)) and not callable(args[0]):
             _reject_waterfall_kwargs(kwargs, graph_type)
+            _reject_histogram2d_kwargs(kwargs, graph_type)
             return cls.parametric_curve(self, *args, **kwargs)
         if len(args) == 1:
             return plot_func(self, *args, graph_type=graph_type, **kwargs)
         if len(args) == 2:
             if graph_type == GraphType.Waterfall:
+                _reject_histogram2d_kwargs(kwargs, graph_type)
                 wf_kwargs = _pop_waterfall_kwargs(kwargs)
                 wf = cls.waterfall(self, *args, **kwargs)
                 return _apply_waterfall_kwargs(wf, **wf_kwargs)
+            if graph_type == GraphType.Histogram2D:
+                _reject_waterfall_kwargs(kwargs, graph_type)
+                return cls.histogram2d(self, *args, **kwargs)
             _reject_waterfall_kwargs(kwargs, graph_type)
+            _reject_histogram2d_kwargs(kwargs, graph_type)
             if graph_type == GraphType.Line:
                 return cls.line(self, *args, **kwargs)
             if graph_type == GraphType.Scatter:
@@ -95,6 +117,7 @@ def _patch_sciqlop_plot(cls):
             raise ValueError(f"unsupported graph_type {graph_type!r} for 2-arg plot()")
         if len(args) == 3:
             _reject_waterfall_kwargs(kwargs, graph_type)
+            _reject_histogram2d_kwargs(kwargs, graph_type)
             return cls.colormap(self, *args, **kwargs)
         raise ValueError(f"only 1, 2 or 3 arguments are supported, got {len(args)}")
 

--- a/SciQLopPlots/bindings/bindings.xml
+++ b/SciQLopPlots/bindings/bindings.xml
@@ -319,6 +319,37 @@
                 <rename to="metaData"/>
             </modify-argument>
         </modify-function>
+        <modify-function signature="histogram2d(const PyBuffer&amp;,const PyBuffer&amp;,QString,int,int,QVariantMap)">
+            <modify-argument index="3">
+                <rename to="name"/>
+            </modify-argument>
+            <modify-argument index="4">
+                <rename to="key_bins"/>
+            </modify-argument>
+            <modify-argument index="5">
+                <rename to="value_bins"/>
+            </modify-argument>
+            <modify-argument index="6">
+                <rename to="metaData"/>
+            </modify-argument>
+        </modify-function>
+        <modify-function signature="histogram2d(GetDataPyCallable,QString,int,int,QObject*,QVariantMap)">
+            <modify-argument index="2">
+                <rename to="name"/>
+            </modify-argument>
+            <modify-argument index="3">
+                <rename to="key_bins"/>
+            </modify-argument>
+            <modify-argument index="4">
+                <rename to="value_bins"/>
+            </modify-argument>
+            <modify-argument index="5">
+                <rename to="sync_with"/>
+            </modify-argument>
+            <modify-argument index="6">
+                <rename to="metaData"/>
+            </modify-argument>
+        </modify-function>
         <property name="name" type="QString" get="objectName" set="setObjectName" generate-getsetdef="yes"/>
         <modify-function signature="save(const QString&amp;,int,int,double,int)">
             <modify-argument index="2"><rename to="width"/></modify-argument>
@@ -405,6 +436,9 @@
         <property name="name" type="QString" get="objectName" set="setObjectName" generate-getsetdef="yes"/>
     </object-type>
     <object-type name="SciQLopColorMapFunction" parent-management="yes">
+        <property name="name" type="QString" get="objectName" set="setObjectName" generate-getsetdef="yes"/>
+    </object-type>
+    <object-type name="SciQLopHistogram2DFunction" parent-management="yes">
         <property name="name" type="QString" get="objectName" set="setObjectName" generate-getsetdef="yes"/>
     </object-type>
     <object-type name="SciQLopWaterfallGraphFunction" parent-management="yes">
@@ -616,6 +650,49 @@
                 <rename to="index"/>
             </modify-argument>
             <modify-argument index="6">
+                <rename to="metaData"/>
+            </modify-argument>
+        </modify-function>
+        <modify-function signature="histogram2d(const PyBuffer&amp;,const PyBuffer&amp;,QString,int,int,PlotType,int,QVariantMap)">
+            <modify-argument index="3">
+                <rename to="name"/>
+            </modify-argument>
+            <modify-argument index="4">
+                <rename to="key_bins"/>
+            </modify-argument>
+            <modify-argument index="5">
+                <rename to="value_bins"/>
+            </modify-argument>
+            <modify-argument index="6">
+                <rename to="plot_type"/>
+            </modify-argument>
+            <modify-argument index="7">
+                <rename to="index"/>
+            </modify-argument>
+            <modify-argument index="8">
+                <rename to="metaData"/>
+            </modify-argument>
+        </modify-function>
+        <modify-function signature="histogram2d(GetDataPyCallable,QString,int,int,PlotType,QObject*,int,QVariantMap)">
+            <modify-argument index="2">
+                <rename to="name"/>
+            </modify-argument>
+            <modify-argument index="3">
+                <rename to="key_bins"/>
+            </modify-argument>
+            <modify-argument index="4">
+                <rename to="value_bins"/>
+            </modify-argument>
+            <modify-argument index="5">
+                <rename to="plot_type"/>
+            </modify-argument>
+            <modify-argument index="6">
+                <rename to="sync_with"/>
+            </modify-argument>
+            <modify-argument index="7">
+                <rename to="index"/>
+            </modify-argument>
+            <modify-argument index="8">
                 <rename to="metaData"/>
             </modify-argument>
         </modify-function>

--- a/include/SciQLopPlots/MultiPlots/SciQLopMultiPlotPanel.hpp
+++ b/include/SciQLopPlots/MultiPlots/SciQLopMultiPlotPanel.hpp
@@ -97,6 +97,17 @@ protected:
         return nullptr;
     }
 
+    template <typename T, typename... Args>
+    QPair<T*, SciQLopColorMapInterface*> _plot_histogram2d(int index, Args&&... args)
+    {
+        auto* plot = new T();
+        if (index == -1)
+            add_plot(plot);
+        else
+            insert_plot(index, plot);
+        return { plot, plot->histogram2d(std::forward<Args>(args)...) };
+    }
+
     template <typename T, typename U, typename... Args>
     QPair<T*, U*> _plot(int index, GraphType graph_type, Args&&... args)
     {
@@ -159,6 +170,16 @@ protected:
               bool y_log_scale = false, bool z_log_scale = false,
               ::PlotType plot_type = ::PlotType::BasicXY, QObject* sync_with = nullptr,
               int index = -1, QVariantMap metaData={}) Q_DECL_OVERRIDE;
+
+    virtual QPair<SciQLopPlotInterface*, SciQLopColorMapInterface*>
+    plot_impl(const PyBuffer& x, const PyBuffer& y, QString name, int key_bins, int value_bins,
+              ::PlotType plot_type = ::PlotType::BasicXY, int index = -1,
+              QVariantMap metaData = {}) Q_DECL_OVERRIDE;
+
+    virtual QPair<SciQLopPlotInterface*, SciQLopColorMapInterface*>
+    plot_impl(GetDataPyCallable callable, QString name, int key_bins, int value_bins,
+              ::PlotType plot_type = ::PlotType::BasicXY, QObject* sync_with = nullptr,
+              int index = -1, QVariantMap metaData = {}) Q_DECL_OVERRIDE;
 
 public:
     Q_PROPERTY(bool selected READ selected WRITE setSelected NOTIFY selectionChanged FINAL);

--- a/include/SciQLopPlots/MultiPlots/SciQLopPlotCollection.hpp
+++ b/include/SciQLopPlots/MultiPlots/SciQLopPlotCollection.hpp
@@ -132,6 +132,22 @@ protected:
         throw std::runtime_error("Not implemented");
     }
 
+    inline virtual QPair<SciQLopPlotInterface*, SciQLopColorMapInterface*>
+    plot_impl(const PyBuffer& x, const PyBuffer& y, QString name, int key_bins, int value_bins,
+              ::PlotType plot_type = ::PlotType::BasicXY, int index = -1,
+              QVariantMap metaData = {})
+    {
+        throw std::runtime_error("Not implemented");
+    }
+
+    inline virtual QPair<SciQLopPlotInterface*, SciQLopColorMapInterface*>
+    plot_impl(GetDataPyCallable callable, QString name, int key_bins, int value_bins,
+              ::PlotType plot_type = ::PlotType::BasicXY, QObject* sync_with = nullptr,
+              int index = -1, QVariantMap metaData = {})
+    {
+        throw std::runtime_error("Not implemented");
+    }
+
 public:
     virtual ~SciQLopPlotCollectionInterface() = default;
 
@@ -338,6 +354,25 @@ public:
     {
         return plot_impl(callable, labels, colors, ::GraphType::ParametricCurve,
                          ::GraphMarkerShape::NoMarker, ::PlotType::Projections, sync_with, index,metaData);
+    }
+
+    inline virtual QPair<SciQLopPlotInterface*, SciQLopColorMapInterface*>
+    histogram2d(const PyBuffer& x, const PyBuffer& y,
+                QString name = QStringLiteral("Histogram2D"), int key_bins = 100,
+                int value_bins = 100, ::PlotType plot_type = ::PlotType::BasicXY,
+                int index = -1, QVariantMap metaData = {})
+    {
+        return plot_impl(x, y, name, key_bins, value_bins, plot_type, index, metaData);
+    }
+
+    inline virtual QPair<SciQLopPlotInterface*, SciQLopColorMapInterface*>
+    histogram2d(GetDataPyCallable callable, QString name = QStringLiteral("Histogram2D"),
+                int key_bins = 100, int value_bins = 100,
+                ::PlotType plot_type = ::PlotType::BasicXY, QObject* sync_with = nullptr,
+                int index = -1, QVariantMap metaData = {})
+    {
+        return plot_impl(callable, name, key_bins, value_bins, plot_type, sync_with, index,
+                         metaData);
     }
 };
 

--- a/include/SciQLopPlots/Plotables/SciQLopHistogram2D.hpp
+++ b/include/SciQLopPlots/Plotables/SciQLopHistogram2D.hpp
@@ -20,6 +20,7 @@
 -- Mail : alexis.jeandet@member.fsf.org
 ----------------------------------------------------------------------------*/
 #pragma once
+#include "SciQLopPlots/DataProducer/DataProducer.hpp"
 #include "SciQLopPlots/Python/PythonInterface.hpp"
 #include "SciQLopPlots/Python/DtypeDispatch.hpp"
 #include "SciQLopPlots/qcp_enums.hpp"
@@ -70,4 +71,19 @@ public:
 
     void set_normalization(int normalization);
     int normalization() const;
+};
+
+
+class SciQLopHistogram2DFunction : public SciQLopHistogram2D, public SciQLopFunctionGraph
+{
+    Q_OBJECT
+
+public:
+    explicit SciQLopHistogram2DFunction(QCustomPlot* parent, SciQLopPlotAxis* xAxis,
+                                        SciQLopPlotAxis* yAxis,
+                                        SciQLopPlotColorScaleAxis* zAxis,
+                                        GetDataPyCallable&& callable, const QString& name,
+                                        int key_bins = 100, int value_bins = 100);
+
+    virtual ~SciQLopHistogram2DFunction() override = default;
 };

--- a/include/SciQLopPlots/SciQLopPlot.hpp
+++ b/include/SciQLopPlots/SciQLopPlot.hpp
@@ -96,6 +96,9 @@ public:
 
     SciQLopHistogram2D* add_histogram2d(const QString& name, int key_bins = 100,
                                         int value_bins = 100);
+    SciQLopHistogram2DFunction* add_histogram2d(GetDataPyCallable&& callable,
+                                                 const QString& name, int key_bins = 100,
+                                                 int value_bins = 100);
 
     inline void set_scroll_factor(double factor) noexcept { m_scroll_factor = factor; }
 
@@ -277,6 +280,16 @@ protected:
                                                 bool y_log_scale = false, bool z_log_scale = false,
                                                 QObject* sync_with = nullptr,QVariantMap metaData={}) override;
 
+    virtual SciQLopColorMapInterface*
+    plot_impl(const PyBuffer& x, const PyBuffer& y,
+              QString name = QStringLiteral("Histogram2D"), int key_bins = 100,
+              int value_bins = 100, QVariantMap metaData = {}) override;
+
+    virtual SciQLopColorMapInterface*
+    plot_impl(GetDataPyCallable callable, QString name = QStringLiteral("Histogram2D"),
+              int key_bins = 100, int value_bins = 100, QObject* sync_with = nullptr,
+              QVariantMap metaData = {}) override;
+
     virtual void toggle_selected_objects_visibility() noexcept override;
 
 public:
@@ -315,6 +328,9 @@ public:
 
     SciQLopHistogram2D* add_histogram2d(const QString& name, int key_bins = 100,
                                         int value_bins = 100);
+    SciQLopHistogram2DFunction* add_histogram2d(GetDataPyCallable&& callable,
+                                                 const QString& name, int key_bins = 100,
+                                                 int value_bins = 100);
 
     SciQLopWaterfallGraph* add_waterfall(const QString& name,
                                          const QStringList& labels = {},

--- a/include/SciQLopPlots/SciQLopPlotInterface.hpp
+++ b/include/SciQLopPlots/SciQLopPlotInterface.hpp
@@ -89,6 +89,22 @@ protected:
         throw std::runtime_error("Not implemented");
     }
 
+    inline virtual SciQLopColorMapInterface*
+    plot_impl(const PyBuffer& x, const PyBuffer& y,
+              QString name = QStringLiteral("Histogram2D"), int key_bins = 100,
+              int value_bins = 100, QVariantMap metaData = {})
+    {
+        throw std::runtime_error("Not implemented");
+    }
+
+    inline virtual SciQLopColorMapInterface*
+    plot_impl(GetDataPyCallable callable, QString name = QStringLiteral("Histogram2D"),
+              int key_bins = 100, int value_bins = 100, QObject* sync_with = nullptr,
+              QVariantMap metaData = {})
+    {
+        throw std::runtime_error("Not implemented");
+    }
+
 public:
     Q_PROPERTY(bool selected READ selected WRITE set_selected NOTIFY selection_changed FINAL)
 
@@ -361,6 +377,22 @@ public:
     {
         return plot_impl(callable, labels, colors, ::GraphType::Waterfall,
                          ::GraphMarkerShape::NoMarker, sync_with, metaData);
+    }
+
+    inline virtual SciQLopColorMapInterface*
+    histogram2d(const PyBuffer& x, const PyBuffer& y,
+                QString name = QStringLiteral("Histogram2D"), int key_bins = 100,
+                int value_bins = 100, QVariantMap metaData = {})
+    {
+        return plot_impl(x, y, name, key_bins, value_bins, metaData);
+    }
+
+    inline virtual SciQLopColorMapInterface*
+    histogram2d(GetDataPyCallable callable, QString name = QStringLiteral("Histogram2D"),
+                int key_bins = 100, int value_bins = 100, QObject* sync_with = nullptr,
+                QVariantMap metaData = {})
+    {
+        return plot_impl(callable, name, key_bins, value_bins, sync_with, metaData);
     }
 
     inline virtual SciQLopPlottableInterface* plottable(int index = -1)

--- a/include/SciQLopPlots/enums.hpp
+++ b/include/SciQLopPlots/enums.hpp
@@ -81,7 +81,8 @@ enum class GraphType
     ParametricCurve,
     Scatter,
     ColorMap,
-    Waterfall
+    Waterfall,
+    Histogram2D
 };
 Q_DECLARE_METATYPE(GraphType);
 

--- a/src/SciQLopHistogram2D.cpp
+++ b/src/SciQLopHistogram2D.cpp
@@ -135,3 +135,15 @@ int SciQLopHistogram2D::normalization() const
 {
     return _hist ? static_cast<int>(_hist->normalization()) : 0;
 }
+
+SciQLopHistogram2DFunction::SciQLopHistogram2DFunction(QCustomPlot* parent, SciQLopPlotAxis* xAxis,
+                                                       SciQLopPlotAxis* yAxis,
+                                                       SciQLopPlotColorScaleAxis* zAxis,
+                                                       GetDataPyCallable&& callable,
+                                                       const QString& name,
+                                                       int key_bins, int value_bins)
+    : SciQLopHistogram2D{parent, xAxis, yAxis, zAxis, name, key_bins, value_bins}
+    , SciQLopFunctionGraph(std::move(callable), this, 2)
+{
+    this->set_range({parent->xAxis->range().lower, parent->xAxis->range().upper});
+}

--- a/src/SciQLopMultiPlotPanel.cpp
+++ b/src/SciQLopMultiPlotPanel.cpp
@@ -411,6 +411,48 @@ SciQLopMultiPlotPanel::plot_impl(GetDataPyCallable callable, QString name, bool 
     return { nullptr, nullptr };
 }
 
+QPair<SciQLopPlotInterface*, SciQLopColorMapInterface*>
+SciQLopMultiPlotPanel::plot_impl(const PyBuffer& x, const PyBuffer& y, QString name, int key_bins,
+                                 int value_bins, PlotType plot_type, int index,
+                                 QVariantMap metaData)
+{
+    switch (plot_type)
+    {
+        case ::PlotType::BasicXY:
+            return _plot_histogram2d<SciQLopPlot>(
+                index, x, y, name, key_bins, value_bins, metaData);
+            break;
+        case ::PlotType::TimeSeries:
+            return _plot_histogram2d<SciQLopTimeSeriesPlot>(
+                index, x, y, name, key_bins, value_bins, metaData);
+            break;
+        default:
+            break;
+    }
+    return { nullptr, nullptr };
+}
+
+QPair<SciQLopPlotInterface*, SciQLopColorMapInterface*>
+SciQLopMultiPlotPanel::plot_impl(GetDataPyCallable callable, QString name, int key_bins,
+                                 int value_bins, PlotType plot_type, QObject* sync_with,
+                                 int index, QVariantMap metaData)
+{
+    switch (plot_type)
+    {
+        case ::PlotType::BasicXY:
+            return _plot_histogram2d<SciQLopPlot>(
+                index, std::move(callable), name, key_bins, value_bins, sync_with, metaData);
+            break;
+        case ::PlotType::TimeSeries:
+            return _plot_histogram2d<SciQLopTimeSeriesPlot>(
+                index, std::move(callable), name, key_bins, value_bins, sync_with, metaData);
+            break;
+        default:
+            break;
+    }
+    return { nullptr, nullptr };
+}
+
 void SciQLopMultiPlotPanel::keyPressEvent(QKeyEvent* event)
 {
     switch (event->key())

--- a/src/SciQLopPlot.cpp
+++ b/src/SciQLopPlot.cpp
@@ -164,6 +164,19 @@ SciQLopHistogram2D* SciQLopPlot::add_histogram2d(const QString& name, int key_bi
     return hist;
 }
 
+SciQLopHistogram2DFunction* SciQLopPlot::add_histogram2d(GetDataPyCallable&& callable,
+                                                          const QString& name, int key_bins,
+                                                          int value_bins)
+{
+    auto hist = new SciQLopHistogram2DFunction(
+        this, this->m_axes[0], this->m_axes[1],
+        static_cast<SciQLopPlotColorScaleAxis*>(this->m_axes[4]), std::move(callable), name,
+        key_bins, value_bins);
+    _ensure_colorscale_is_visible(hist);
+    _register_plottable_wrapper(hist);
+    return hist;
+}
+
 SciQLopColorMapFunction* SciQLopPlot::add_color_map(GetDataPyCallable&& callable,
                                                     const QString& name, bool y_log_scale,
                                                     bool z_log_scale)
@@ -656,6 +669,19 @@ SciQLopHistogram2D* SciQLopPlot::add_histogram2d(const QString& name, int key_bi
     return hist;
 }
 
+SciQLopHistogram2DFunction* SciQLopPlot::add_histogram2d(GetDataPyCallable&& callable,
+                                                          const QString& name, int key_bins,
+                                                          int value_bins)
+{
+    auto hist = m_impl->add_histogram2d(std::move(callable), name, key_bins, value_bins);
+    if (hist)
+    {
+        _configure_color_map(hist, false, false);
+        _connect_callable_sync(hist, nullptr);
+    }
+    return hist;
+}
+
 SciQLopWaterfallGraph* SciQLopPlot::add_waterfall(const QString& name, const QStringList& labels,
                                                    const QList<QColor>& colors)
 {
@@ -893,6 +919,34 @@ SciQLopColorMapInterface* SciQLopPlot::plot_impl(GetDataPyCallable callable, QSt
         _connect_callable_sync(plotable, sync_with);
     }
     return plotable;
+}
+
+SciQLopColorMapInterface* SciQLopPlot::plot_impl(const PyBuffer& x, const PyBuffer& y,
+                                                  QString name, int key_bins, int value_bins,
+                                                  QVariantMap metaData)
+{
+    auto* hist = m_impl->add_histogram2d(name, key_bins, value_bins);
+    if (hist)
+    {
+        hist->set_meta_data(metaData);
+        _configure_color_map(hist, false, false);
+        hist->set_data(x, y);
+    }
+    return hist;
+}
+
+SciQLopColorMapInterface* SciQLopPlot::plot_impl(GetDataPyCallable callable, QString name,
+                                                  int key_bins, int value_bins,
+                                                  QObject* sync_with, QVariantMap metaData)
+{
+    auto* hist = m_impl->add_histogram2d(std::move(callable), name, key_bins, value_bins);
+    if (hist)
+    {
+        hist->set_meta_data(metaData);
+        _configure_color_map(hist, false, false);
+        _connect_callable_sync(hist, sync_with);
+    }
+    return hist;
 }
 
 void SciQLopPlot::toggle_selected_objects_visibility() noexcept

--- a/tests/integration/test_histogram2d.py
+++ b/tests/integration/test_histogram2d.py
@@ -3,7 +3,12 @@ import numpy as np
 import pytest
 from PySide6.QtWidgets import QApplication
 
-from SciQLopPlots import SciQLopPlot, SciQLopHistogram2D
+from SciQLopPlots import (
+    SciQLopPlot,
+    SciQLopHistogram2D,
+    SciQLopMultiPlotPanel,
+    GraphType,
+)
 
 
 @pytest.fixture(scope="module")
@@ -144,3 +149,92 @@ class TestHistogram2DReplot:
         hist.set_data(rng.normal(0, 1, 5000), rng.normal(0, 1, 5000))
         hist.set_bins(20, 20)
         plot.replot(True)
+
+
+class TestHistogram2DCallable:
+    def test_callable_histogram2d_returns_interface(self, plot):
+        rng = np.random.default_rng(0)
+
+        def producer(start, stop):
+            return rng.normal(0, 1, 500), rng.normal(0, 1, 500)
+
+        hist = plot.histogram2d(producer, name="cb")
+        assert hist is not None
+
+    def test_callable_custom_bins(self, plot):
+        def producer(start, stop):
+            return np.arange(100.0), np.arange(100.0)
+
+        hist = plot.histogram2d(producer, name="cb", key_bins=25, value_bins=30)
+        assert hist.key_bins() == 25
+        assert hist.value_bins() == 30
+
+
+class TestHistogram2DPanel:
+    def test_panel_histogram2d_static(self, app):
+        panel = SciQLopMultiPlotPanel()
+        rng = np.random.default_rng(0)
+        x = rng.normal(0, 1, 300)
+        y = rng.normal(0, 1, 300)
+        p, hist = panel.histogram2d(x, y, name="static_panel")
+        assert p is not None
+        assert hist is not None
+        del panel
+
+    def test_panel_histogram2d_callable(self, app):
+        panel = SciQLopMultiPlotPanel()
+        rng = np.random.default_rng(0)
+
+        def producer(start, stop):
+            return rng.normal(0, 1, 300), rng.normal(0, 1, 300)
+
+        p, hist = panel.histogram2d(producer, name="cb_panel",
+                                     key_bins=40, value_bins=40)
+        assert p is not None
+        assert hist is not None
+        del panel
+
+
+class TestHistogram2DDispatcher:
+    def test_plot_dispatcher_static(self, plot):
+        rng = np.random.default_rng(0)
+        x = rng.normal(0, 1, 400)
+        y = rng.normal(0, 1, 400)
+        hist = plot.plot(x, y, graph_type=GraphType.Histogram2D,
+                         name="disp_static", key_bins=30, value_bins=30)
+        assert hist is not None
+        assert hist.key_bins() == 30
+
+    def test_plot_dispatcher_callable(self, plot):
+        rng = np.random.default_rng(0)
+
+        def producer(start, stop):
+            return rng.normal(0, 1, 400), rng.normal(0, 1, 400)
+
+        hist = plot.plot(producer, graph_type=GraphType.Histogram2D,
+                         name="disp_cb", key_bins=30, value_bins=30)
+        assert hist is not None
+        assert hist.key_bins() == 30
+
+    def test_panel_plot_dispatcher_static(self, app):
+        panel = SciQLopMultiPlotPanel()
+        rng = np.random.default_rng(0)
+        x = rng.normal(0, 1, 300)
+        y = rng.normal(0, 1, 300)
+        result = panel.plot(x, y, graph_type=GraphType.Histogram2D,
+                            name="panel_disp", key_bins=20, value_bins=20)
+        assert result is not None
+        del panel
+
+    def test_reject_histogram2d_kwargs_for_line(self, plot):
+        x = np.arange(10.0)
+        y = np.arange(10.0)
+        with pytest.raises(TypeError, match="Histogram2D"):
+            plot.plot(x, y, graph_type=GraphType.Line, key_bins=10)
+
+    def test_reject_waterfall_kwargs_for_histogram2d(self, plot):
+        rng = np.random.default_rng(0)
+        x = rng.normal(0, 1, 100)
+        y = rng.normal(0, 1, 100)
+        with pytest.raises(TypeError, match="Waterfall"):
+            plot.plot(x, y, graph_type=GraphType.Histogram2D, gain=2.0)


### PR DESCRIPTION
## Summary

Brings `SciQLopHistogram2D` to full feature parity with `SciQLopColorMap` and `SciQLopWaterfallGraph`. Before this PR, Histogram2D was a static-only plotable missing the callable pipeline, panel-level entry points, and `plot()` dispatcher routing that the other 2D graph types have.

## Changes

Eight atomic commits across the six architectural layers:

- **`feat(enums)`** — new `GraphType::Histogram2D` enum value.
- **`feat(plotables)`** — `SciQLopHistogram2DFunction` callable variant (multiple inheritance of `SciQLopHistogram2D` + `SciQLopFunctionGraph`, N=2 buffers), mirroring the waterfall pattern.
- **`feat(plot)`** — `SciQLopPlot::add_histogram2d(callable, ...)` overload plus matching `plot_impl` overrides for both static and callable forms.
- **`feat(interface)`** — `histogram2d(x, y, ...)` and `histogram2d(callable, ...)` virtual bridges on `SciQLopPlotInterface`.
- **`feat(panel)`** — panel-level bridges on `SciQLopPlotCollectionInterface`, implemented in `SciQLopMultiPlotPanel` via a dedicated `_plot_histogram2d<T>()` helper.
- **`feat(bindings)`** — registers `SciQLopHistogram2DFunction` and renames the `histogram2d` args via `modify-function` on both per-plot and panel-level interfaces (static + callable signatures).
- **`feat(python)`** — `plot(graph_type=GraphType.Histogram2D)` routing in the Python dispatcher for 1-arg (callable) and 2-arg (static) call shapes, with a `_HISTOGRAM2D_KWARGS` (`key_bins`, `value_bins`) rejection helper that raises `TypeError` when those kwargs are passed to other graph types.
- **`test`** — extends `tests/integration/test_histogram2d.py` with callable, panel, dispatcher, and kwarg-rejection coverage (28 tests total, all passing).

## Design note: panel dispatch bypasses `__plot` SFINAE

Colormap and histogram2d both return `SciQLopColorMapInterface*` and their callable signatures are implicitly convertible (colormap takes `bool` log-scale flags where histogram2d takes `int` bin counts). A third `__plot` overload specialized on histogram2d would be ambiguous with the colormap overload for calls where args satisfy both. Instead, the panel calls a small `_plot_histogram2d<T>(index, args...)` helper that creates the plot and forwards directly to `plot->histogram2d(...)`. The `__plot` SFINAE chain is left untouched.

## Test plan

- [x] `meson compile -C build` — clean build.
- [x] `pytest tests/integration/test_histogram2d.py` — 28 tests pass (callable, panel, dispatcher, kwargs).
- [x] Full `pytest tests/integration/` — 428 tests pass, no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)