### PR TITLE
fix(pipeline): invalidate_cache() forces refetch on identical range

### DIFF
--- a/include/SciQLopPlots/DataProducer/DataProducer.hpp
+++ b/include/SciQLopPlots/DataProducer/DataProducer.hpp
@@ -53,6 +53,7 @@ class DataProviderInterface : public QObject
     QTimer* m_rate_limit_timer;
     QMutex m_mutex;
     bool m_has_pending_change = false;
+    bool m_force_next_update = false;
 
 #ifndef BINDINGS_H
     Q_SIGNAL void _state_changed();
@@ -83,6 +84,8 @@ public:
     virtual QList<PyBuffer> get_data(PyBuffer x, PyBuffer y);
     virtual QList<PyBuffer> get_data(PyBuffer x, PyBuffer y, PyBuffer z);
     virtual QList<PyBuffer> get_data(QList<PyBuffer> values);
+
+    void invalidate_cache();
 
 
 
@@ -221,6 +224,8 @@ public:
 
     inline void set_callable(GetDataPyCallable&& callable) { m_callable_wrapper->set_callable(std::move(callable)); }
     inline GetDataPyCallable callable() const { return m_callable_wrapper->callable(); }
+
+    inline void invalidate_cache() { m_callable_wrapper->invalidate_cache(); }
 
 
 #ifdef BINDINGS_H

--- a/include/SciQLopPlots/Plotables/SciQLopColorMap.hpp
+++ b/include/SciQLopPlots/Plotables/SciQLopColorMap.hpp
@@ -93,4 +93,6 @@ public:
                                      GetDataPyCallable&& callable, const QString& name);
 
     virtual ~SciQLopColorMapFunction() override = default;
+
+    inline void invalidate_cache() noexcept override { invalidate_pipeline_cache(); }
 };

--- a/include/SciQLopPlots/Plotables/SciQLopCurve.hpp
+++ b/include/SciQLopPlots/Plotables/SciQLopCurve.hpp
@@ -106,4 +106,6 @@ public:
                                   const QStringList& labels,QVariantMap metaData={});
 
     virtual ~SciQLopCurveFunction() override = default;
+
+    inline void invalidate_cache() noexcept override { invalidate_pipeline_cache(); }
 };

--- a/include/SciQLopPlots/Plotables/SciQLopGraphInterface.hpp
+++ b/include/SciQLopPlots/Plotables/SciQLopGraphInterface.hpp
@@ -166,6 +166,8 @@ public:
     void remove_inspector_extension(InspectorExtension* extension);
     QList<InspectorExtension*> inspector_extensions() const;
 
+    virtual void invalidate_cache() noexcept { }
+
 #ifdef BINDINGS_H
 #define Q_SIGNAL
 signals:
@@ -349,4 +351,5 @@ public:
         m_pipeline->call(values);
     }
 
+    inline void invalidate_pipeline_cache() noexcept { m_pipeline->invalidate_cache(); }
 };

--- a/include/SciQLopPlots/Plotables/SciQLopHistogram2D.hpp
+++ b/include/SciQLopPlots/Plotables/SciQLopHistogram2D.hpp
@@ -86,4 +86,6 @@ public:
                                         int key_bins = 100, int value_bins = 100);
 
     virtual ~SciQLopHistogram2DFunction() override = default;
+
+    inline void invalidate_cache() noexcept override { invalidate_pipeline_cache(); }
 };

--- a/include/SciQLopPlots/Plotables/SciQLopLineGraph.hpp
+++ b/include/SciQLopPlots/Plotables/SciQLopLineGraph.hpp
@@ -52,4 +52,6 @@ public:
                                       SciQLopPlotAxis* value_axis, GetDataPyCallable&& callable,
                                       const QStringList& labels, QVariantMap metaData = {});
     ~SciQLopLineGraphFunction() override = default;
+
+    inline void invalidate_cache() noexcept override { invalidate_pipeline_cache(); }
 };

--- a/include/SciQLopPlots/Plotables/SciQLopNDProjectionCurves.hpp
+++ b/include/SciQLopPlots/Plotables/SciQLopNDProjectionCurves.hpp
@@ -65,5 +65,5 @@ public:
 
     virtual ~SciQLopNDProjectionCurvesFunction() override = default;
 
-
+    inline void invalidate_cache() noexcept override { invalidate_pipeline_cache(); }
 };

--- a/include/SciQLopPlots/Plotables/SciQLopSingleLineGraph.hpp
+++ b/include/SciQLopPlots/Plotables/SciQLopSingleLineGraph.hpp
@@ -80,4 +80,6 @@ public:
                                             const QStringList& labels, QVariantMap metaData = {});
 
     virtual ~SciQLopSingleLineGraphFunction() override = default;
+
+    inline void invalidate_cache() noexcept override { invalidate_pipeline_cache(); }
 };

--- a/include/SciQLopPlots/Plotables/SciQLopWaterfallGraph.hpp
+++ b/include/SciQLopPlots/Plotables/SciQLopWaterfallGraph.hpp
@@ -83,4 +83,6 @@ public:
                                            const QStringList& labels = QStringList(),
                                            QVariantMap metaData = {});
     ~SciQLopWaterfallGraphFunction() override = default;
+
+    inline void invalidate_cache() noexcept override { invalidate_pipeline_cache(); }
 };

--- a/src/DataProducer.cpp
+++ b/src/DataProducer.cpp
@@ -87,12 +87,24 @@ void DataProviderInterface::_notify_new_data(const QList<PyBuffer> &data)
 
 void DataProviderInterface::_range_based_update(const SciQLopPlotRange& new_range)
 {
-    if (std::holds_alternative<SciQLopPlotRange>(m_current_state)
+    bool force;
+    {
+        QMutexLocker lock(&m_mutex);
+        force = m_force_next_update;
+        m_force_next_update = false;
+    }
+    if (!force && std::holds_alternative<SciQLopPlotRange>(m_current_state)
         && new_range == std::get<SciQLopPlotRange>(m_current_state))
         return;
     auto r = get_data(new_range.start(), new_range.stop());
     m_current_state = new_range;
     _notify_new_data(r);
+}
+
+void DataProviderInterface::invalidate_cache()
+{
+    QMutexLocker lock(&m_mutex);
+    m_force_next_update = true;
 }
 
 void DataProviderInterface::_data_based_update(const _2D_data& new_data)

--- a/tests/integration/test_invalidate_cache.py
+++ b/tests/integration/test_invalidate_cache.py
@@ -1,0 +1,126 @@
+"""Reproducer and regression test for the DataProvider cache invalidation bug.
+
+DataProviderInterface::_range_based_update short-circuits when the new range
+equals the cached m_current_state (src/DataProducer.cpp:_range_based_update).
+When a caller needs to re-fetch because some external state (e.g. knob values)
+changed but the range didn't, the pipeline silently drops the request.
+
+Fix: callers can call `graph.invalidate_cache()` to force the next same-range
+fetch to bypass the dedup.
+"""
+import numpy as np
+import pytest
+from conftest import process_events
+
+
+def _wait_calls(calls_list, target, qtbot, timeout=2000):
+    """Spin the event loop until the callable counter hits `target` or timeout."""
+    def done():
+        assert len(calls_list) >= target
+    qtbot.waitUntil(done, timeout=timeout)
+
+
+class TestInvalidateCacheForcesRefetch:
+    def test_same_range_without_invalidate_dedups(self, plot, qtbot):
+        """Baseline: second call with identical range must be deduped (current behavior)."""
+        calls = []
+
+        def cb(start, stop):
+            calls.append((start, stop))
+            x = np.linspace(start, stop, 10, dtype=np.float64)
+            return x, np.sin(x)
+
+        g = plot.line(cb)
+        from SciQLopPlots import SciQLopPlotRange
+        r = SciQLopPlotRange(0.0, 1.0)
+
+        g.set_range(r)
+        _wait_calls(calls, 1, qtbot)
+        n_after_first = len(calls)
+
+        # Same range, no invalidate — should NOT re-fetch.
+        g.set_range(r)
+        for _ in range(10):
+            process_events()
+        assert len(calls) == n_after_first, "dedup expected without invalidate"
+
+    def test_invalidate_then_same_range_refetches(self, plot, qtbot):
+        """Fix behavior: invalidate_cache() forces next same-range fetch."""
+        calls = []
+
+        def cb(start, stop):
+            calls.append((start, stop))
+            x = np.linspace(start, stop, 10, dtype=np.float64)
+            return x, np.sin(x)
+
+        g = plot.line(cb)
+        from SciQLopPlots import SciQLopPlotRange
+        r = SciQLopPlotRange(0.0, 1.0)
+
+        g.set_range(r)
+        _wait_calls(calls, 1, qtbot)
+        n_after_first = len(calls)
+
+        g.invalidate_cache()
+        g.set_range(r)
+        _wait_calls(calls, n_after_first + 1, qtbot)
+        assert len(calls) == n_after_first + 1
+
+    def test_invalidate_is_one_shot(self, plot, qtbot):
+        """A single invalidate_cache() forces one fetch, not all subsequent calls."""
+        calls = []
+
+        def cb(start, stop):
+            calls.append((start, stop))
+            x = np.linspace(start, stop, 10, dtype=np.float64)
+            return x, np.sin(x)
+
+        g = plot.line(cb)
+        from SciQLopPlots import SciQLopPlotRange
+        r = SciQLopPlotRange(0.0, 1.0)
+
+        g.set_range(r)
+        _wait_calls(calls, 1, qtbot)
+
+        g.invalidate_cache()
+        g.set_range(r)
+        _wait_calls(calls, 2, qtbot)
+
+        g.set_range(r)
+        for _ in range(10):
+            process_events()
+        assert len(calls) == 2, "second same-range call (no invalidate) must dedup again"
+
+
+class TestInvalidateCacheOnNonFunctionGraphs:
+    def test_noop_on_static_line(self, plot, sample_data, qtbot):
+        """Static graph has no pipeline; invalidate_cache() must be a safe no-op."""
+        x, y = sample_data
+        g = plot.line(x, y)
+        g.invalidate_cache()  # must not crash
+        process_events()
+
+
+class TestInvalidateCacheColorMap:
+    def test_invalidate_refetches_colormap(self, plot, qtbot):
+        calls = []
+
+        def cb(start, stop):
+            calls.append((start, stop))
+            x = np.linspace(start, stop, 20, dtype=np.float64)
+            y = np.linspace(0, 1, 10, dtype=np.float64)
+            z = np.random.rand(10, 20).astype(np.float64)
+            return x, y, z
+
+        g = plot.colormap(cb)
+        from SciQLopPlots import SciQLopPlotRange
+        r = SciQLopPlotRange(0.0, 1.0)
+
+        g.set_range(r)
+        _wait_calls(calls, 1, qtbot)
+        n = len(calls)
+
+        g.invalidate_cache()
+        g.set_range(r)
+        _wait_calls(calls, n + 1, qtbot)
+        assert len(calls) == n + 1


### PR DESCRIPTION
## Summary

- `DataProviderInterface::_range_based_update` dedups when `new_range == m_current_state`, silently dropping refetches triggered by non-range state changes (the concrete driver: parameterized virtual-product knob updates in SciQLop — knob change keeps the time range identical, so `graph.call(range)` is thrown away).
- Add a one-shot `m_force_next_update` flag (guarded by `m_mutex`, cleared on consumption), exposed as `invalidate_cache()` on `DataProviderInterface` and `SimplePyCallablePipeline`.
- Surface it polymorphically on `SciQLopPlottableInterface::invalidate_cache()` (no-op default) with overrides in all 7 `SciQLopFunctionGraph` subclasses (Line, SingleLine, Curve, ColorMap, Histogram2D, NDProjectionCurves, Waterfall).
- Call site: `_trigger_refetch` on the SciQLop side can now `graph.invalidate_cache()` before `graph.call(range)` to force the pipeline through.

## Test plan

- [x] Reproducer test written first: `tests/integration/test_invalidate_cache.py` — baseline confirms dedup, 4 others verify force-refetch, one-shot semantics, colormap parity, and no-op on static (non-function) graphs.
- [x] Full integration suite: 449 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)