### PR TITLE
fix(ColorMap): clear instead of aborting on empty payload

### DIFF
--- a/src/SciQLopColorMap.cpp
+++ b/src/SciQLopColorMap.cpp
@@ -77,20 +77,28 @@ void SciQLopColorMap::set_data(PyBuffer x, PyBuffer y, PyBuffer z)
     const std::size_t nx_sz = x.flat_size();
     const std::size_t ny_sz = y.flat_size();
     const std::size_t nz_sz = z.flat_size();
-    // All-empty is allowed and behaves as a clear; otherwise z must be the
-    // full nx*ny matrix the QCP datasource expects.
-    const bool all_empty = (nx_sz == 0 && ny_sz == 0 && nz_sz == 0);
-    if (!all_empty && nz_sz != nx_sz * ny_sz)
+    // Empty payload ⇒ clear the colormap and bail out. Speasy returns a
+    // "well-formed empty" spectrogram (time=0, freq=N, values=(0,N)) for
+    // windows with no data; QCPSoADataSource2D asserts nx > 0 && nz > 0 so
+    // we must not construct it on empty input.
+    if (nx_sz == 0 || ny_sz == 0)
+    {
+        _dataHolder.reset();
+        _cmap->setDataSource(std::shared_ptr<QCPAbstractDataSource2D>{});
+        m_data_range = SciQLopPlotRange();
+        Q_EMIT data_changed(x, y, z);
+        Q_EMIT data_changed();
+        return;
+    }
+
+    if (nz_sz != nx_sz * ny_sz)
         throw std::runtime_error(
             "ColorMap.set_data: z size must equal len(x) * len(y)");
 
     const auto* x_ptr = static_cast<const double*>(x.raw_data());
     const int nx = static_cast<int>(nx_sz);
 
-    if (nx > 0)
-        m_data_range = SciQLopPlotRange(x_ptr[0], x_ptr[nx - 1]);
-    else
-        m_data_range = SciQLopPlotRange();
+    m_data_range = SciQLopPlotRange(x_ptr[0], x_ptr[nx - 1]);
 
     dispatch_dtype(y.format_code(), [&](auto y_tag) {
         dispatch_dtype(z.format_code(), [&](auto z_tag) {

--- a/tests/integration/test_colormap_api.py
+++ b/tests/integration/test_colormap_api.py
@@ -1,4 +1,9 @@
 """Tests for colormap creation, data manipulation, and properties."""
+import sys
+import subprocess
+import tempfile
+import textwrap
+
 import pytest
 import numpy as np
 
@@ -7,6 +12,29 @@ from SciQLopPlots import (
     ColorGradient,
 )
 from conftest import force_gc
+
+
+# Subprocess cwd: outside the repo so the in-tree `SciQLopPlots/` source dir
+# doesn't shadow the installed package (which carries the .so).
+_SUBPROCESS_CWD = tempfile.gettempdir()
+
+
+def _run_colormap_script(body: str) -> subprocess.CompletedProcess:
+    """Run a snippet that already has `app`, `plot`, and `np` in scope."""
+    full = textwrap.dedent(
+        """
+        import sys
+        import numpy as np
+        from PySide6.QtWidgets import QApplication
+        from SciQLopPlots import SciQLopPlot
+        app = QApplication.instance() or QApplication(sys.argv)
+        plot = SciQLopPlot()
+        """
+    ) + textwrap.dedent(body)
+    return subprocess.run(
+        [sys.executable, "-c", full], capture_output=True, timeout=30,
+        cwd=_SUBPROCESS_CWD,
+    )
 
 
 class TestColormapCreation:
@@ -83,3 +111,87 @@ class TestColormapProperties:
         cmap = plot.colormap(x, y, z)
         del cmap
         force_gc()
+
+
+class TestColormapEmptyData:
+    """set_data with no time samples must not crash.
+
+    Speasy returns a "well-formed empty" spectrogram for windows that fall
+    inside a product's definition but contain no data:
+        time.shape  = (0,)
+        freq.shape  = (N,)        # constant axis present regardless
+        values.shape = (0, N)     # flat size 0
+    The previous all-empty shortcut required nx == ny == nz == 0, so this
+    case fell through to QCPSoADataSource2D's `Q_ASSERT(nx > 0 ...)` and
+    aborted via qFatal. Run in subprocesses because the unfixed code aborts
+    the interpreter.
+    """
+
+    def test_empty_x_with_constant_y_does_not_crash(self):
+        result = _run_colormap_script(
+            """
+            x0 = np.linspace(0, 10, 20).astype(np.float64)
+            y0 = np.linspace(0, 5, 22).astype(np.float64)
+            z0 = np.random.rand(22, 20).astype(np.float64)
+            cmap = plot.colormap(x0, y0, z0)
+            empty_x = np.array([], dtype=np.float64)
+            const_y = np.linspace(0, 5, 22).astype(np.float64)
+            empty_z = np.empty((22, 0), dtype=np.float64)
+            cmap.set_data(empty_x, const_y, empty_z)
+            print("OK")
+            """
+        )
+        assert result.returncode == 0, (
+            "set_data with empty time / constant freq aborted "
+            f"(rc={result.returncode}): "
+            f"stderr={result.stderr.decode(errors='replace')[-400:]}"
+        )
+        assert b"OK" in result.stdout
+
+    def test_all_empty_does_not_crash(self):
+        result = _run_colormap_script(
+            """
+            x0 = np.linspace(0, 10, 20).astype(np.float64)
+            y0 = np.linspace(0, 5, 10).astype(np.float64)
+            z0 = np.random.rand(10, 20).astype(np.float64)
+            cmap = plot.colormap(x0, y0, z0)
+            cmap.set_data(
+                np.array([], dtype=np.float64),
+                np.array([], dtype=np.float64),
+                np.array([], dtype=np.float64),
+            )
+            print("OK")
+            """
+        )
+        assert result.returncode == 0, (
+            "set_data with fully empty triple aborted "
+            f"(rc={result.returncode}): "
+            f"stderr={result.stderr.decode(errors='replace')[-400:]}"
+        )
+        assert b"OK" in result.stdout
+
+    def test_empty_then_real_data_recovers(self):
+        """After an empty set_data, a subsequent populated update must work."""
+        result = _run_colormap_script(
+            """
+            x0 = np.linspace(0, 10, 20).astype(np.float64)
+            y0 = np.linspace(0, 5, 22).astype(np.float64)
+            z0 = np.random.rand(22, 20).astype(np.float64)
+            cmap = plot.colormap(x0, y0, z0)
+            cmap.set_data(
+                np.array([], dtype=np.float64),
+                y0,
+                np.empty((22, 0), dtype=np.float64),
+            )
+            x1 = np.linspace(0, 10, 30).astype(np.float64)
+            z1 = np.random.rand(22, 30).astype(np.float64)
+            cmap.set_data(x1, y0, z1)
+            print("OK")
+            """
+        )
+        assert result.returncode == 0, (
+            "set_data recovery after empty payload aborted "
+            f"(rc={result.returncode}): "
+            f"stderr={result.stderr.decode(errors='replace')[-400:]}"
+        )
+        assert b"OK" in result.stdout


### PR DESCRIPTION
## Summary

- `SciQLopColorMap::set_data` aborted via qFatal when fed a "well-formed empty" spectrogram (`time.shape=(0,)`, `freq.shape=(N,)`, `values.shape=(0,N)`) — the shape Speasy returns for windows that fall inside a product's definition but contain no samples.
- The pre-existing `all_empty` shortcut required `nx == ny == nz == 0`, so this case slipped past the size guard and reached `QCPSoADataSource2D`'s `Q_ASSERT(nx > 0 && nz > 0 ...)`. (The shortcut also never actually cleared anything — it only suppressed the size-mismatch throw before falling through into the same crash, so a fully-empty triple was equally lethal.)
- Replace it with a real clear path: when `nx_sz == 0 || ny_sz == 0`, drop the data holder, null the colormap's data source, reset the data range, emit `data_changed`, return.

## Test plan

New `TestColormapEmptyData` class in `tests/integration/test_colormap_api.py` (subprocess-isolated because the unfixed code aborts the interpreter):

- [x] `test_empty_x_with_constant_y_does_not_crash` — the Speasy case (`nx=0, ny=22, nz=0`).
- [x] `test_all_empty_does_not_crash` — fully empty triple.
- [x] `test_empty_then_real_data_recovers` — populated update after an empty payload still works.

All three FAIL on `main` with `ASSERT: "nx > 0 && nz > 0 && nz % nx == 0"` from `subprojects/NeoQCP/src/datasource/soa-datasource-2d.h:23`, and PASS with this change. Existing `TestC6_ColorMapShapeValidation` cases (`test_z_size_mismatch_does_not_crash`, `test_empty_z_does_not_crash`) still pass — the size-mismatch throw path is unchanged for `nx > 0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)