### PR TITLE
fix(products): path-aware fuzzy search + completion insertion fix

### DIFF
--- a/include/SciQLopPlots/Products/ProductsFlatFilterModel.hpp
+++ b/include/SciQLopPlots/Products/ProductsFlatFilterModel.hpp
@@ -41,7 +41,12 @@ class ProductsFlatFilterModel : public QAbstractListModel
     };
     QList<ScoredNode> m_results;
 
-    QList<ProductsModelNode*> m_pending_leaves;
+    struct LeafEntry
+    {
+        ProductsModelNode* node;
+        QString full_text;
+    };
+    QList<LeafEntry> m_pending_leaves;
     int m_batch_cursor = 0;
     int m_batch_generation = 0;
     QTimer* m_batch_timer;
@@ -62,8 +67,8 @@ public:
 
 private:
     void rebuild();
-    void collect_all_leaves(ProductsModelNode* node, QList<ProductsModelNode*>& out) const;
+    void collect_all_leaves(ProductsModelNode* node, QList<LeafEntry>& out) const;
     void process_batch();
     bool filters_match(ProductsModelNode* node) const;
-    int free_text_score(ProductsModelNode* node) const;
+    int free_text_score(const QString& text) const;
 };

--- a/src/ProductsFlatFilterModel.cpp
+++ b/src/ProductsFlatFilterModel.cpp
@@ -119,11 +119,11 @@ void ProductsFlatFilterModel::rebuild()
 }
 
 void ProductsFlatFilterModel::collect_all_leaves(ProductsModelNode* node,
-                                                  QList<ProductsModelNode*>& out) const
+                                                  QList<LeafEntry>& out) const
 {
     if (node->node_type() == ProductsModelNodeType::PARAMETER)
     {
-        out.append(node);
+        out.append({ node, node->path().join(' ') + ' ' + node->raw_text() });
         return;
     }
     for (auto* child : node->children_nodes())
@@ -141,10 +141,10 @@ void ProductsFlatFilterModel::process_batch()
         if (m_batch_generation != generation)
             return;
 
-        auto* node = m_pending_leaves[i];
+        auto& [node, full_text] = m_pending_leaves[i];
         if (!filters_match(node))
             continue;
-        int score = free_text_score(node);
+        int score = free_text_score(full_text);
         if (score > 0)
             batch_results.append({ node, score });
     }
@@ -217,7 +217,7 @@ bool ProductsFlatFilterModel::filters_match(ProductsModelNode* node) const
     return true;
 }
 
-int ProductsFlatFilterModel::free_text_score(ProductsModelNode* node) const
+int ProductsFlatFilterModel::free_text_score(const QString& text) const
 {
     if (m_query.free_text_tokens.isEmpty())
         return 1;
@@ -225,7 +225,7 @@ int ProductsFlatFilterModel::free_text_score(ProductsModelNode* node) const
     int total = 0;
     for (const auto& token : m_query.free_text_tokens)
     {
-        int s = subsequence_score(token, node->raw_text());
+        int s = subsequence_score(token, text);
         if (s == 0)
             return 0;
         total += s;

--- a/src/ProductsTreeFilterModel.cpp
+++ b/src/ProductsTreeFilterModel.cpp
@@ -89,10 +89,11 @@ int ProductsTreeFilterModel::free_text_score(ProductsModelNode* node) const
     if (m_query.free_text_tokens.isEmpty())
         return 1;
 
+    QString full_text = node->path().join(' ') + ' ' + node->raw_text();
     int total = 0;
     for (const auto& token : m_query.free_text_tokens)
     {
-        int s = subsequence_score(token, node->raw_text());
+        int s = subsequence_score(token, full_text);
         if (s == 0)
             return 0;
         total += s;

--- a/src/QueryLineEdit.cpp
+++ b/src/QueryLineEdit.cpp
@@ -178,23 +178,20 @@ void QueryLineEdit::accept_completion()
         return;
 
     QString completion = m_completion_model->data(idx).toString();
-    QString word = current_word();
+    QString full_text = toPlainText();
+    int cursor_pos = textCursor().position();
+
+    int word_start = cursor_pos;
+    while (word_start > 0 && !full_text[word_start - 1].isSpace())
+        --word_start;
+
+    int colon_pos = full_text.lastIndexOf(':', cursor_pos - 1);
+    int replace_start
+        = (colon_pos > word_start) ? colon_pos + 1 : word_start;
 
     auto cursor = textCursor();
-    cursor.movePosition(QTextCursor::Left, QTextCursor::MoveAnchor, word.length());
-    cursor.movePosition(QTextCursor::Right, QTextCursor::KeepAnchor, word.length());
-
-    QString full_text = toPlainText();
-    int cursor_pos = cursor.position() + word.length();
-    int colon_pos = full_text.lastIndexOf(':', cursor_pos - 1);
-    int space_pos = full_text.lastIndexOf(' ', cursor_pos - 1);
-
-    if (colon_pos > space_pos && colon_pos >= 0)
-    {
-        QString partial = full_text.mid(colon_pos + 1, cursor_pos - colon_pos - 1);
-        cursor.movePosition(QTextCursor::Left, QTextCursor::MoveAnchor, partial.length());
-        cursor.movePosition(QTextCursor::Right, QTextCursor::KeepAnchor, partial.length());
-    }
+    cursor.setPosition(replace_start);
+    cursor.setPosition(cursor_pos, QTextCursor::KeepAnchor);
 
     cursor.insertText(completion);
     if (!completion.endsWith(':'))

--- a/tests/integration/test_products_filter.py
+++ b/tests/integration/test_products_filter.py
@@ -183,3 +183,50 @@ class TestDateRangeFilters:
         names = [fm.data(fm.index(i, 0)) for i in range(fm.rowCount())]
         assert "EnergySpectrum" in names
         assert "MagneticField" not in names
+
+
+@pytest.fixture
+def deep_tree_model(qtbot):
+    """Tree: amda -> ACE -> MFI -> b_gse (leaf), mimicking real product paths."""
+    model = ProductsModel.instance()
+
+    amda = ProductsModelNode("amda")
+    ace = ProductsModelNode("ACE")
+    mfi = ProductsModelNode("MFI")
+    b_gse = ProductsModelNode(
+        "b_gse", "amda", {},
+        ProductsModelNodeType.PARAMETER, ParameterType.Vector)
+
+    mfi.add_child(b_gse)
+    ace.add_child(mfi)
+    amda.add_child(ace)
+    model.add_node([], amda)
+
+    yield model
+
+
+class TestPathScoring:
+    """Search tokens matching ancestor folder names must surface the leaf."""
+
+    def test_flat_ancestor_query_matches_leaf(self, qtbot, deep_tree_model):
+        fm = ProductsFlatFilterModel(deep_tree_model)
+        q = QueryParser.parse("amdaacemfi")
+        fm.set_query(q)
+        flush_events()
+        names = [fm.data(fm.index(i, 0)) for i in range(fm.rowCount())]
+        assert "b_gse" in names
+
+    def test_flat_mixed_path_and_leaf_query(self, qtbot, deep_tree_model):
+        fm = ProductsFlatFilterModel(deep_tree_model)
+        q = QueryParser.parse("mfi b_gse")
+        fm.set_query(q)
+        flush_events()
+        names = [fm.data(fm.index(i, 0)) for i in range(fm.rowCount())]
+        assert "b_gse" in names
+
+    def test_tree_ancestor_query_matches_leaf(self, qtbot, deep_tree_model):
+        fm = ProductsTreeFilterModel()
+        fm.setSourceModel(deep_tree_model)
+        q = QueryParser.parse("amdaacemfi")
+        fm.set_query(q)
+        assert fm.rowCount() > 0


### PR DESCRIPTION
## Summary
- **Fuzzy search now includes ancestor path segments** in scoring. Queries like `amdaacemfi` now correctly surface `amda/ACE/MFI/b_gse`. Previously only the leaf's own name + metadata were scored, making cross-level queries impossible.
- **Fix QueryLineEdit completion insertion** that produced garbled output (e.g. `nT ITS:nT` instead of `UNITS:nT`). The fragile Left/Right/KeepAnchor cursor dance was replaced with direct `setPosition` calls to compute the exact replacement range.

## Test plan
- [x] 3 new tests in `TestPathScoring` covering flat ancestor query, mixed path+leaf query, and tree ancestor query
- [x] All 19 existing product filter tests still pass
- [ ] Manual: open SciQLop product search, type `amdaacemfi` → verify AMDA/ACE/MFI parameters appear
- [ ] Manual: type `UNITS:` then `nT` value completion → verify `UNITS:nT` (no garbled text)

🤖 Generated with [Claude Code](https://claude.com/claude-code)