### PR TITLE
feat(inspector): per-graph InspectorExtension hook for custom delegates

### DIFF
--- a/SciQLopPlots/bindings/bindings.h
+++ b/SciQLopPlots/bindings/bindings.h
@@ -17,6 +17,7 @@
 #include <SciQLopPlots/Inspector/Model/TypeDescriptor.hpp>
 #include <SciQLopPlots/Inspector/Model/Model.hpp>
 #include <SciQLopPlots/Inspector/Model/Node.hpp>
+#include <SciQLopPlots/Inspector/InspectorExtension.hpp>
 #include <SciQLopPlots/Inspector/PropertyDelegateBase.hpp>
 #include <SciQLopPlots/Inspector/View/InspectorView.hpp>
 #include <SciQLopPlots/Inspector/View/PropertiesPanel.hpp>

--- a/SciQLopPlots/bindings/bindings.xml
+++ b/SciQLopPlots/bindings/bindings.xml
@@ -848,6 +848,7 @@
     <object-type name="PlotsTreeView" parent-management="yes"/>
     <object-type name="InspectorView" parent-management="yes"/>
     <object-type name="PropertyDelegateBase" parent-management="yes"/>
+    <object-type name="InspectorExtension" parent-management="yes"/>
     <object-type name="PropertiesPanel" parent-management="yes"/>
 
     <value-type name="MatchResult"/>

--- a/SciQLopPlots/meson.build
+++ b/SciQLopPlots/meson.build
@@ -119,6 +119,7 @@ moc_headers = [
     project_source_root + '/include/SciQLopPlots/Inspector/View/TreeView.hpp',
     project_source_root + '/include/SciQLopPlots/Inspector/View/InspectorView.hpp',
     project_source_root + '/include/SciQLopPlots/Inspector/PropertyDelegateBase.hpp',
+    project_source_root + '/include/SciQLopPlots/Inspector/InspectorExtension.hpp',
     project_source_root + '/include/SciQLopPlots/Inspector/PropertiesDelegates/SciQLopMultiPlotPanelDelegate.hpp',
     project_source_root + '/include/SciQLopPlots/Inspector/View/PropertiesPanel.hpp',
     project_source_root + '/include/SciQLopPlots/Inspector/View/PropertiesView.hpp',

--- a/include/SciQLopPlots/Inspector/InspectorExtension.hpp
+++ b/include/SciQLopPlots/Inspector/InspectorExtension.hpp
@@ -1,6 +1,6 @@
 /*------------------------------------------------------------------------------
 -- This file is a part of the SciQLop Software
--- Copyright (C) 2024, Plasma Physics Laboratory - CNRS
+-- Copyright (C) 2026, Plasma Physics Laboratory - CNRS
 --
 -- This program is free software; you can redistribute it and/or modify
 -- it under the terms of the GNU General Public License as published by
@@ -16,25 +16,29 @@
 -- along with this program; if not, write to the Free Software
 -- Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 -------------------------------------------------------------------------------*/
-
 /*-- Author : Alexis Jeandet
 -- Mail : alexis.jeandet@member.fsf.org
 ----------------------------------------------------------------------------*/
-#include "SciQLopPlots/Inspector/PropertiesDelegates/SciQLopColorMapDelegate.hpp"
-#include "SciQLopPlots/Inspector/PropertiesDelegates/Delegates/ColorGradientDelegate.hpp"
-#include "SciQLopPlots/Plotables/SciQLopColorMap.hpp"
+#pragma once
+#include <QObject>
+#include <QString>
+#include <QWidget>
 
-SciQLopColorMap* SciQLopColorMapDelegate::colorMap() const
+class InspectorExtension : public QObject
 {
-    return as_type<SciQLopColorMap>(m_object);
-}
+    Q_OBJECT
 
-SciQLopColorMapDelegate::SciQLopColorMapDelegate(SciQLopColorMap* object, QWidget* parent)
-        : PropertyDelegateBase(object, parent)
-{
-    ColorGradientDelegate* gradient = new ColorGradientDelegate(colorMap()->gradient(), this);
-    m_layout->addWidget(gradient);
-    connect(gradient, &ColorGradientDelegate::gradientChanged, this,
-            [this](ColorGradient gradient) { colorMap()->set_gradient(gradient); });
-    append_inspector_extensions();
-}
+public:
+    explicit InspectorExtension(QObject* parent = nullptr) : QObject(parent) { }
+    virtual ~InspectorExtension() = default;
+
+    virtual QString section_title() const = 0;
+    virtual int priority() const { return 0; }
+    virtual QWidget* build_widget(QWidget* parent) = 0;
+
+#ifdef BINDINGS_H
+#define Q_SIGNAL
+signals:
+#endif
+    Q_SIGNAL void invalidated();
+};

--- a/include/SciQLopPlots/Inspector/PropertyDelegateBase.hpp
+++ b/include/SciQLopPlots/Inspector/PropertyDelegateBase.hpp
@@ -53,4 +53,10 @@ public:
     }
 
     virtual ~PropertyDelegateBase() = default;
+
+protected:
+    void append_inspector_extensions();
+
+private:
+    void rebuild_inspector_extensions();
 };

--- a/include/SciQLopPlots/Plotables/SciQLopGraphInterface.hpp
+++ b/include/SciQLopPlots/Plotables/SciQLopGraphInterface.hpp
@@ -33,10 +33,12 @@
 #include <QObjectBindableProperty>
 #include <QList>
 #include <QObject>
+#include <QPointer>
 #include <QWidget>
 #include <utility>
 
 class SciQLopPlotAxisInterface;
+class InspectorExtension;
 
 class SciQLopPlottableInterface : public QObject
 {
@@ -160,11 +162,16 @@ public:
         return qobject_cast<QWidget*>(parent())->size();
     }
 
+    void add_inspector_extension(InspectorExtension* extension);
+    void remove_inspector_extension(InspectorExtension* extension);
+    QList<InspectorExtension*> inspector_extensions() const;
+
 #ifdef BINDINGS_H
 #define Q_SIGNAL
 signals:
 #endif
     Q_SIGNAL void range_changed(SciQLopPlotRange range);
+    Q_SIGNAL void inspector_extensions_changed();
     Q_SIGNAL void visible_changed(bool visible);
     Q_SIGNAL void name_changed(const QString& name);
     Q_SIGNAL void replot();
@@ -179,6 +186,7 @@ signals:
 
     protected:
     bool _got_first_data = false;
+    QList<QPointer<InspectorExtension>> m_inspector_extensions;
 
     void check_first_data(std::size_t n)
     {

--- a/src/PropertyDelegateBase.cpp
+++ b/src/PropertyDelegateBase.cpp
@@ -20,6 +20,13 @@
 -- Mail : alexis.jeandet@member.fsf.org
 ----------------------------------------------------------------------------*/
 #include "SciQLopPlots/Inspector/PropertyDelegateBase.hpp"
+#include "SciQLopPlots/Inspector/InspectorExtension.hpp"
+#include "SciQLopPlots/Plotables/SciQLopGraphInterface.hpp"
+#include <QGroupBox>
+#include <QVBoxLayout>
+#include <algorithm>
+
+static constexpr auto EXT_GROUP_PREFIX = "__inspector_ext__";
 
 PropertyDelegateBase::PropertyDelegateBase(QObject *object, QWidget *parent)
         : QWidget(parent), m_object { object }
@@ -31,4 +38,49 @@ PropertyDelegateBase::PropertyDelegateBase(QObject *object, QWidget *parent)
     connect(object, &QObject::objectNameChanged, this,
             &PropertyDelegateBase::object_name_changed);
     object_name_changed(object->objectName());
+}
+
+void PropertyDelegateBase::append_inspector_extensions()
+{
+    auto* plottable = qobject_cast<SciQLopPlottableInterface*>(m_object.data());
+    if (!plottable)
+        return;
+    rebuild_inspector_extensions();
+    connect(plottable, &SciQLopPlottableInterface::inspector_extensions_changed, this,
+            &PropertyDelegateBase::rebuild_inspector_extensions, Qt::UniqueConnection);
+}
+
+void PropertyDelegateBase::rebuild_inspector_extensions()
+{
+    auto* plottable = qobject_cast<SciQLopPlottableInterface*>(m_object.data());
+    if (!plottable)
+        return;
+
+    const auto prior = findChildren<QGroupBox*>(QString(), Qt::FindDirectChildrenOnly);
+    for (auto* gb : prior)
+    {
+        if (gb->objectName().startsWith(EXT_GROUP_PREFIX))
+        {
+            m_layout->removeWidget(gb);
+            gb->deleteLater();
+        }
+    }
+
+    auto exts = plottable->inspector_extensions();
+    std::sort(exts.begin(), exts.end(),
+              [](InspectorExtension* a, InspectorExtension* b)
+              { return a->priority() < b->priority(); });
+
+    for (auto* ext : exts)
+    {
+        auto* group = new QGroupBox(ext->section_title(), this);
+        group->setObjectName(QString(EXT_GROUP_PREFIX) + QString::number(quintptr(ext)));
+        auto* outer = new QVBoxLayout(group);
+        outer->setContentsMargins(6, 6, 6, 6);
+        if (auto* w = ext->build_widget(group))
+            outer->addWidget(w);
+        m_layout->addRow(group);
+        connect(ext, &InspectorExtension::invalidated, this,
+                &PropertyDelegateBase::rebuild_inspector_extensions, Qt::UniqueConnection);
+    }
 }

--- a/src/SciQLopGraphDelegate.cpp
+++ b/src/SciQLopGraphDelegate.cpp
@@ -30,4 +30,5 @@ SciQLopGraphInterface* SciQLopGraphDelegate::graph() const
 SciQLopGraphDelegate::SciQLopGraphDelegate(SciQLopGraphInterface* object, QWidget* parent)
         : PropertyDelegateBase(object, parent)
 {
+    append_inspector_extensions();
 }

--- a/src/SciQLopGraphInterface.cpp
+++ b/src/SciQLopGraphInterface.cpp
@@ -20,6 +20,7 @@
 -- Mail : alexis.jeandet@member.fsf.org
 ----------------------------------------------------------------------------*/
 #include "SciQLopPlots/Plotables/SciQLopGraphInterface.hpp"
+#include "SciQLopPlots/Inspector/InspectorExtension.hpp"
 #include "SciQLopPlots/SciQLopPlotAxis.hpp"
 #include "SciQLopPlots/unique_names_factory.hpp"
 
@@ -38,6 +39,50 @@ void SciQLopPlottableInterface::set_range(const SciQLopPlotRange& range)
         m_range = range;
         Q_EMIT range_changed(range);
     }
+}
+
+void SciQLopPlottableInterface::add_inspector_extension(InspectorExtension* extension)
+{
+    if (!extension)
+        return;
+    for (const auto& p : m_inspector_extensions)
+        if (p.data() == extension)
+            return;
+    extension->setParent(this);
+    m_inspector_extensions.append(QPointer<InspectorExtension>(extension));
+    connect(extension, &QObject::destroyed, this,
+            [this]() { Q_EMIT inspector_extensions_changed(); });
+    Q_EMIT inspector_extensions_changed();
+}
+
+void SciQLopPlottableInterface::remove_inspector_extension(InspectorExtension* extension)
+{
+    bool removed = false;
+    for (int i = m_inspector_extensions.size() - 1; i >= 0; --i)
+    {
+        auto& p = m_inspector_extensions[i];
+        if (!p || p.data() == extension)
+        {
+            m_inspector_extensions.removeAt(i);
+            removed = true;
+        }
+    }
+    if (removed)
+    {
+        if (extension && extension->parent() == this)
+            extension->setParent(nullptr);
+        Q_EMIT inspector_extensions_changed();
+    }
+}
+
+QList<InspectorExtension*> SciQLopPlottableInterface::inspector_extensions() const
+{
+    QList<InspectorExtension*> out;
+    out.reserve(m_inspector_extensions.size());
+    for (const auto& p : m_inspector_extensions)
+        if (p)
+            out.append(p.data());
+    return out;
 }
 
 SciQLopColorMapInterface::SciQLopColorMapInterface(QVariantMap metaData, QObject* parent)

--- a/src/SciQLopWaterfallDelegate.cpp
+++ b/src/SciQLopWaterfallDelegate.cpp
@@ -111,6 +111,8 @@ SciQLopWaterfallDelegate::SciQLopWaterfallDelegate(SciQLopWaterfallGraph* object
             [this](double v) { m_gainSpin->setValue(v); });
     connect(object, QOverload<>::of(&SciQLopGraphInterface::data_changed), this,
             [this]() { rebuild_offsets_editor(); });
+
+    append_inspector_extensions();
 }
 
 void SciQLopWaterfallDelegate::rebuild_offsets_editor()

--- a/tests/integration/test_inspector_extensions.py
+++ b/tests/integration/test_inspector_extensions.py
@@ -1,0 +1,193 @@
+"""Tests for the InspectorExtension API.
+
+Covers the per-graph extension triad (add/remove/list), signal emission,
+lifetime via QObject parenting, Python subclassing, and delegate rendering.
+"""
+import numpy as np
+import pytest
+from PySide6.QtWidgets import QGroupBox, QLabel, QWidget
+
+from SciQLopPlots import (
+    DelegateRegistry,
+    GraphType,
+    InspectorExtension,
+    SciQLopColorMap,
+)
+
+
+def _make_delegate(target, qtbot):
+    d = DelegateRegistry.instance().create_delegate(target, None)
+    assert d is not None
+    qtbot.addWidget(d)
+    return d
+from conftest import process_events, force_gc
+
+
+class LabelExtension(InspectorExtension):
+    """Minimal extension producing a QLabel. Tracks build_widget calls."""
+
+    def __init__(self, title="Parameters", prio=0, text="ext-body"):
+        super().__init__()
+        self._title = title
+        self._prio = prio
+        self._text = text
+        self.build_calls = 0
+
+    def section_title(self):
+        return self._title
+
+    def priority(self):
+        return self._prio
+
+    def build_widget(self, parent):
+        self.build_calls += 1
+        return QLabel(self._text, parent)
+
+
+@pytest.fixture
+def line_graph(plot, sample_data):
+    x, y = sample_data
+    g = plot.plot(x, y, graph_type=GraphType.Line)
+    process_events()
+    return g
+
+
+class TestExtensionTriad:
+    def test_empty_on_fresh_graph(self, line_graph):
+        assert line_graph.inspector_extensions() == []
+
+    def test_add_appears_in_list(self, line_graph):
+        ext = LabelExtension()
+        line_graph.add_inspector_extension(ext)
+        exts = line_graph.inspector_extensions()
+        assert len(exts) == 1
+        assert exts[0] is ext
+
+    def test_add_is_idempotent(self, line_graph):
+        ext = LabelExtension()
+        line_graph.add_inspector_extension(ext)
+        line_graph.add_inspector_extension(ext)
+        assert len(line_graph.inspector_extensions()) == 1
+
+    def test_remove(self, line_graph):
+        ext = LabelExtension()
+        line_graph.add_inspector_extension(ext)
+        line_graph.remove_inspector_extension(ext)
+        assert line_graph.inspector_extensions() == []
+
+    def test_remove_unknown_noop(self, line_graph):
+        ext = LabelExtension()
+        line_graph.remove_inspector_extension(ext)
+        assert line_graph.inspector_extensions() == []
+
+    def test_multiple_extensions_preserve_order(self, line_graph):
+        a, b, c = LabelExtension("A"), LabelExtension("B"), LabelExtension("C")
+        for e in (a, b, c):
+            line_graph.add_inspector_extension(e)
+        assert line_graph.inspector_extensions() == [a, b, c]
+
+
+class TestSignal:
+    def test_signal_emits_on_add(self, line_graph, qtbot):
+        with qtbot.waitSignal(line_graph.inspector_extensions_changed, timeout=500):
+            line_graph.add_inspector_extension(LabelExtension())
+
+    def test_signal_emits_on_remove(self, line_graph, qtbot):
+        ext = LabelExtension()
+        line_graph.add_inspector_extension(ext)
+        with qtbot.waitSignal(line_graph.inspector_extensions_changed, timeout=500):
+            line_graph.remove_inspector_extension(ext)
+
+
+class TestLifetime:
+    def test_extension_reparented_to_graph(self, line_graph):
+        ext = LabelExtension()
+        line_graph.add_inspector_extension(ext)
+        assert ext.parent() is line_graph
+
+    def test_extension_autoremoved_when_destroyed(self, line_graph, qtbot):
+        import shiboken6
+        ext = LabelExtension()
+        line_graph.add_inspector_extension(ext)
+        with qtbot.waitSignal(line_graph.inspector_extensions_changed, timeout=500):
+            shiboken6.delete(ext)
+        assert line_graph.inspector_extensions() == []
+
+
+class TestDelegateRendering:
+    def test_graph_delegate_renders_extension(self, line_graph, qtbot):
+        ext = LabelExtension(title="My Params", text="hello-body")
+        line_graph.add_inspector_extension(ext)
+
+        delegate = _make_delegate(line_graph, qtbot)
+        process_events()
+
+        groups = delegate.findChildren(QGroupBox)
+        ext_groups = [g for g in groups if g.objectName().startswith("__inspector_ext__")]
+        assert len(ext_groups) == 1
+        assert ext_groups[0].title() == "My Params"
+        assert ext.build_calls == 1
+        # Body widget reachable as a descendant label.
+        labels = [w for w in ext_groups[0].findChildren(QLabel) if w.text() == "hello-body"]
+        assert labels, "extension body widget not found under group"
+
+    def test_delegate_renders_nothing_without_extensions(self, line_graph, qtbot):
+        delegate = _make_delegate(line_graph, qtbot)
+        process_events()
+        groups = [g for g in delegate.findChildren(QGroupBox)
+                  if g.objectName().startswith("__inspector_ext__")]
+        assert groups == []
+
+    def test_delegate_sorts_by_priority(self, line_graph, qtbot):
+        low = LabelExtension(title="Low", prio=0)
+        high = LabelExtension(title="High", prio=100)
+        # Insert high first — delegate must still render Low before High.
+        line_graph.add_inspector_extension(high)
+        line_graph.add_inspector_extension(low)
+
+        delegate = _make_delegate(line_graph, qtbot)
+        process_events()
+
+        titles = [g.title() for g in delegate.findChildren(QGroupBox)
+                  if g.objectName().startswith("__inspector_ext__")]
+        assert titles == ["Low", "High"]
+
+    def test_invalidated_rebuilds_section(self, line_graph, qtbot):
+        ext = LabelExtension(title="X")
+        line_graph.add_inspector_extension(ext)
+        delegate = _make_delegate(line_graph, qtbot)
+        process_events()
+        assert ext.build_calls == 1
+        ext.invalidated.emit()
+        process_events()
+        assert ext.build_calls == 2
+
+    def test_add_after_delegate_built_appears(self, line_graph, qtbot):
+        delegate = _make_delegate(line_graph, qtbot)
+        process_events()
+
+        ext = LabelExtension(title="LateAdd")
+        line_graph.add_inspector_extension(ext)
+        process_events()
+
+        titles = [g.title() for g in delegate.findChildren(QGroupBox)
+                  if g.objectName().startswith("__inspector_ext__")]
+        assert titles == ["LateAdd"]
+
+    def test_colormap_delegate_also_renders(self, qtbot, sample_colormap_data):
+        from SciQLopPlots import SciQLopPlot
+        plot = SciQLopPlot()
+        qtbot.addWidget(plot)
+        x, y, z = sample_colormap_data
+        cmap = plot.plot(x, y, z, graph_type=GraphType.ColorMap)
+        assert isinstance(cmap, SciQLopColorMap)
+
+        ext = LabelExtension(title="CMapParams")
+        cmap.add_inspector_extension(ext)
+
+        delegate = _make_delegate(cmap, qtbot)
+        process_events()
+
+        titles = [g.title() for g in delegate.findChildren(QGroupBox)
+                  if g.objectName().startswith("__inspector_ext__")]
+        assert titles == ["CMapParams"]


### PR DESCRIPTION
## Summary

Adds an extension slot on `SciQLopPlottableInterface` that lets callers attach arbitrary QWidget-producing QObjects to a graph; graph-family delegates render each one as an extra section in the inspector.

Motivation: SciQLop's parameterized virtual products (2026-04-18 knobs spec) need per-graph editors that live on the Python side — knob specs vary per product, so subclassing the built-in delegates per-graph isn't viable. This PR gives SciQLop a single seam (`graph.add_inspector_extension(ext)`) with lifecycle tied to the graph via `QObject` parenting.

## What's in

- `InspectorExtension`: abstract `QObject` with `section_title`, `priority`, `build_widget(parent)`, `invalidated` signal.
- `SciQLopPlottableInterface`: `add/remove/inspector_extensions()` triad + `inspector_extensions_changed` signal. Extensions are reparented on add; stale `QPointer`s are filtered; destruction auto-emits.
- `PropertyDelegateBase::append_inspector_extensions()`: finalizer that appends each extension as a tagged `QGroupBox` row sorted by `priority()`, rebuilds on `invalidated()` or `inspector_extensions_changed`. Called from `SciQLopGraphDelegate`, `SciQLopColorMapDelegate`, `SciQLopWaterfallDelegate`.
- Bindings: `InspectorExtension` exposed with `parent-management="yes"` so Python subclasses work.
- 16 integration tests in `tests/integration/test_inspector_extensions.py`.

## What's not

- No knob spec / value / validation types — those live in SciQLop, not this repo.
- No changes to `SciQLopGraphComponentInterface` / `SciQLopPlotInterface` (per-graph scope).
- No overlay info-badge plumbing — existing `SciQLopOverlay::show_message` covers v1.

## Test plan

- [x] Full existing integration suite: 444 passed.
- [x] New suite: 16 passed (triad, signal emission, reparenting lifetime, auto-prune on destroy, delegate rendering on line + colormap, priority ordering, `invalidated` rebuild, late-add rendering).
- [ ] SciQLop-side: build a `KnobInspectorExtension` using this API as a downstream smoke test.