### PR TITLE
fix(ColorMap): accept 2D y axis in shape validation

### DIFF
--- a/src/SciQLopColorMap.cpp
+++ b/src/SciQLopColorMap.cpp
@@ -77,11 +77,11 @@ void SciQLopColorMap::set_data(PyBuffer x, PyBuffer y, PyBuffer z)
     const std::size_t nx_sz = x.flat_size();
     const std::size_t ny_sz = y.flat_size();
     const std::size_t nz_sz = z.flat_size();
-    // Empty payload ⇒ clear the colormap and bail out. Speasy returns a
-    // "well-formed empty" spectrogram (time=0, freq=N, values=(0,N)) for
-    // windows with no data; QCPSoADataSource2D asserts nx > 0 && nz > 0 so
-    // we must not construct it on empty input.
-    if (nx_sz == 0 || ny_sz == 0)
+    // No data to plot ⇒ clear and bail. Speasy returns a "well-formed
+    // empty" spectrogram (time=0, freq=N, values=(0,N)) for windows
+    // with no samples; QCPSoADataSource2D asserts nx > 0 && nz > 0 so
+    // we must not construct it on any empty input.
+    if (nx_sz == 0 || nz_sz == 0)
     {
         _dataHolder.reset();
         _cmap->setDataSource(std::shared_ptr<QCPAbstractDataSource2D>{});
@@ -91,9 +91,21 @@ void SciQLopColorMap::set_data(PyBuffer x, PyBuffer y, PyBuffer z)
         return;
     }
 
-    if (nz_sz != nx_sz * ny_sz)
+    // QCPSoADataSource2D accepts both 1D and 2D y axes:
+    //   1D y:  ny == nz / nx   (one y value per row)
+    //   2D y:  ny == nz        (per-cell y, e.g. a spectrogram whose
+    //                           frequency axis varies per timestamp)
+    if (nz_sz % nx_sz != 0)
         throw std::runtime_error(
-            "ColorMap.set_data: z size must equal len(x) * len(y)");
+            "ColorMap.set_data: z size must be a multiple of x size");
+
+    const std::size_t y_size_per_row = nz_sz / nx_sz;
+    const bool valid_1d_y = (ny_sz == y_size_per_row);
+    const bool valid_2d_y = (ny_sz == nz_sz);
+    if (!valid_1d_y && !valid_2d_y)
+        throw std::runtime_error(
+            "ColorMap.set_data: y size must equal len(z)/len(x) (1D y) "
+            "or len(z) (2D y)");
 
     const auto* x_ptr = static_cast<const double*>(x.raw_data());
     const int nx = static_cast<int>(nx_sz);

--- a/tests/integration/test_colormap_api.py
+++ b/tests/integration/test_colormap_api.py
@@ -170,6 +170,34 @@ class TestColormapEmptyData:
         )
         assert b"OK" in result.stdout
 
+    def test_2d_y_axis_does_not_throw(self):
+        """y can be 2D (per-timestamp varying frequencies).
+
+        QCPSoADataSource2D supports both 1D y (`ny == nz/nx`) and 2D y
+        (`ny == nz`). The size check must accept both — spectrograms with
+        a per-timestamp frequency axis send `y` flattened from shape
+        `(nx, M)` with `ny = nx*M = nz`, which violates the naive
+        `nz == nx*ny` invariant.
+        """
+        result = _run_colormap_script(
+            """
+            nx, m = 20, 22
+            x = np.linspace(0, 10, nx).astype(np.float64)
+            y_2d = np.tile(np.linspace(0, 5, m), (nx, 1)).astype(np.float64)
+            z = np.random.rand(nx, m).astype(np.float64)
+            cmap = plot.colormap(x, y_2d.ravel(), z)
+            cmap.set_data(x, y_2d.ravel(), z)
+            print("OK")
+            """
+        )
+        assert result.returncode == 0, (
+            "set_data with 2D y axis aborted/threw "
+            f"(rc={result.returncode}): "
+            f"stderr={result.stderr.decode(errors='replace')[-400:]}\n"
+            f"stdout={result.stdout.decode(errors='replace')[-200:]}"
+        )
+        assert b"OK" in result.stdout
+
     def test_empty_then_real_data_recovers(self):
         """After an empty set_data, a subsequent populated update must work."""
         result = _run_colormap_script(


### PR DESCRIPTION
## Summary

The C6 audit shape check (`96d0492`) enforced `nz == nx * ny`, but `QCPSoADataSource2D` has always supported **both** layouts:

- **1D y**: `ny == nz / nx` (one y value per row)
- **2D y**: `ny == nz` (per-cell y, e.g. spectrograms whose frequency axis varies per timestamp)

Spectrograms with a per-timestamp varying frequency axis send `y` flattened from shape `(nx, M)` with `ny = nx*M = nz` — which violates `nz == nx*ny`. The audit check rejected legitimate data, and the resulting throw escaped through a Qt direct-connected slot (no exception handler around `set_data` dispatch) → `std::terminate`. Pre-`96d0492` such data flowed straight into `QCPSoADataSource2D::mYIs2D = (ny == nz)`.

## Change

`src/SciQLopColorMap.cpp::set_data`:

- Clear+return when `nx_sz == 0 || nz_sz == 0` (covers the speasy "well-formed empty" case and the audit's empty-`z` reproducer in one path).
- Then validate `nz % nx == 0` and `ny ∈ {nz/nx, nz}`, with separate error messages so the failure mode is unambiguous.

## Test plan

- [x] New `test_2d_y_axis_does_not_throw` (subprocess-isolated): builds `y_2d = np.tile(...).ravel()` with `ny = nx*M = nz` and verifies `set_data` accepts it.
- [x] Empty-payload tests from PR #56 (`test_empty_x_with_constant_y_does_not_crash`, `test_all_empty_does_not_crash`, `test_empty_then_real_data_recovers`) still pass.
- [x] Existing audit C6 reproducers (`test_z_size_mismatch_does_not_crash`, `test_empty_z_does_not_crash`) still pass — the size-mismatch path now throws "z must be a multiple of x size" instead of the original wording but still raises (test accepts either RAISED or NO_RAISE).

16/16 tests across `test_colormap_api.py` + `TestC6_ColorMapShapeValidation` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)