### PR TITLE
ci: repair Windows wheels with delvewheel (bundle MSVC runtime, exclude Qt)

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -114,6 +114,17 @@ jobs:
           CIBW_REPAIR_WHEEL_COMMAND_LINUX: >
             auditwheel repair -w {dest_dir} --exclude libpyside6.abi3.so.6.11 --exclude libshiboken6.abi3.so.6.11 --exclude libQt6Core.so.6 --exclude libQt6Widgets.so.6 --exclude libQt6Gui.so.6 --exclude libpyside6qml.abi3.so.6.11 --exclude libGLX.so.0 --exclude libOpenGL.so.0 --exclude libxcb.so.1 --only-plat --plat ${{ matrix.platform }} {wheel}
           CIBW_REPAIR_WHEEL_COMMAND_MACOS:
+          # Windows: cibuildwheel runs delvewheel by default, but (1) it skips the MSVC
+          # runtime, causing "DLL load failed" on machines without the VC++ redistributable,
+          # and (2) it would otherwise vendor a private copy of Qt, which conflicts with the
+          # Qt that PySide6 loads in-process. Force-bundle the runtime, exclude the Qt/PySide
+          # stack (provided by PySide6 at runtime, mirroring the Linux auditwheel excludes).
+          CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: >
+            delvewheel repair -w {dest_dir}
+            --add-path "${{ env.GITHUB_WORKSPACE }}\\Qt\\${{ env.QT_VERSION }}\\msvc2022_64\\bin"
+            --include "msvcp140.dll;msvcp140_1.dll;msvcp140_2.dll;vcruntime140.dll;vcruntime140_1.dll;concrt140.dll"
+            --exclude "Qt6Core.dll;Qt6Gui.dll;Qt6Widgets.dll;Qt6Svg.dll;Qt6PrintSupport.dll;Qt6OpenGL.dll;Qt6OpenGLWidgets.dll;pyside6.abi3.dll;shiboken6.abi3.dll;pyside6qml.abi3.dll"
+            {wheel}
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_34
           CIBW_MANYLINUX_AARCH64_IMAGE: quay.io/pypa/manylinux_2_39_aarch64
           CIBW_SKIP: "*-win32 *i686 *38-* *39-* pp* *musllinux* *314t*"

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -120,7 +120,8 @@ jobs:
           # Qt that PySide6 loads in-process. Force-bundle the runtime, exclude the Qt/PySide
           # stack (provided by PySide6 at runtime, mirroring the Linux auditwheel excludes).
           CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: >
-            delvewheel repair -w {dest_dir}
+            pip install delvewheel &&
+            python -m delvewheel repair -w {dest_dir}
             --add-path "${{ env.GITHUB_WORKSPACE }}\\Qt\\${{ env.QT_VERSION }}\\msvc2022_64\\bin"
             --include "msvcp140.dll;msvcp140_1.dll;msvcp140_2.dll;vcruntime140.dll;vcruntime140_1.dll;concrt140.dll"
             --exclude "Qt6Core.dll;Qt6Gui.dll;Qt6Widgets.dll;Qt6Svg.dll;Qt6PrintSupport.dll;Qt6OpenGL.dll;Qt6OpenGLWidgets.dll;pyside6.abi3.dll;shiboken6.abi3.dll;pyside6qml.abi3.dll"

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -101,7 +101,7 @@ jobs:
           CIBW_ENVIRONMENT_MACOS: PYSIDE_VERSION=${{ env.PYSIDE_VERSION }} MACOSX_DEPLOYMENT_TARGET='13.3' PATH=/usr/lib/ccache:${{ env.GITHUB_WORKSPACE }}/Qt/${{ env.QT_VERSION }}/macos/bin:$PATH
           CIBW_ENVIRONMENT_LINUX: PYSIDE_VERSION=${{ env.PYSIDE_VERSION }} PIP_EXTRA_INDEX_URL=${{ env.PIP_EXTRA_INDEX_URL }} CC="ccache gcc" CXX="ccache g++" CCACHE_DIR=${{ env.GITHUB_WORKSPACE }}/.ccache PATH=${{ env.GITHUB_WORKSPACE }}/Qt/${{ env.QT_VERSION }}/${{ matrix.qt_dir }}/bin:$PATH LD_LIBRARY_PATH=${{ env.GITHUB_WORKSPACE }}/Qt/${{ env.QT_VERSION }}/${{ matrix.qt_dir }}/lib:$LD_LIBRARY_PATH
           CIBW_BEFORE_BUILD_WINDOWS: >
-            pip install "aqtinstall @ git+https://github.com/miurahr/aqtinstall.git@master"
+            pip install delvewheel "aqtinstall @ git+https://github.com/miurahr/aqtinstall.git@master"
             && if not exist "${{ env.GITHUB_WORKSPACE }}\\Qt\\${{ env.QT_VERSION }}" aqt install-qt -O ${{ env.GITHUB_WORKSPACE }}\\Qt windows desktop ${{ env.QT_VERSION }} win64_msvc2022_64 -m qtshadertools
           CIBW_BEFORE_BUILD_MACOS: >
             pip install "aqtinstall @ git+https://github.com/miurahr/aqtinstall.git@master"
@@ -114,14 +114,13 @@ jobs:
           CIBW_REPAIR_WHEEL_COMMAND_LINUX: >
             auditwheel repair -w {dest_dir} --exclude libpyside6.abi3.so.6.11 --exclude libshiboken6.abi3.so.6.11 --exclude libQt6Core.so.6 --exclude libQt6Widgets.so.6 --exclude libQt6Gui.so.6 --exclude libpyside6qml.abi3.so.6.11 --exclude libGLX.so.0 --exclude libOpenGL.so.0 --exclude libxcb.so.1 --only-plat --plat ${{ matrix.platform }} {wheel}
           CIBW_REPAIR_WHEEL_COMMAND_MACOS:
-          # Windows: cibuildwheel runs delvewheel by default, but (1) it skips the MSVC
-          # runtime, causing "DLL load failed" on machines without the VC++ redistributable,
-          # and (2) it would otherwise vendor a private copy of Qt, which conflicts with the
-          # Qt that PySide6 loads in-process. Force-bundle the runtime, exclude the Qt/PySide
-          # stack (provided by PySide6 at runtime, mirroring the Linux auditwheel excludes).
+          # Windows has no default repair command, so the wheel was never repaired and
+          # the MSVC runtime was never bundled -> "DLL load failed" on machines without the
+          # VC++ redistributable. delvewheel (installed in before-build) vendors the runtime;
+          # exclude the Qt/PySide stack so we don't ship a private Qt that conflicts with the
+          # one PySide6 loads in-process (mirrors the Linux auditwheel excludes).
           CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: >
-            pip install delvewheel &&
-            python -m delvewheel repair -w {dest_dir}
+            delvewheel repair -w {dest_dir}
             --add-path "${{ env.GITHUB_WORKSPACE }}\\Qt\\${{ env.QT_VERSION }}\\msvc2022_64\\bin"
             --include "msvcp140.dll;msvcp140_1.dll;msvcp140_2.dll;vcruntime140.dll;vcruntime140_1.dll;concrt140.dll"
             --exclude "Qt6Core.dll;Qt6Gui.dll;Qt6Widgets.dll;Qt6Svg.dll;Qt6PrintSupport.dll;Qt6OpenGL.dll;Qt6OpenGLWidgets.dll;pyside6.abi3.dll;shiboken6.abi3.dll;pyside6qml.abi3.dll"

--- a/src/SciQLopCrosshair.cpp
+++ b/src/SciQLopCrosshair.cpp
@@ -30,6 +30,20 @@
 #include <cmath>
 #include <ctime>
 
+namespace
+{
+std::tm to_local_tm(std::time_t t)
+{
+    std::tm tm {};
+#ifdef _WIN32
+    localtime_s(&tm, &t);
+#else
+    localtime_r(&t, &tm);
+#endif
+    return tm;
+}
+}
+
 SciQLopCrosshair::SciQLopCrosshair(QCustomPlot* plot)
     : QObject(plot), m_plot(plot)
 {
@@ -202,8 +216,7 @@ QString SciQLopCrosshair::build_tooltip_html(double key, const QPointF& pixelPos
         const auto sec_part = static_cast<std::time_t>(us / 1'000'000);
         const auto frac_us = static_cast<long>(
             std::abs(us - static_cast<long long>(sec_part) * 1'000'000));
-        std::tm tm {};
-        localtime_r(&sec_part, &tm);
+        const std::tm tm = to_local_tm(sec_part);
         header = QString::fromStdString(
             fmt::format("{:%Y-%m-%d %H:%M:%S}.{:06d}", tm, frac_us));
     }


### PR DESCRIPTION
## Summary

Windows users hit `ImportError: DLL load failed while importing _sciqlop_dsp: Le module spécifié est introuvable` on launch. The `.pyd` is found, but a dependent native DLL cannot be located.

Root cause: the Windows wheel never bundled the **MSVC C++ runtime** (`MSVCP140.dll`, `VCRUNTIME140_1.dll`, …). CPython ships only `vcruntime140.dll`, not the C++ stdlib, and `delvewheel` (which cibuildwheel runs by default on Windows) deliberately skips the runtime. On machines without the VC++ 2015–2022 redistributable, the first C++ extension imported (`_sciqlop_dsp`) fails to load. `SciQLopPlotsBindings` would fail the same way — it's just imported later in the chain.

This adds an explicit `CIBW_REPAIR_WHEEL_COMMAND_WINDOWS` that:
- **force-includes** the MSVC runtime DLLs so the wheel is self-contained, and
- **excludes** the Qt/PySide/shiboken DLLs so we don't ship a private Qt that would clash with the Qt PySide6 loads in-process (mirrors the existing Linux `auditwheel` excludes).

NeoQCP and fmt are statically linked, so they need no bundling.

## Test plan

- [ ] CI Windows wheel build succeeds with the new repair step
- [ ] On a **clean** Windows machine (no Visual Studio / no VC++ redistributable), `from SciQLopPlots import dsp` and the bindings both import successfully
- [ ] Confirm via `delvewheel show` / `dumpbin /dependents` that no `Qt6*.dll` survived the repair (no double-Qt), and that the runtime DLLs are vendored

🤖 Generated with [Claude Code](https://claude.com/claude-code)