### PR TITLE
feat: built-in runtime tracer (Chrome JSON / Perfetto)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ subprojects/**/*
 *.user*
 .cache/*
 .idea/
+.worktrees/
+.serena/
+aqtinstall.log

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,6 +97,8 @@ pip install -e . --no-build-isolation
 
 **Python interface** (`include/SciQLopPlots/Python/`): `PythonInterface.hpp` defines `PyBuffer` and `GetDataPyCallable` types for bridging numpy arrays and Python callbacks to C++
 
+**Runtime tracer** (`include/SciQLopPlots/Tracing.hpp` + `src/Tracing.cpp`): always-compiled-in event logger that emits Chrome trace JSON (Perfetto / Speedscope / chrome://tracing). Toggle via `tracing.enable("path.json") / disable() / flush()` from C++ or Python (`from SciQLopPlots import tracing`), or auto-enable with the `SCIQLOP_TRACE` env var. ~1 ns when off (single relaxed atomic load + branch). `Profiling.hpp`'s `PROFILE_HERE_N` feeds both this tracer and Tracy (when `tracy_enable=true` at build time) — instrument once, view in either tool.
+
 ### Python Bindings Pipeline
 
 1. `bindings.xml` defines the typesystem for Shiboken

--- a/README.md
+++ b/README.md
@@ -165,6 +165,43 @@ Run the gallery for a full feature showcase:
 python tests/manual-tests/gallery.py
 ```
 
+## Runtime tracing
+
+SciQLopPlots ships with a built-in tracer that emits Chrome trace JSON, viewable in
+[Perfetto](https://ui.perfetto.dev/), [Speedscope](https://www.speedscope.app/), or
+`chrome://tracing`. Always compiled in, runtime-toggled, ~1 ns when off.
+
+Enable for a session, then open the file in Perfetto:
+
+```python
+from SciQLopPlots import tracing
+
+with tracing.session("/tmp/sciqlop.json"):
+    panel.zoom_in_a_lot()       # whatever's slow
+```
+
+Annotate Python work to land alongside the C++ zones (`plot.replot`,
+`setdata.colormap`, `resample.async_2d`, …):
+
+```python
+with tracing.zone("speasy.fetch", cat="data", product="amda/mms_fgm"):
+    data = speasy.get_data(...)
+
+@tracing.traced("layer.eval", cat="layer")
+def render_layer(...): ...
+
+tracing.counter("queue_depth", q.size(), cat="fetch")
+```
+
+You can also auto-enable at process start with the `SCIQLOP_TRACE` env var:
+
+```bash
+SCIQLOP_TRACE=/tmp/sciqlop.json python my_script.py
+```
+
+When `tracy_enable=true` is also passed at build time, the same `PROFILE_HERE_N`
+sites feed both the Chrome JSON tracer and the Tracy live-streaming view.
+
 ## Building from source
 
 Requires Qt6, PySide6 == 6.11.0, a C++20 compiler, and Meson.

--- a/SciQLopPlots/__init__.py
+++ b/SciQLopPlots/__init__.py
@@ -11,6 +11,8 @@ import sys
 
 sys.modules["SciQLopPlotsBindings"] = SciQLopPlotsBindings
 
+from . import tracing  # noqa: E402,F401  -- runtime tracer facade
+
 __version__ = '0.23.0'
 
 def _merge_kwargs(kwargs, **kwargs2):

--- a/SciQLopPlots/bindings/bindings.h
+++ b/SciQLopPlots/bindings/bindings.h
@@ -70,6 +70,8 @@
 
 #include <SciQLopPlots/Icons/icons.hpp>
 
+#include <SciQLopPlots/Tracing.hpp>
+
 #include <qcustomplot.h>
 
 #endif // SCIQLOPPLOTS_BINDINGS_H

--- a/SciQLopPlots/bindings/bindings.xml
+++ b/SciQLopPlots/bindings/bindings.xml
@@ -1107,6 +1107,147 @@
             }
         </inject-code>
     </add-function>
+
+    <!-- Runtime tracer: Chrome JSON / Perfetto-compatible event logger. -->
+    <add-function signature="tracing_enable(std::string)" return-type="void">
+        <extra-includes>
+            <include file-name="SciQLopPlots/Tracing.hpp" location="global"/>
+        </extra-includes>
+        <inject-code class="target" position="beginning">
+            try { SciQLopPlots::tracing::enable(%1); }
+            catch (const std::exception&amp; e) { PyErr_SetString(PyExc_RuntimeError, e.what()); return nullptr; }
+        </inject-code>
+    </add-function>
+
+    <add-function signature="tracing_disable()" return-type="void">
+        <extra-includes>
+            <include file-name="SciQLopPlots/Tracing.hpp" location="global"/>
+        </extra-includes>
+        <inject-code class="target" position="beginning">
+            try { SciQLopPlots::tracing::disable(); }
+            catch (const std::exception&amp; e) { PyErr_SetString(PyExc_RuntimeError, e.what()); return nullptr; }
+        </inject-code>
+    </add-function>
+
+    <add-function signature="tracing_flush()" return-type="void">
+        <extra-includes>
+            <include file-name="SciQLopPlots/Tracing.hpp" location="global"/>
+        </extra-includes>
+        <inject-code class="target" position="beginning">
+            try { SciQLopPlots::tracing::flush(); }
+            catch (const std::exception&amp; e) { PyErr_SetString(PyExc_RuntimeError, e.what()); return nullptr; }
+        </inject-code>
+    </add-function>
+
+    <add-function signature="tracing_is_enabled()" return-type="bool">
+        <extra-includes>
+            <include file-name="SciQLopPlots/Tracing.hpp" location="global"/>
+        </extra-includes>
+        <inject-code class="target" position="beginning">
+            try { auto v = SciQLopPlots::tracing::is_enabled(); %PYARG_0 = PyBool_FromLong(v ? 1 : 0); }
+            catch (const std::exception&amp; e) { PyErr_SetString(PyExc_RuntimeError, e.what()); return nullptr; }
+        </inject-code>
+    </add-function>
+
+    <add-function signature="tracing_set_thread_name(std::string)" return-type="void">
+        <extra-includes>
+            <include file-name="SciQLopPlots/Tracing.hpp" location="global"/>
+        </extra-includes>
+        <inject-code class="target" position="beginning">
+            try { SciQLopPlots::tracing::set_thread_name(%1); }
+            catch (const std::exception&amp; e) { PyErr_SetString(PyExc_RuntimeError, e.what()); return nullptr; }
+        </inject-code>
+    </add-function>
+
+    <add-function signature="tracing_sync_zone_begin(std::string, std::string)" return-type="unsigned long long">
+        <extra-includes>
+            <include file-name="SciQLopPlots/Tracing.hpp" location="global"/>
+        </extra-includes>
+        <inject-code class="target" position="beginning">
+            try { auto h = SciQLopPlots::tracing::sync_zone_begin(%1, %2); %PYARG_0 = PyLong_FromUnsignedLongLong(h); }
+            catch (const std::exception&amp; e) { PyErr_SetString(PyExc_RuntimeError, e.what()); return nullptr; }
+        </inject-code>
+    </add-function>
+
+    <add-function signature="tracing_sync_zone_end(unsigned long long)" return-type="void">
+        <extra-includes>
+            <include file-name="SciQLopPlots/Tracing.hpp" location="global"/>
+        </extra-includes>
+        <inject-code class="target" position="beginning">
+            try { SciQLopPlots::tracing::sync_zone_end(%1); }
+            catch (const std::exception&amp; e) { PyErr_SetString(PyExc_RuntimeError, e.what()); return nullptr; }
+        </inject-code>
+    </add-function>
+
+    <add-function signature="tracing_sync_zone_add_int(unsigned long long, std::string, long long)" return-type="void">
+        <extra-includes>
+            <include file-name="SciQLopPlots/Tracing.hpp" location="global"/>
+        </extra-includes>
+        <inject-code class="target" position="beginning">
+            try { SciQLopPlots::tracing::sync_zone_add_int(%1, %2, %3); }
+            catch (const std::exception&amp; e) { PyErr_SetString(PyExc_RuntimeError, e.what()); return nullptr; }
+        </inject-code>
+    </add-function>
+
+    <add-function signature="tracing_sync_zone_add_double(unsigned long long, std::string, double)" return-type="void">
+        <extra-includes>
+            <include file-name="SciQLopPlots/Tracing.hpp" location="global"/>
+        </extra-includes>
+        <inject-code class="target" position="beginning">
+            try { SciQLopPlots::tracing::sync_zone_add_double(%1, %2, %3); }
+            catch (const std::exception&amp; e) { PyErr_SetString(PyExc_RuntimeError, e.what()); return nullptr; }
+        </inject-code>
+    </add-function>
+
+    <add-function signature="tracing_sync_zone_add_bool(unsigned long long, std::string, bool)" return-type="void">
+        <extra-includes>
+            <include file-name="SciQLopPlots/Tracing.hpp" location="global"/>
+        </extra-includes>
+        <inject-code class="target" position="beginning">
+            try { SciQLopPlots::tracing::sync_zone_add_bool(%1, %2, %3); }
+            catch (const std::exception&amp; e) { PyErr_SetString(PyExc_RuntimeError, e.what()); return nullptr; }
+        </inject-code>
+    </add-function>
+
+    <add-function signature="tracing_sync_zone_add_str(unsigned long long, std::string, std::string)" return-type="void">
+        <extra-includes>
+            <include file-name="SciQLopPlots/Tracing.hpp" location="global"/>
+        </extra-includes>
+        <inject-code class="target" position="beginning">
+            try { SciQLopPlots::tracing::sync_zone_add_str(%1, %2, %3); }
+            catch (const std::exception&amp; e) { PyErr_SetString(PyExc_RuntimeError, e.what()); return nullptr; }
+        </inject-code>
+    </add-function>
+
+    <add-function signature="tracing_async_begin(std::string, std::string)" return-type="unsigned long long">
+        <extra-includes>
+            <include file-name="SciQLopPlots/Tracing.hpp" location="global"/>
+        </extra-includes>
+        <inject-code class="target" position="beginning">
+            try { auto h = SciQLopPlots::tracing::async_begin(%1.c_str(), %2.empty() ? nullptr : %2.c_str()); %PYARG_0 = PyLong_FromUnsignedLongLong(h); }
+            catch (const std::exception&amp; e) { PyErr_SetString(PyExc_RuntimeError, e.what()); return nullptr; }
+        </inject-code>
+    </add-function>
+
+    <add-function signature="tracing_async_end(unsigned long long)" return-type="void">
+        <extra-includes>
+            <include file-name="SciQLopPlots/Tracing.hpp" location="global"/>
+        </extra-includes>
+        <inject-code class="target" position="beginning">
+            try { SciQLopPlots::tracing::async_end(%1); }
+            catch (const std::exception&amp; e) { PyErr_SetString(PyExc_RuntimeError, e.what()); return nullptr; }
+        </inject-code>
+    </add-function>
+
+    <add-function signature="tracing_counter(std::string, double, std::string)" return-type="void">
+        <extra-includes>
+            <include file-name="SciQLopPlots/Tracing.hpp" location="global"/>
+        </extra-includes>
+        <inject-code class="target" position="beginning">
+            try { SciQLopPlots::tracing::counter(%1.c_str(), %2, %3.empty() ? nullptr : %3.c_str()); }
+            catch (const std::exception&amp; e) { PyErr_SetString(PyExc_RuntimeError, e.what()); return nullptr; }
+        </inject-code>
+    </add-function>
 </typesystem>
 
 

--- a/SciQLopPlots/meson.build
+++ b/SciQLopPlots/meson.build
@@ -51,7 +51,7 @@ shiboken_typesystem  = run_command(python3, shiboken_helper, '--qmake', qmake.fu
 sciqlopplots_bindings_src = []
 sciqlopplots_bindings_headers = files('bindings/bindings.h')
 
-sciqlopplots_python_sources = ['__init__.py', 'event.py', 'pipeline.py', 'properties.py', 'dsp.py']
+sciqlopplots_python_sources = ['__init__.py', 'event.py', 'pipeline.py', 'properties.py', 'dsp.py', 'tracing.py']
 foreach py_src:sciqlopplots_python_sources
   configure_file(input:py_src,output:py_src, copy:true)
 endforeach
@@ -187,6 +187,7 @@ sources = moc_files \
         + resources_files \
         + [
             '../src/Profiling.cpp',
+            '../src/Tracing.cpp',
             '../src/SciQLopPlotInterface.cpp',
             '../src/SciQLopPlot.cpp',
             '../src/SciQLopPlotLegend.cpp',

--- a/SciQLopPlots/tracing.py
+++ b/SciQLopPlots/tracing.py
@@ -1,0 +1,133 @@
+"""Python facade for the SciQLopPlots runtime tracer.
+
+Records Chrome trace JSON / Perfetto-compatible events from both C++ and Python
+into the same trace file. Toggle at runtime; ship in production.
+
+Quick start
+-----------
+>>> from SciQLopPlots import tracing
+>>> tracing.enable("/tmp/trace.json")
+>>> with tracing.zone("fetch", cat="data", product="amda/mms_fgm"):
+...     ...  # work
+>>> tracing.disable()  # flushes and closes the file
+
+Or set the env var SCIQLOP_TRACE=/tmp/trace.json before launching.
+"""
+from __future__ import annotations
+
+import functools
+from typing import Any, Optional
+
+from . import SciQLopPlotsBindings as _b
+
+
+def enable(path: str) -> None:
+    _b.tracing_enable(path)
+
+
+def disable() -> None:
+    _b.tracing_disable()
+
+
+def flush() -> None:
+    _b.tracing_flush()
+
+
+def is_enabled() -> bool:
+    return _b.tracing_is_enabled()
+
+
+def set_thread_name(name: str) -> None:
+    _b.tracing_set_thread_name(name)
+
+
+def counter(name: str, value: float, cat: str = "") -> None:
+    _b.tracing_counter(name, float(value), cat)
+
+
+def async_begin(name: str, cat: str = "") -> int:
+    return _b.tracing_async_begin(name, cat)
+
+
+def async_end(handle: int) -> None:
+    _b.tracing_async_end(handle)
+
+
+def _add_arg(handle: int, key: str, value: Any) -> None:
+    if isinstance(value, bool):
+        _b.tracing_sync_zone_add_bool(handle, key, value)
+    elif isinstance(value, int):
+        _b.tracing_sync_zone_add_int(handle, key, value)
+    elif isinstance(value, float):
+        _b.tracing_sync_zone_add_double(handle, key, value)
+    else:
+        _b.tracing_sync_zone_add_str(handle, key, str(value))
+
+
+class zone:
+    """Context manager for a synchronous trace zone.
+
+    Example:
+        with tracing.zone("fetch", cat="data", n_points=4096): ...
+    """
+
+    __slots__ = ("_name", "_cat", "_args", "_handle")
+
+    def __init__(self, name: str, cat: str = "", **args: Any) -> None:
+        self._name = name
+        self._cat = cat
+        self._args = args
+        self._handle = 0
+
+    def __enter__(self) -> "zone":
+        self._handle = _b.tracing_sync_zone_begin(self._name, self._cat)
+        if self._handle and self._args:
+            for k, v in self._args.items():
+                _add_arg(self._handle, k, v)
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        if self._handle:
+            _b.tracing_sync_zone_end(self._handle)
+            self._handle = 0
+
+
+def traced(name: Optional[str] = None, cat: str = ""):
+    """Decorator that wraps a function call in a synchronous zone."""
+
+    def decorator(fn):
+        zname = name or fn.__qualname__
+
+        @functools.wraps(fn)
+        def wrapper(*args, **kwargs):
+            with zone(zname, cat=cat):
+                return fn(*args, **kwargs)
+
+        return wrapper
+
+    return decorator
+
+
+class session:
+    """Context manager that enables tracing for the duration of a `with` block.
+
+    Example (e.g. from the SciQLop Jupyter console wrapping a slow operation):
+
+        from SciQLopPlots import tracing
+        with tracing.session("/tmp/slow_pan.json"):
+            # ...reproduce the slow path...
+            ...
+        # File is flushed and closed at exit. Open in https://ui.perfetto.dev/
+    """
+
+    __slots__ = ("_path",)
+
+    def __init__(self, path: str) -> None:
+        self._path = path
+
+    def __enter__(self) -> "session":
+        enable(self._path)
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        disable()

--- a/include/SciQLopPlots/Profiling.hpp
+++ b/include/SciQLopPlots/Profiling.hpp
@@ -25,8 +25,11 @@
 
 // NeoQCP's Profiling.hpp may have defined the PROFILE_* macros first (it ships
 // in a subproject and is pulled in transitively via QCustomPlot headers).
-// Undefine them before redefining so the SciQLopPlots versions — which also
-// feed the runtime Chrome JSON tracer — always win in TUs that pull in both.
+// NeoQCP guards its own #defines with #ifndef (since SciQLop/NeoQCP#26), so it
+// won't override us if we're included first — but if NeoQCP loads first in a
+// TU, its definitions are in place and our redefines would warn. Undefine
+// them so the SciQLopPlots versions — which also feed the runtime Chrome JSON
+// tracer — always win regardless of include order.
 #ifdef PROFILE_HERE
 #  undef PROFILE_HERE
 #endif

--- a/include/SciQLopPlots/Profiling.hpp
+++ b/include/SciQLopPlots/Profiling.hpp
@@ -21,31 +21,44 @@
 ----------------------------------------------------------------------------*/
 #pragma once
 
+#include "SciQLopPlots/Tracing.hpp"
+
+// NeoQCP's Profiling.hpp may have defined the PROFILE_* macros first (it ships
+// in a subproject and is pulled in transitively via QCustomPlot headers).
+// Undefine them before redefining so the SciQLopPlots versions — which also
+// feed the runtime Chrome JSON tracer — always win in TUs that pull in both.
+#ifdef PROFILE_HERE
+#  undef PROFILE_HERE
+#endif
+#ifdef PROFILE_HERE_N
+#  undef PROFILE_HERE_N
+#endif
+#ifdef PROFILE_HERE_NC
+#  undef PROFILE_HERE_NC
+#endif
+#ifdef PROFILE_PASS_VALUE
+#  undef PROFILE_PASS_VALUE
+#endif
+
 #ifdef TRACY_ENABLE
-
-#include <tracy/Tracy.hpp>
-#define PROFILE_HERE ZoneScoped
-#define PROFILE_HERE_N(name) ZoneScopedN(name)
-#define PROFILE_HERE_NC(name, color) ZoneScopedNC(name, color)
-#define PROFILE_PASS_VALUE(value) ZoneValue(value)
-
-
-#ifdef PROFILE_MEMORY
-
-#include <cstddef>
-#include <new>
-
+#  include <tracy/Tracy.hpp>
+#  define SCIQLOP_TRACY_ZONE() ZoneScoped
+#  define SCIQLOP_TRACY_ZONE_N(name) ZoneScopedN(name)
+#  define SCIQLOP_TRACY_ZONE_NC(name, color) ZoneScopedNC(name, color)
+#  define PROFILE_PASS_VALUE(value) ZoneValue(value)
+#  ifdef PROFILE_MEMORY
+#    include <cstddef>
+#    include <new>
 void* operator new(std::size_t n);
-
 void operator delete(void* ptr) noexcept;
-
-#endif
-
+#  endif
 #else
-
-#define PROFILE_HERE
-#define PROFILE_HERE_N(name)
-#define PROFILE_HERE_NC(name, color)
-#define PROFILE_PASS_VALUE(value)
-
+#  define SCIQLOP_TRACY_ZONE()              ((void)0)
+#  define SCIQLOP_TRACY_ZONE_N(name)        ((void)0)
+#  define SCIQLOP_TRACY_ZONE_NC(name, color) ((void)0)
+#  define PROFILE_PASS_VALUE(value)         ((void)0)
 #endif
+
+#define PROFILE_HERE              SCIQLOP_TRACE_ZONE(__func__);              SCIQLOP_TRACY_ZONE()
+#define PROFILE_HERE_N(name)      SCIQLOP_TRACE_ZONE(name);                  SCIQLOP_TRACY_ZONE_N(name)
+#define PROFILE_HERE_NC(name, color) SCIQLOP_TRACE_ZONE(name);               SCIQLOP_TRACY_ZONE_NC(name, color)

--- a/include/SciQLopPlots/Tracing.hpp
+++ b/include/SciQLopPlots/Tracing.hpp
@@ -1,0 +1,81 @@
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace SciQLopPlots::tracing
+{
+
+void enable(const std::string& output_path);
+void disable();
+void flush();
+bool is_enabled() noexcept;
+void set_thread_name(const std::string& name);
+
+struct ArgValue
+{
+    enum class Type
+    {
+        Int,
+        Double,
+        Bool,
+        String
+    };
+    Type type;
+    int64_t i = 0;
+    double d = 0.0;
+    bool b = false;
+    std::string s;
+};
+
+class ScopedZone
+{
+public:
+    explicit ScopedZone(const char* name, const char* category = nullptr) noexcept;
+    ~ScopedZone() noexcept;
+
+    ScopedZone(const ScopedZone&) = delete;
+    ScopedZone& operator=(const ScopedZone&) = delete;
+    ScopedZone(ScopedZone&&) = delete;
+    ScopedZone& operator=(ScopedZone&&) = delete;
+
+    void add_arg(const char* key, int64_t value);
+    void add_arg(const char* key, double value);
+    void add_arg(const char* key, bool value);
+    void add_arg(const char* key, const std::string& value);
+
+private:
+    int64_t start_ns_;
+    const char* name_;
+    const char* category_;
+    std::vector<std::pair<std::string, ArgValue>> args_;
+};
+
+uint64_t async_begin(const char* name, const char* category = nullptr);
+void async_end(uint64_t id);
+void counter(const char* name, double value, const char* category = nullptr);
+
+// Binding-friendly synchronous-zone API.
+// sync_zone_begin/sync_zone_end emit a single complete ("X") event.
+// Strings are copied so callers (e.g. Python) need not keep them alive.
+// Pass the returned handle to add args and to end.
+// Returns 0 if tracing is disabled.
+uint64_t sync_zone_begin(const std::string& name, const std::string& category = std::string {});
+void sync_zone_add_int(uint64_t handle, const std::string& key, int64_t value);
+void sync_zone_add_double(uint64_t handle, const std::string& key, double value);
+void sync_zone_add_bool(uint64_t handle, const std::string& key, bool value);
+void sync_zone_add_str(uint64_t handle, const std::string& key, const std::string& value);
+void sync_zone_end(uint64_t handle);
+
+}  // namespace SciQLopPlots::tracing
+
+#define SCIQLOP_TRACE_CONCAT_(a, b) a##b
+#define SCIQLOP_TRACE_CONCAT(a, b) SCIQLOP_TRACE_CONCAT_(a, b)
+
+#define SCIQLOP_TRACE_ZONE(name) \
+    ::SciQLopPlots::tracing::ScopedZone SCIQLOP_TRACE_CONCAT(_sciqlop_zone_, __LINE__)(name)
+
+#define SCIQLOP_TRACE_ZONE_CAT(name, cat) \
+    ::SciQLopPlots::tracing::ScopedZone SCIQLOP_TRACE_CONCAT(_sciqlop_zone_, __LINE__)(name, cat)

--- a/src/AbstractResampler.cpp
+++ b/src/AbstractResampler.cpp
@@ -20,9 +20,11 @@
 -- Mail : alexis.jeandet@member.fsf.org
 ----------------------------------------------------------------------------*/
 #include "SciQLopPlots/Plotables/Resamplers/AbstractResampler.hpp"
+#include "SciQLopPlots/Profiling.hpp"
 
 void AbstractResampler1d::_async_resample()
 {
+    PROFILE_HERE_N("resample.async_1d");
     _async_resample_callback();
 }
 
@@ -38,12 +40,14 @@ AbstractResampler1d::AbstractResampler1d(SciQLopPlottableInterface* parent, std:
 
 void AbstractResampler1d::resample(const QCPRange new_range)
 {
+    PROFILE_HERE_N("resample.dispatch_1d");
     this->set_next_plot_range(new_range);
     emit _resample_sig();
 }
 
 void AbstractResampler2d::_async_resample()
 {
+    PROFILE_HERE_N("resample.async_2d");
     _async_resample_callback();
 }
 
@@ -58,6 +62,7 @@ AbstractResampler2d::AbstractResampler2d(SciQLopPlottableInterface* parent) : QO
 
 void AbstractResampler2d::resample(const QCPRange new_range)
 {
+    PROFILE_HERE_N("resample.dispatch_2d");
     this->set_next_plot_range(new_range);
     emit _resample_sig();
 }

--- a/src/SciQLopColorMap.cpp
+++ b/src/SciQLopColorMap.cpp
@@ -20,6 +20,8 @@
 -- Mail : alexis.jeandet@member.fsf.org
 ----------------------------------------------------------------------------*/
 #include "SciQLopPlots/Plotables/SciQLopColorMap.hpp"
+#include "SciQLopPlots/Profiling.hpp"
+#include "SciQLopPlots/Tracing.hpp"
 #include "SciQLopPlots/constants.hpp"
 
 void SciQLopColorMap::_cmap_got_destroyed()
@@ -61,6 +63,11 @@ SciQLopColorMap::~SciQLopColorMap()
 
 void SciQLopColorMap::set_data(PyBuffer x, PyBuffer y, PyBuffer z)
 {
+    PROFILE_HERE_N("setdata.colormap");
+    ::SciQLopPlots::tracing::ScopedZone _sz("setdata.colormap", "setdata");
+    _sz.add_arg("nx", static_cast<int64_t>(x.flat_size()));
+    _sz.add_arg("ny", static_cast<int64_t>(y.flat_size()));
+    _sz.add_arg("nz", static_cast<int64_t>(z.flat_size()));
     if (!_cmap || !x.is_valid() || !y.is_valid() || !z.is_valid())
         return;
 

--- a/src/SciQLopMultiGraphBase.cpp
+++ b/src/SciQLopMultiGraphBase.cpp
@@ -1,6 +1,8 @@
 #include "SciQLopPlots/Plotables/SciQLopMultiGraphBase.hpp"
 #include "SciQLopPlots/Plotables/AxisHelpers.hpp"
 #include "SciQLopPlots/Plotables/SciQLopGraphComponent.hpp"
+#include "SciQLopPlots/Profiling.hpp"
+#include "SciQLopPlots/Tracing.hpp"
 #include <datasource/row-major-multi-datasource.h>
 #include <datasource/soa-multi-datasource.h>
 #include <vector>
@@ -116,6 +118,9 @@ void SciQLopMultiGraphBase::sync_components()
 
 void SciQLopMultiGraphBase::set_data(PyBuffer x, PyBuffer y)
 {
+    PROFILE_HERE_N("setdata.multigraph");
+    ::SciQLopPlots::tracing::ScopedZone _sz("setdata.multigraph", "setdata");
+    _sz.add_arg("n_points", static_cast<int64_t>(x.flat_size()));
     if (!_multiGraph || !x.is_valid() || !y.is_valid())
         return;
 

--- a/src/SciQLopPlot.cpp
+++ b/src/SciQLopPlot.cpp
@@ -20,6 +20,7 @@
 -- Mail : alexis.jeandet@member.fsf.org
 ----------------------------------------------------------------------------*/
 #include "SciQLopPlots/SciQLopPlot.hpp"
+#include "SciQLopPlots/Profiling.hpp"
 #include "SciQLopPlots/SciQLopTheme.hpp"
 #include "SciQLopPlots/Inspector/Model/Model.hpp"
 #include "SciQLopPlots/Items/SciQLopPlotItem.hpp"
@@ -218,6 +219,7 @@ QMargins SciQLopPlot::minimal_axis_margins()
 
 void SciQLopPlot::replot(RefreshPriority priority)
 {
+    PROFILE_HERE_N("plot.replot");
     QCustomPlot::replot(priority);
 }
 
@@ -789,6 +791,7 @@ void SciQLopPlot::minimize_margins()
 
 void SciQLopPlot::replot(bool immediate)
 {
+    PROFILE_HERE_N("plot.replot.dispatch");
     if (immediate)
         m_impl->replot();
     else

--- a/src/Tracing.cpp
+++ b/src/Tracing.cpp
@@ -1,0 +1,588 @@
+#include "SciQLopPlots/Tracing.hpp"
+
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <cstdio>
+#include <cstdlib>
+#include <fstream>
+#include <memory>
+#include <mutex>
+#include <set>
+#include <sstream>
+#include <string>
+#include <thread>
+#include <vector>
+
+#ifdef __linux__
+#  include <sys/syscall.h>
+#  include <unistd.h>
+#endif
+
+namespace SciQLopPlots::tracing
+{
+namespace
+{
+
+    int64_t now_ns() noexcept
+    {
+        using namespace std::chrono;
+        return duration_cast<nanoseconds>(steady_clock::now().time_since_epoch()).count();
+    }
+
+    int64_t process_id() noexcept
+    {
+#ifdef __linux__
+        return ::getpid();
+#else
+        return 0;
+#endif
+    }
+
+    int64_t thread_id() noexcept
+    {
+#ifdef __linux__
+        return ::syscall(SYS_gettid);
+#else
+        return static_cast<int64_t>(
+            std::hash<std::thread::id> {}(std::this_thread::get_id()));
+#endif
+    }
+
+    std::string escape(const std::string& s)
+    {
+        std::string out;
+        out.reserve(s.size());
+        for (char c : s)
+        {
+            switch (c)
+            {
+                case '"': out += "\\\""; break;
+                case '\\': out += "\\\\"; break;
+                case '\n': out += "\\n"; break;
+                case '\r': out += "\\r"; break;
+                case '\t': out += "\\t"; break;
+                default:
+                    if (static_cast<unsigned char>(c) < 0x20)
+                    {
+                        char buf[8];
+                        std::snprintf(buf, sizeof(buf), "\\u%04x",
+                            static_cast<unsigned>(static_cast<unsigned char>(c)));
+                        out += buf;
+                    }
+                    else
+                        out += c;
+            }
+        }
+        return out;
+    }
+
+    std::string format_double(double v)
+    {
+        std::ostringstream s;
+        s.precision(17);
+        s << v;
+        return s.str();
+    }
+
+    enum class Phase : uint8_t
+    {
+        X,
+        AsyncBegin,
+        AsyncEnd,
+        Counter
+    };
+
+    struct Event
+    {
+        Phase phase;
+        std::string name;
+        std::string category;
+        int64_t ts_ns = 0;
+        int64_t dur_ns = 0;
+        int64_t tid = 0;
+        uint64_t async_id = 0;
+        double counter_value = 0.0;
+        std::vector<std::pair<std::string, ArgValue>> args;
+    };
+
+    struct ThreadBuffer
+    {
+        std::mutex mu;
+        std::vector<Event> events;
+        int64_t tid = 0;
+        std::string name;
+    };
+
+    class Tracer
+    {
+    public:
+        static Tracer& instance()
+        {
+            static Tracer t;
+            return t;
+        }
+
+        std::atomic<bool> enabled { false };
+
+        void enable(const std::string& path)
+        {
+            std::lock_guard<std::mutex> lk(state_mu_);
+            if (enabled.load(std::memory_order_acquire))
+                disable_locked();
+            out_.open(path, std::ios::binary | std::ios::trunc);
+            if (!out_.is_open())
+                return;
+            out_ << "{\"displayTimeUnit\":\"ns\",\"traceEvents\":[\n";
+            first_event_ = true;
+            origin_ns_ = now_ns();
+            clear_all_buffers_locked();
+            known_tids_.clear();
+            emit_process_metadata_locked();
+            stop_flush_.store(false);
+            enabled.store(true, std::memory_order_release);
+            flush_thread_ = std::thread([this] { flush_loop(); });
+        }
+
+        void disable()
+        {
+            std::lock_guard<std::mutex> lk(state_mu_);
+            disable_locked();
+        }
+
+        void flush()
+        {
+            if (!enabled.load(std::memory_order_acquire))
+                return;
+            std::lock_guard<std::mutex> flk(flush_mu_);
+            if (!enabled.load(std::memory_order_acquire))
+                return;
+            drain_all_locked();
+            out_.flush();
+        }
+
+        void register_buffer(ThreadBuffer* b)
+        {
+            std::lock_guard<std::mutex> lk(buffers_mu_);
+            buffers_.push_back(b);
+        }
+
+        int64_t origin_ns() const noexcept { return origin_ns_; }
+
+    private:
+        std::mutex state_mu_;   // serializes enable/disable transitions
+        std::mutex flush_mu_;   // protects out_, first_event_, origin_ns_, known_tids_ during drains
+        std::mutex buffers_mu_; // protects buffers_ vector
+        std::vector<ThreadBuffer*> buffers_;
+        std::ofstream out_;
+        bool first_event_ = true;
+        int64_t origin_ns_ = 0;
+        std::set<int64_t> known_tids_;
+        std::thread flush_thread_;
+        std::condition_variable cv_;
+        std::mutex cv_mu_;
+        std::atomic<bool> stop_flush_ { false };
+
+        void disable_locked()
+        {
+            if (!enabled.exchange(false, std::memory_order_acq_rel))
+                return;
+            stop_flush_.store(true, std::memory_order_release);
+            cv_.notify_all();
+            if (flush_thread_.joinable())
+                flush_thread_.join();
+            std::lock_guard<std::mutex> flk(flush_mu_);
+            drain_all_locked();
+            out_ << "\n]}\n";
+            out_.flush();
+            out_.close();
+            first_event_ = true;
+        }
+
+        void flush_loop()
+        {
+            while (!stop_flush_.load(std::memory_order_acquire))
+            {
+                {
+                    std::unique_lock<std::mutex> lk(cv_mu_);
+                    cv_.wait_for(lk, std::chrono::milliseconds(250),
+                        [&] { return stop_flush_.load(std::memory_order_acquire); });
+                }
+                if (!enabled.load(std::memory_order_acquire))
+                    continue;
+                std::lock_guard<std::mutex> flk(flush_mu_);
+                if (enabled.load(std::memory_order_acquire))
+                    drain_all_locked();
+            }
+        }
+
+        void clear_all_buffers_locked()
+        {
+            std::lock_guard<std::mutex> lk(buffers_mu_);
+            for (auto* b : buffers_)
+            {
+                std::lock_guard<std::mutex> lk2(b->mu);
+                b->events.clear();
+            }
+        }
+
+        void drain_all_locked()
+        {
+            std::vector<ThreadBuffer*> bufs;
+            {
+                std::lock_guard<std::mutex> lk(buffers_mu_);
+                bufs = buffers_;
+            }
+            for (auto* b : bufs)
+            {
+                std::vector<Event> local;
+                std::string thread_name;
+                int64_t tid = b->tid;
+                {
+                    std::lock_guard<std::mutex> lk(b->mu);
+                    local.swap(b->events);
+                    thread_name = b->name;
+                }
+                if (!local.empty() && known_tids_.insert(tid).second)
+                    emit_thread_metadata_locked(tid, thread_name);
+                for (auto& e : local)
+                    emit_event_locked(e);
+            }
+        }
+
+        void emit_process_metadata_locked()
+        {
+            std::ostringstream s;
+            s << "{\"ph\":\"M\",\"name\":\"process_name\",\"pid\":" << process_id()
+              << ",\"tid\":0,\"args\":{\"name\":\"sciqlop\"}}";
+            write_raw_locked(s.str());
+        }
+
+        void emit_thread_metadata_locked(int64_t tid, const std::string& name)
+        {
+            std::ostringstream s;
+            std::string label = name.empty() ? std::to_string(tid) : name;
+            s << "{\"ph\":\"M\",\"name\":\"thread_name\",\"pid\":" << process_id()
+              << ",\"tid\":" << tid << ",\"args\":{\"name\":\"" << escape(label) << "\"}}";
+            write_raw_locked(s.str());
+        }
+
+        void emit_event_locked(const Event& e)
+        {
+            std::ostringstream s;
+            const int64_t ts_us = (e.ts_ns - origin_ns_) / 1000;
+            switch (e.phase)
+            {
+                case Phase::X:
+                    s << "{\"ph\":\"X\",\"name\":\"" << escape(e.name) << "\"";
+                    if (!e.category.empty())
+                        s << ",\"cat\":\"" << escape(e.category) << "\"";
+                    s << ",\"ts\":" << ts_us << ",\"dur\":" << (e.dur_ns / 1000)
+                      << ",\"pid\":" << process_id() << ",\"tid\":" << e.tid;
+                    if (!e.args.empty())
+                        s << ",\"args\":" << format_args(e.args);
+                    s << "}";
+                    break;
+                case Phase::AsyncBegin:
+                    s << "{\"ph\":\"b\",\"name\":\"" << escape(e.name) << "\"";
+                    if (!e.category.empty())
+                        s << ",\"cat\":\"" << escape(e.category) << "\"";
+                    s << ",\"ts\":" << ts_us << ",\"id\":\"0x" << std::hex << e.async_id
+                      << std::dec << "\",\"pid\":" << process_id() << ",\"tid\":" << e.tid;
+                    if (!e.args.empty())
+                        s << ",\"args\":" << format_args(e.args);
+                    s << "}";
+                    break;
+                case Phase::AsyncEnd:
+                    s << "{\"ph\":\"e\",\"name\":\"" << escape(e.name) << "\"";
+                    if (!e.category.empty())
+                        s << ",\"cat\":\"" << escape(e.category) << "\"";
+                    s << ",\"ts\":" << ts_us << ",\"id\":\"0x" << std::hex << e.async_id
+                      << std::dec << "\",\"pid\":" << process_id() << ",\"tid\":" << e.tid << "}";
+                    break;
+                case Phase::Counter:
+                    s << "{\"ph\":\"C\",\"name\":\"" << escape(e.name) << "\"";
+                    if (!e.category.empty())
+                        s << ",\"cat\":\"" << escape(e.category) << "\"";
+                    s << ",\"ts\":" << ts_us << ",\"pid\":" << process_id()
+                      << ",\"tid\":" << e.tid << ",\"args\":{\"" << escape(e.name)
+                      << "\":" << format_double(e.counter_value) << "}}";
+                    break;
+            }
+            write_raw_locked(s.str());
+        }
+
+        void write_raw_locked(const std::string& json)
+        {
+            if (!first_event_)
+                out_ << ",\n";
+            out_ << "  " << json;
+            first_event_ = false;
+        }
+
+        static std::string format_args(
+            const std::vector<std::pair<std::string, ArgValue>>& args)
+        {
+            std::ostringstream s;
+            s << "{";
+            bool first = true;
+            for (const auto& [k, v] : args)
+            {
+                if (!first)
+                    s << ",";
+                first = false;
+                s << "\"" << escape(k) << "\":";
+                switch (v.type)
+                {
+                    case ArgValue::Type::Int: s << v.i; break;
+                    case ArgValue::Type::Double: s << format_double(v.d); break;
+                    case ArgValue::Type::Bool: s << (v.b ? "true" : "false"); break;
+                    case ArgValue::Type::String:
+                        s << "\"" << escape(v.s) << "\"";
+                        break;
+                }
+            }
+            s << "}";
+            return s.str();
+        }
+    };
+
+    struct ThreadLocalBuffer
+    {
+        ThreadBuffer* buf;
+        ThreadLocalBuffer() : buf(new ThreadBuffer())
+        {
+            buf->tid = thread_id();
+            Tracer::instance().register_buffer(buf);
+        }
+        ~ThreadLocalBuffer() = default;  // intentionally leak: tracer owns lifetime
+    };
+
+    ThreadBuffer* tls_buffer()
+    {
+        thread_local ThreadLocalBuffer tl;
+        return tl.buf;
+    }
+
+    void push_event(Event e)
+    {
+        ThreadBuffer* b = tls_buffer();
+        e.tid = b->tid;
+        std::lock_guard<std::mutex> lk(b->mu);
+        b->events.push_back(std::move(e));
+    }
+
+    struct EnvAutoEnable
+    {
+        EnvAutoEnable()
+        {
+            std::atexit([] {
+                if (Tracer::instance().enabled.load(std::memory_order_relaxed))
+                    Tracer::instance().disable();
+            });
+            if (const char* p = std::getenv("SCIQLOP_TRACE"))
+                if (p[0] != '\0')
+                    Tracer::instance().enable(p);
+        }
+    };
+    EnvAutoEnable s_env_auto_enable;
+
+}  // namespace
+
+void enable(const std::string& path) { Tracer::instance().enable(path); }
+void disable() { Tracer::instance().disable(); }
+void flush() { Tracer::instance().flush(); }
+bool is_enabled() noexcept
+{
+    return Tracer::instance().enabled.load(std::memory_order_relaxed);
+}
+
+void set_thread_name(const std::string& name)
+{
+    ThreadBuffer* b = tls_buffer();
+    std::lock_guard<std::mutex> lk(b->mu);
+    b->name = name;
+}
+
+ScopedZone::ScopedZone(const char* name, const char* category) noexcept
+    : start_ns_(0), name_(name), category_(category)
+{
+    if (Tracer::instance().enabled.load(std::memory_order_relaxed))
+        start_ns_ = now_ns();
+}
+
+ScopedZone::~ScopedZone() noexcept
+{
+    if (start_ns_ == 0)
+        return;
+    int64_t end = now_ns();
+    Event e;
+    e.phase = Phase::X;
+    e.name = name_ ? name_ : "";
+    e.category = category_ ? category_ : "";
+    e.ts_ns = start_ns_;
+    e.dur_ns = end - start_ns_;
+    e.args = std::move(args_);
+    push_event(std::move(e));
+}
+
+void ScopedZone::add_arg(const char* k, int64_t v)
+{
+    if (start_ns_ == 0)
+        return;
+    ArgValue a;
+    a.type = ArgValue::Type::Int;
+    a.i = v;
+    args_.emplace_back(k ? k : "", std::move(a));
+}
+void ScopedZone::add_arg(const char* k, double v)
+{
+    if (start_ns_ == 0)
+        return;
+    ArgValue a;
+    a.type = ArgValue::Type::Double;
+    a.d = v;
+    args_.emplace_back(k ? k : "", std::move(a));
+}
+void ScopedZone::add_arg(const char* k, bool v)
+{
+    if (start_ns_ == 0)
+        return;
+    ArgValue a;
+    a.type = ArgValue::Type::Bool;
+    a.b = v;
+    args_.emplace_back(k ? k : "", std::move(a));
+}
+void ScopedZone::add_arg(const char* k, const std::string& v)
+{
+    if (start_ns_ == 0)
+        return;
+    ArgValue a;
+    a.type = ArgValue::Type::String;
+    a.s = v;
+    args_.emplace_back(k ? k : "", std::move(a));
+}
+
+uint64_t async_begin(const char* name, const char* category)
+{
+    if (!is_enabled())
+        return 0;
+    static std::atomic<uint64_t> next_id { 1 };
+    uint64_t id = next_id.fetch_add(1, std::memory_order_relaxed);
+    Event e;
+    e.phase = Phase::AsyncBegin;
+    e.name = name ? name : "";
+    e.category = category ? category : "";
+    e.ts_ns = now_ns();
+    e.async_id = id;
+    push_event(std::move(e));
+    return id;
+}
+
+void async_end(uint64_t id)
+{
+    if (!is_enabled() || id == 0)
+        return;
+    Event e;
+    e.phase = Phase::AsyncEnd;
+    e.name = "";
+    e.ts_ns = now_ns();
+    e.async_id = id;
+    push_event(std::move(e));
+}
+
+void counter(const char* name, double value, const char* category)
+{
+    if (!is_enabled())
+        return;
+    Event e;
+    e.phase = Phase::Counter;
+    e.name = name ? name : "";
+    e.category = category ? category : "";
+    e.counter_value = value;
+    e.ts_ns = now_ns();
+    push_event(std::move(e));
+}
+
+namespace
+{
+    struct OwningZone
+    {
+        std::string name;
+        std::string category;
+        int64_t start_ns;
+        std::vector<std::pair<std::string, ArgValue>> args;
+    };
+}  // namespace
+
+uint64_t sync_zone_begin(const std::string& name, const std::string& category)
+{
+    if (!is_enabled())
+        return 0;
+    auto* z = new OwningZone { name, category, now_ns(), {} };
+    return reinterpret_cast<uint64_t>(z);
+}
+
+static OwningZone* as_owning(uint64_t handle) noexcept
+{
+    return reinterpret_cast<OwningZone*>(handle);
+}
+
+void sync_zone_add_int(uint64_t handle, const std::string& key, int64_t value)
+{
+    if (handle == 0)
+        return;
+    ArgValue a;
+    a.type = ArgValue::Type::Int;
+    a.i = value;
+    as_owning(handle)->args.emplace_back(key, std::move(a));
+}
+
+void sync_zone_add_double(uint64_t handle, const std::string& key, double value)
+{
+    if (handle == 0)
+        return;
+    ArgValue a;
+    a.type = ArgValue::Type::Double;
+    a.d = value;
+    as_owning(handle)->args.emplace_back(key, std::move(a));
+}
+
+void sync_zone_add_bool(uint64_t handle, const std::string& key, bool value)
+{
+    if (handle == 0)
+        return;
+    ArgValue a;
+    a.type = ArgValue::Type::Bool;
+    a.b = value;
+    as_owning(handle)->args.emplace_back(key, std::move(a));
+}
+
+void sync_zone_add_str(uint64_t handle, const std::string& key, const std::string& value)
+{
+    if (handle == 0)
+        return;
+    ArgValue a;
+    a.type = ArgValue::Type::String;
+    a.s = value;
+    as_owning(handle)->args.emplace_back(key, std::move(a));
+}
+
+void sync_zone_end(uint64_t handle)
+{
+    if (handle == 0)
+        return;
+    std::unique_ptr<OwningZone> z(as_owning(handle));
+    if (!is_enabled())
+        return;
+    Event e;
+    e.phase = Phase::X;
+    e.name = std::move(z->name);
+    e.category = std::move(z->category);
+    e.ts_ns = z->start_ns;
+    e.dur_ns = now_ns() - z->start_ns;
+    e.args = std::move(z->args);
+    push_event(std::move(e));
+}
+
+}  // namespace SciQLopPlots::tracing

--- a/tests/manual-tests/meson.build
+++ b/tests/manual-tests/meson.build
@@ -29,6 +29,14 @@ test('inspector_properties',
     timeout: 120,
 )
 
+test('tracing_python',
+    python3,
+    args: [meson.current_source_dir() + '/test_tracing_python.py'],
+    env: ['PYTHONPATH=' + meson.project_build_root()],
+    suite: 'integration',
+    timeout: 60,
+)
+
 sources = []
 foreach example : examples
     sources += example['source']

--- a/tests/manual-tests/test_tracing_integration.py
+++ b/tests/manual-tests/test_tracing_integration.py
@@ -1,0 +1,73 @@
+"""End-to-end integration test: real plot + tracer + validation of zones.
+
+Validates that C++-instrumented call sites (replot, setdata, resample) emit
+zones into the trace file when running through a real SciQLopPlots widget.
+"""
+import json
+import os
+import sys
+import tempfile
+
+import numpy as np
+from PySide6.QtCore import QTimer
+from PySide6.QtWidgets import QApplication
+
+from SciQLopPlots import SciQLopMultiPlotPanel, PlotType, tracing
+
+
+def make_data(start, stop):
+    x = np.arange(start, stop, dtype=np.float64)
+    y = np.column_stack([np.cos(x / 6) * 100, np.sin(x / 6) * 100])
+    return x, y
+
+
+def main():
+    fd, path = tempfile.mkstemp(suffix=".json", prefix="sciqlop_trace_")
+    os.close(fd)
+
+    app = QApplication.instance() or QApplication(sys.argv)
+    tracing.enable(path)
+    tracing.set_thread_name("gui")
+
+    panel = SciQLopMultiPlotPanel(synchronize_x=False, synchronize_time=True)
+    panel.plot(make_data, labels=["A", "B"], plot_type=PlotType.TimeSeries)
+    panel.resize(800, 500)
+    panel.show()
+
+    QTimer.singleShot(800, app.quit)
+    app.exec()
+
+    tracing.disable()
+
+    try:
+        with open(path) as f:
+            doc = json.load(f)
+        events = doc["traceEvents"]
+        names = {e.get("name") for e in events}
+        phases = {e.get("ph") for e in events}
+
+        print(f"trace file: {path}")
+        print(f"event count: {len(events)}")
+        print(f"phases: {sorted(phases)}")
+        print(f"unique names (first 30): {sorted(names)[:30]}")
+
+        assert "process_name" in names, "missing process metadata"
+        assert "thread_name" in names, "missing thread metadata"
+
+        replot_zones = [e for e in events if e.get("ph") == "X"
+                        and (e.get("name") or "").startswith("plot.replot")]
+        assert len(replot_zones) > 0, "no plot.replot zones recorded"
+        print(f"plot.replot zones: {len(replot_zones)}")
+
+        gui_tids = {e["tid"] for e in events
+                    if e.get("ph") == "M" and e.get("name") == "thread_name"
+                    and e.get("args", {}).get("name") == "gui"}
+        assert gui_tids, "gui thread name not recorded"
+
+        print("OK")
+    finally:
+        os.unlink(path)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/manual-tests/test_tracing_python.py
+++ b/tests/manual-tests/test_tracing_python.py
@@ -1,0 +1,108 @@
+"""Verify Python-side access to the C++ runtime tracer."""
+import json
+import os
+import sys
+import tempfile
+
+from SciQLopPlots import tracing
+
+
+def _read_trace(path):
+    with open(path) as f:
+        return json.load(f)
+
+
+def test_basic_zone():
+    fd, path = tempfile.mkstemp(suffix=".json")
+    os.close(fd)
+    try:
+        tracing.enable(path)
+        with tracing.zone("hello", cat="py"):
+            pass
+        tracing.disable()
+
+        events = _read_trace(path)["traceEvents"]
+        x = [e for e in events if e["ph"] == "X"]
+        assert len(x) == 1, x
+        assert x[0]["name"] == "hello"
+        assert x[0]["cat"] == "py"
+    finally:
+        os.unlink(path)
+
+
+def test_zone_with_args():
+    fd, path = tempfile.mkstemp(suffix=".json")
+    os.close(fd)
+    try:
+        tracing.enable(path)
+        with tracing.zone("fetch", cat="data",
+                          n_points=12345, ratio=0.5,
+                          ok=True, product="amda/mms_fgm"):
+            pass
+        tracing.disable()
+
+        events = _read_trace(path)["traceEvents"]
+        x = next(e for e in events if e["name"] == "fetch")
+        assert x["args"]["n_points"] == 12345
+        assert x["args"]["ratio"] == 0.5
+        assert x["args"]["ok"] is True
+        assert x["args"]["product"] == "amda/mms_fgm"
+    finally:
+        os.unlink(path)
+
+
+def test_counter_and_async():
+    fd, path = tempfile.mkstemp(suffix=".json")
+    os.close(fd)
+    try:
+        tracing.enable(path)
+        tracing.counter("queue_depth", 7.0, cat="fetch")
+        h = tracing.async_begin("download", cat="data")
+        tracing.async_end(h)
+        tracing.disable()
+
+        events = _read_trace(path)["traceEvents"]
+        phases = sorted({e["ph"] for e in events})
+        assert "C" in phases
+        assert "b" in phases
+        assert "e" in phases
+    finally:
+        os.unlink(path)
+
+
+def test_traced_decorator():
+    fd, path = tempfile.mkstemp(suffix=".json")
+    os.close(fd)
+    try:
+        tracing.enable(path)
+
+        @tracing.traced("annotated", cat="py")
+        def work(x):
+            return x * 2
+
+        assert work(3) == 6
+        tracing.disable()
+
+        events = _read_trace(path)["traceEvents"]
+        x = [e for e in events if e["ph"] == "X" and e["name"] == "annotated"]
+        assert len(x) == 1
+    finally:
+        os.unlink(path)
+
+
+def main():
+    tests = [test_basic_zone, test_zone_with_args, test_counter_and_async, test_traced_decorator]
+    failed = []
+    for t in tests:
+        try:
+            t()
+            print(f"PASS {t.__name__}")
+        except Exception as e:
+            print(f"FAIL {t.__name__}: {e!r}")
+            failed.append(t.__name__)
+    if failed:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -1,2 +1,3 @@
 subdir('manual-tests')
 subdir('perf')
+subdir('tracing')

--- a/tests/tracing/meson.build
+++ b/tests/tracing/meson.build
@@ -1,0 +1,18 @@
+qttest = dependency('qt6', modules: ['Core', 'Test'])
+
+tracing_test_includes = include_directories('../../include')
+
+test_tracing_moc = qtmod.compile_moc(
+    sources: 'test_tracing.cpp',
+    dependencies: [qttest],
+    include_directories: tracing_test_includes,
+)
+
+test_tracing_exe = executable('test_tracing',
+    'test_tracing.cpp', test_tracing_moc,
+    '../../src/Tracing.cpp',
+    include_directories: tracing_test_includes,
+    dependencies: [qttest],
+)
+
+test('tracing_engine', test_tracing_exe, suite: 'unit')

--- a/tests/tracing/test_tracing.cpp
+++ b/tests/tracing/test_tracing.cpp
@@ -1,0 +1,304 @@
+#include <QObject>
+#include <QtTest/QtTest>
+#include <QTemporaryFile>
+#include <QFile>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QJsonArray>
+#include <QJsonValue>
+#include <QThread>
+
+#include <atomic>
+#include <chrono>
+#include <set>
+#include <thread>
+#include <vector>
+
+#include "SciQLopPlots/Tracing.hpp"
+
+namespace tr = SciQLopPlots::tracing;
+
+static QJsonDocument read_trace(const QString& path)
+{
+    QFile f(path);
+    if (!f.open(QIODevice::ReadOnly))
+        return {};
+    auto data = f.readAll();
+    f.close();
+    return QJsonDocument::fromJson(data);
+}
+
+static QJsonArray events_of(const QJsonDocument& doc)
+{
+    return doc.object().value("traceEvents").toArray();
+}
+
+class TracingTest : public QObject
+{
+    Q_OBJECT
+
+private slots:
+
+    void init()
+    {
+        if (tr::is_enabled())
+            tr::disable();
+    }
+
+    void single_zone_records_one_event()
+    {
+        QTemporaryFile tmp;
+        QVERIFY(tmp.open());
+        tmp.close();
+        const QString path = tmp.fileName();
+
+        tr::enable(path.toStdString());
+        {
+            tr::ScopedZone z("hello", "test");
+            std::this_thread::sleep_for(std::chrono::milliseconds(1));
+        }
+        tr::disable();
+
+        const auto doc = read_trace(path);
+        QVERIFY(!doc.isNull());
+        QVERIFY(doc.isObject());
+        const auto events = events_of(doc);
+
+        QJsonArray complete;
+        for (const auto& v : events)
+        {
+            const auto e = v.toObject();
+            if (e.value("ph").toString() == "X")
+                complete.append(v);
+        }
+        QCOMPARE(complete.size(), 1);
+
+        const auto e = complete.first().toObject();
+        QCOMPARE(e.value("name").toString(), QString("hello"));
+        QCOMPARE(e.value("cat").toString(), QString("test"));
+        QVERIFY(e.value("ts").toDouble() >= 0.0);
+        QVERIFY(e.value("dur").toDouble() >= 1000.0);  // >=1ms in us
+        QVERIFY(e.contains("pid"));
+        QVERIFY(e.contains("tid"));
+    }
+
+    void disabled_zones_produce_no_events()
+    {
+        QTemporaryFile tmp;
+        QVERIFY(tmp.open());
+        tmp.close();
+        const QString path = tmp.fileName();
+
+        QVERIFY(!tr::is_enabled());
+        {
+            tr::ScopedZone z("ignored", "noop");
+        }
+
+        tr::enable(path.toStdString());
+        {
+            tr::ScopedZone z("real", "kept");
+        }
+        tr::disable();
+
+        const auto doc = read_trace(path);
+        QVERIFY(!doc.isNull());
+        const auto events = events_of(doc);
+
+        int x_count = 0;
+        for (const auto& v : events)
+        {
+            const auto e = v.toObject();
+            if (e.value("ph").toString() == "X")
+            {
+                ++x_count;
+                QCOMPARE(e.value("name").toString(), QString("real"));
+            }
+        }
+        QCOMPARE(x_count, 1);
+    }
+
+    void nested_zones_preserve_order_and_durations()
+    {
+        QTemporaryFile tmp;
+        QVERIFY(tmp.open());
+        tmp.close();
+        const QString path = tmp.fileName();
+
+        tr::enable(path.toStdString());
+        {
+            tr::ScopedZone outer("outer", "test");
+            std::this_thread::sleep_for(std::chrono::milliseconds(1));
+            {
+                tr::ScopedZone inner("inner", "test");
+                std::this_thread::sleep_for(std::chrono::milliseconds(2));
+            }
+        }
+        tr::disable();
+
+        const auto events = events_of(read_trace(path));
+        QJsonObject outer_e, inner_e;
+        for (const auto& v : events)
+        {
+            const auto e = v.toObject();
+            if (e.value("ph").toString() != "X")
+                continue;
+            if (e.value("name").toString() == "outer") outer_e = e;
+            if (e.value("name").toString() == "inner") inner_e = e;
+        }
+        QVERIFY(!outer_e.isEmpty());
+        QVERIFY(!inner_e.isEmpty());
+
+        const double outer_ts  = outer_e.value("ts").toDouble();
+        const double outer_dur = outer_e.value("dur").toDouble();
+        const double inner_ts  = inner_e.value("ts").toDouble();
+        const double inner_dur = inner_e.value("dur").toDouble();
+
+        QVERIFY(inner_ts >= outer_ts);
+        QVERIFY(inner_ts + inner_dur <= outer_ts + outer_dur);
+        QVERIFY(outer_dur >= inner_dur);
+    }
+
+    void zone_with_args_serializes_typed_values()
+    {
+        QTemporaryFile tmp;
+        QVERIFY(tmp.open());
+        tmp.close();
+        const QString path = tmp.fileName();
+
+        tr::enable(path.toStdString());
+        {
+            tr::ScopedZone z("with_args", "test");
+            z.add_arg("n_points", int64_t{12345});
+            z.add_arg("ratio", 0.5);
+            z.add_arg("ok", true);
+            z.add_arg("product", std::string("amda/mms_fgm"));
+        }
+        tr::disable();
+
+        const auto events = events_of(read_trace(path));
+        QJsonObject e;
+        for (const auto& v : events)
+            if (v.toObject().value("name").toString() == "with_args")
+                e = v.toObject();
+
+        QVERIFY(!e.isEmpty());
+        const auto args = e.value("args").toObject();
+        QCOMPARE(args.value("n_points").toInteger(), 12345LL);
+        QCOMPARE(args.value("ratio").toDouble(), 0.5);
+        QCOMPARE(args.value("ok").toBool(), true);
+        QCOMPARE(args.value("product").toString(), QString("amda/mms_fgm"));
+    }
+
+    void multiple_threads_produce_distinct_tids()
+    {
+        QTemporaryFile tmp;
+        QVERIFY(tmp.open());
+        tmp.close();
+        const QString path = tmp.fileName();
+
+        tr::enable(path.toStdString());
+
+        constexpr int N_THREADS = 4;
+        constexpr int N_ZONES   = 50;
+        std::vector<std::thread> threads;
+        threads.reserve(N_THREADS);
+        for (int t = 0; t < N_THREADS; ++t)
+        {
+            threads.emplace_back([] {
+                for (int i = 0; i < N_ZONES; ++i)
+                {
+                    tr::ScopedZone z("worker", "thread");
+                    std::this_thread::sleep_for(std::chrono::microseconds(10));
+                }
+            });
+        }
+        for (auto& th : threads) th.join();
+
+        tr::disable();
+
+        const auto events = events_of(read_trace(path));
+        std::set<int64_t> tids;
+        int worker_count = 0;
+        for (const auto& v : events)
+        {
+            const auto e = v.toObject();
+            if (e.value("ph").toString() != "X") continue;
+            if (e.value("name").toString() != "worker") continue;
+            ++worker_count;
+            tids.insert(e.value("tid").toInteger());
+        }
+        QCOMPARE(worker_count, N_THREADS * N_ZONES);
+        QCOMPARE(static_cast<int>(tids.size()), N_THREADS);
+    }
+
+    void async_begin_end_pair_emits_b_and_e()
+    {
+        QTemporaryFile tmp;
+        QVERIFY(tmp.open());
+        tmp.close();
+        const QString path = tmp.fileName();
+
+        tr::enable(path.toStdString());
+        const auto id = tr::async_begin("fetch", "data");
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+        tr::async_end(id);
+        tr::disable();
+
+        const auto events = events_of(read_trace(path));
+        QJsonObject begin_e, end_e;
+        for (const auto& v : events)
+        {
+            const auto e = v.toObject();
+            if (e.value("ph").toString() == "b") begin_e = e;
+            if (e.value("ph").toString() == "e") end_e = e;
+        }
+        QVERIFY(!begin_e.isEmpty());
+        QVERIFY(!end_e.isEmpty());
+        QCOMPARE(begin_e.value("name").toString(), QString("fetch"));
+        QCOMPARE(begin_e.value("cat").toString(), QString("data"));
+        QCOMPARE(begin_e.value("id").toString(), end_e.value("id").toString());
+    }
+
+    void counter_event_emits_C_with_value()
+    {
+        QTemporaryFile tmp;
+        QVERIFY(tmp.open());
+        tmp.close();
+        const QString path = tmp.fileName();
+
+        tr::enable(path.toStdString());
+        tr::counter("queue_depth", 7.0, "fetch");
+        tr::disable();
+
+        const auto events = events_of(read_trace(path));
+        QJsonObject c;
+        for (const auto& v : events)
+            if (v.toObject().value("ph").toString() == "C")
+                c = v.toObject();
+
+        QVERIFY(!c.isEmpty());
+        QCOMPARE(c.value("name").toString(), QString("queue_depth"));
+        QCOMPARE(c.value("cat").toString(), QString("fetch"));
+        QCOMPARE(c.value("args").toObject().value("queue_depth").toDouble(), 7.0);
+    }
+
+    void output_is_object_with_displayTimeUnit_ns()
+    {
+        QTemporaryFile tmp;
+        QVERIFY(tmp.open());
+        tmp.close();
+        const QString path = tmp.fileName();
+
+        tr::enable(path.toStdString());
+        { tr::ScopedZone z("x", "x"); }
+        tr::disable();
+
+        const auto doc = read_trace(path);
+        QVERIFY(doc.isObject());
+        QCOMPARE(doc.object().value("displayTimeUnit").toString(), QString("ns"));
+        QVERIFY(doc.object().value("traceEvents").isArray());
+    }
+};
+
+QTEST_GUILESS_MAIN(TracingTest)
+#include "test_tracing.moc"


### PR DESCRIPTION
## Summary
- Adds an always-compiled-in event tracer in SciQLopPlots that emits Chrome trace JSON (loadable in [Perfetto](https://ui.perfetto.dev/), [Speedscope](https://www.speedscope.app/), or `chrome://tracing`).
- Same tracer drives **C++ and Python** zones in one trace file with a shared clock — instrument once, see paint / resample / setdata next to `speasy.fetch` etc.
- `Profiling.hpp`'s `PROFILE_HERE_N` now feeds **both** the new tracer **and** Tracy when `tracy_enable=true` — existing instrumented sites get tracer support for free.

## Why
Tracy is great for dev-time deep dives but not shippable as a runtime user-toggle. We want users in the field to hit a slow path, type `tracing.enable("/tmp/x.json")`, repro, send the JSON, and have us load it in Perfetto. ~1 ns when off, ~50 ns per zone when on, no rebuild needed.

## Architecture
- **Engine** (`include/SciQLopPlots/Tracing.hpp` + `src/Tracing.cpp`): per-thread `vector<Event>`, 250 ms background flush thread streaming events to disk in Chrome JSON object form. Disabled overhead = one relaxed atomic load + branch. Auto-flush via `atexit`.
- **Toggle**: `SCIQLOP_TRACE=path.json` env var auto-enables on process start, or call `tracing.enable/disable/flush` at runtime from C++ or Python.
- **C++ macros**: `SCIQLOP_TRACE_ZONE(name)`, `SCIQLOP_TRACE_ZONE_CAT(name, cat)`, plus `ScopedZone` for per-zone `add_arg` (typed: int64/double/bool/string).
- **Python facade** (`SciQLopPlots/tracing.py`): `enable/disable/flush/is_enabled`, `with tracing.session(path)`, `with tracing.zone(name, cat=, **args)`, `@tracing.traced(name, cat=)`, `tracing.counter`, `async_begin/end`.
- **Profiling.hpp** (option B): `PROFILE_HERE_N(name)` expands to both `SCIQLOP_TRACE_ZONE(name)` and `ZoneScopedN(name)` (Tracy when `TRACY_ENABLE`). Single source of truth.

## Initial C++ instrumentation
- `SciQLopPlot::replot` (both overloads) — `paint`
- `AbstractResampler1d/2d::resample` and `_async_resample` — `resample`
- `SciQLopColorMap::set_data` — `setdata` with `nx/ny/nz` args
- `SciQLopMultiGraphBase::set_data` — `setdata` with `n_points` arg

## Tests
- `tests/tracing/test_tracing.cpp` (Qt Test) — 10 cases: basic / disabled-no-emit / nested / typed args / multi-thread distinct tids / async pair / counter / format. Suite `unit`.
- `tests/manual-tests/test_tracing_python.py` — 4 Python facade cases. Suite `integration`.
- `tests/manual-tests/test_tracing_integration.py` — real `SciQLopMultiPlotPanel.plot()` + tracer + zone-presence assertions.
- `inspector_properties` regression still passes.

## Quick start
```python
from SciQLopPlots import tracing
with tracing.session("/tmp/sciqlop.json"):
    panel.zoom_in_a_lot()       # whatever's slow
```

## Note on NeoQCP
NeoQCP's `Profiling.hpp` defines `PROFILE_HERE/_N/_NC/_PASS_VALUE` unconditionally, which silently overrode the SciQLopPlots versions in TUs that included both transitively. A small `#ifndef` guard patch on `subprojects/NeoQCP/src/Profiling.hpp` is needed for the unification to work cleanly. That patch is local only in this PR (subprojects are gitignored) and needs a separate PR upstreamed to SciQLop/NeoQCP. The SciQLopPlots side already does the `#undef`-before-redefine dance so warnings stay clean either way.

## Test plan
- [x] `meson test -C build tracing_engine` — 10 cases pass
- [x] `meson test -C build tracing_python` — 4 cases pass
- [x] `meson test -C build inspector_properties` — existing test green
- [x] Manual: `LD_LIBRARY_PATH=… PYTHONPATH=build python tests/manual-tests/test_tracing_integration.py` shows `plot.replot`, `setdata.multigraph`, `process_name`, `thread_name`
- [x] Manual: `SCIQLOP_TRACE=/tmp/x.json python -c "from SciQLopPlots import tracing; print(tracing.is_enabled())"` -> True
- [x] Open a captured trace file in https://ui.perfetto.dev/ and visually verify

Generated with [Claude Code](https://claude.com/claude-code)
