### PR TITLE
feat(colormap): percentile-based robust autoscale for the z (color) axis

### DIFF
--- a/include/SciQLopPlots/Plotables/SciQLopColorMap.hpp
+++ b/include/SciQLopPlots/Plotables/SciQLopColorMap.hpp
@@ -67,6 +67,10 @@ public:
     void set_auto_scale_y(bool auto_scale_y);
     inline bool auto_scale_y() const { return _auto_scale_y; }
 
+    SciQLopPlotRange z_percentile_range(const SciQLopPlotRange& x_range,
+                                        const SciQLopPlotRange& y_range, double low,
+                                        double high) const noexcept override;
+
     inline void set_contour_levels(const QVector<double>& levels)
     {
         if (_cmap) _cmap->setContourLevels(levels);

--- a/include/SciQLopPlots/Plotables/SciQLopColorMapBase.hpp
+++ b/include/SciQLopPlots/Plotables/SciQLopColorMapBase.hpp
@@ -22,6 +22,7 @@
 #pragma once
 #include "SciQLopPlots/Plotables/SciQLopGraphInterface.hpp"
 #include "SciQLopPlots/SciQLopPlotAxis.hpp"
+#include <optional>
 #include <qcustomplot.h>
 
 class SciQLopColorMapBase : public SciQLopColorMapInterface
@@ -33,6 +34,8 @@ protected:
     SciQLopPlotAxis* _keyAxis;
     SciQLopPlotAxis* _valueAxis;
     SciQLopPlotColorScaleAxis* _colorScaleAxis;
+    double _autoscale_percentile_low = 0.;
+    double _autoscale_percentile_high = 100.;
 
     inline QCustomPlot* _plot() const { return qobject_cast<QCustomPlot*>(this->parent()); }
 
@@ -140,4 +143,37 @@ public:
     {
         return _colorScaleAxis ? _colorScaleAxis->log() : false;
     }
+
+    void set_autoscale_percentile_low(double percentile) noexcept;
+    inline double autoscale_percentile_low() const noexcept { return _autoscale_percentile_low; }
+    void set_autoscale_percentile_high(double percentile) noexcept;
+    inline double autoscale_percentile_high() const noexcept { return _autoscale_percentile_high; }
+
+    // Range of z over cells whose x/y fall in the given visible ranges, clamped
+    // to [low, high] percentiles (nearest-rank). low=0/high=100 gives plain
+    // min/max of the visible data. Non-finite cells are skipped. Default returns
+    // an empty (NaN) range; concrete plotables override it.
+    virtual SciQLopPlotRange z_percentile_range(const SciQLopPlotRange& x_range,
+                                                const SciQLopPlotRange& y_range, double low,
+                                                double high) const noexcept
+    {
+        Q_UNUSED(x_range);
+        Q_UNUSED(y_range);
+        Q_UNUSED(low);
+        Q_UNUSED(high);
+        return SciQLopPlotRange();
+    }
+
+protected:
+#ifndef BINDINGS_H
+    // [low, high] percentile cutoffs (nearest-rank) of the collected values.
+    // Empty input yields a NaN range. Shared by concrete z_percentile_range
+    // overrides, which differ only in how they gather the visible cells.
+    static SciQLopPlotRange percentile_range(std::vector<double>& values, double low,
+                                             double high) noexcept;
+    // nullopt ⇒ caller should use the plain min/max fast path (default 0/100).
+    std::optional<SciQLopPlotRange> z_rescale_range() const noexcept;
+    // Installs z_rescale_range as the color-scale axis rescale provider.
+    void install_rescale_provider() noexcept;
+#endif
 };

--- a/include/SciQLopPlots/Plotables/SciQLopHistogram2D.hpp
+++ b/include/SciQLopPlots/Plotables/SciQLopHistogram2D.hpp
@@ -72,6 +72,10 @@ public:
     void set_normalization(int normalization);
     int normalization() const;
 
+    SciQLopPlotRange z_percentile_range(const SciQLopPlotRange& x_range,
+                                        const SciQLopPlotRange& y_range, double low,
+                                        double high) const noexcept override;
+
 #ifdef BINDINGS_H
 #define Q_SIGNAL
 signals:

--- a/include/SciQLopPlots/SciQLopPlotAxis.hpp
+++ b/include/SciQLopPlots/SciQLopPlotAxis.hpp
@@ -28,7 +28,9 @@
 #include <QFont>
 #include <QObject>
 #include <QPointer>
+#include <functional>
 #include <memory>
+#include <optional>
 class QCPAxis;
 class QCPColorScale;
 namespace _impl { class SciQLopPlot; }
@@ -307,11 +309,24 @@ class SciQLopPlotColorScaleAxis : public SciQLopPlotAxis
     Q_OBJECT
     QPointer<QCPColorScale> m_axis;
     ColorGradient m_color_gradient;
+#ifndef BINDINGS_H
+    // Lets the owning colormap supply a custom rescale range (e.g. percentile
+    // over visible data). Returning nullopt falls back to plain min/max.
+    std::function<std::optional<SciQLopPlotRange>()> m_rescale_range_provider;
+#endif
 
 public:
     explicit SciQLopPlotColorScaleAxis(QCPColorScale* axis, QObject* parent = nullptr,
                                        const QString& name = "ColorScale");
     virtual ~SciQLopPlotColorScaleAxis() = default;
+
+#ifndef BINDINGS_H
+    inline void
+    set_rescale_range_provider(std::function<std::optional<SciQLopPlotRange>()> provider) noexcept
+    {
+        m_rescale_range_provider = std::move(provider);
+    }
+#endif
 
     void set_range(const SciQLopPlotRange& range) noexcept override;
     void set_visible(bool visible) noexcept override;

--- a/src/SciQLopColorMap.cpp
+++ b/src/SciQLopColorMap.cpp
@@ -23,6 +23,9 @@
 #include "SciQLopPlots/Profiling.hpp"
 #include "SciQLopPlots/Tracing.hpp"
 #include "SciQLopPlots/constants.hpp"
+#include <algorithm>
+#include <cmath>
+#include <vector>
 
 void SciQLopColorMap::_cmap_got_destroyed()
 {
@@ -41,6 +44,8 @@ SciQLopColorMap::SciQLopColorMap(QCustomPlot* parent, SciQLopPlotAxis* xAxis,
             this, &SciQLopPlottableInterface::busy_changed);
     SciQLopColorMap::set_gradient(ColorGradient::Jet);
     SciQLopColorMap::set_name(name);
+
+    install_rescale_provider();
 
     if (auto legend_item = _legend_item(); legend_item)
     {
@@ -159,6 +164,67 @@ void SciQLopColorMap::set_auto_scale_y(bool auto_scale_y)
 {
     _auto_scale_y = auto_scale_y;
     Q_EMIT auto_scale_y_changed(auto_scale_y);
+}
+
+SciQLopPlotRange SciQLopColorMap::z_percentile_range(const SciQLopPlotRange& x_range,
+                                                     const SciQLopPlotRange& y_range, double low,
+                                                     double high) const noexcept
+{
+    if (!_dataHolder)
+        return SciQLopPlotRange();
+    const PyBuffer& xb = _dataHolder->x;
+    const PyBuffer& yb = _dataHolder->y;
+    const PyBuffer& zb = _dataHolder->z;
+    if (!xb.is_valid() || !yb.is_valid() || !zb.is_valid())
+        return SciQLopPlotRange();
+
+    const std::size_t nx = xb.flat_size();
+    const std::size_t nz = zb.flat_size();
+    if (nx == 0 || nz == 0 || nz % nx != 0)
+        return SciQLopPlotRange();
+    const std::size_t y_per_row = nz / nx;
+    const bool y_is_2d = (yb.flat_size() == nz);
+
+    const double x_lo = std::min(x_range.start(), x_range.stop());
+    const double x_hi = std::max(x_range.start(), x_range.stop());
+    const double y_lo = std::min(y_range.start(), y_range.stop());
+    const double y_hi = std::max(y_range.start(), y_range.stop());
+
+    const auto* x_ptr = static_cast<const double*>(xb.raw_data());
+
+    std::vector<double> values;
+    values.reserve(nz);
+    dispatch_dtype(yb.format_code(),
+                   [&](auto y_tag)
+                   {
+                       dispatch_dtype(zb.format_code(),
+                                      [&](auto z_tag)
+                                      {
+                                          using Y = typename decltype(y_tag)::type;
+                                          using Z = typename decltype(z_tag)::type;
+                                          const auto* y_ptr = static_cast<const Y*>(yb.raw_data());
+                                          const auto* z_ptr = static_cast<const Z*>(zb.raw_data());
+                                          for (std::size_t i = 0; i < nx; ++i)
+                                          {
+                                              const double xi = x_ptr[i];
+                                              if (xi < x_lo || xi > x_hi)
+                                                  continue;
+                                              for (std::size_t j = 0; j < y_per_row; ++j)
+                                              {
+                                                  const std::size_t idx = i * y_per_row + j;
+                                                  const double yj = static_cast<double>(
+                                                      y_is_2d ? y_ptr[idx] : y_ptr[j]);
+                                                  if (yj < y_lo || yj > y_hi)
+                                                      continue;
+                                                  const double zv = static_cast<double>(z_ptr[idx]);
+                                                  if (std::isfinite(zv))
+                                                      values.push_back(zv);
+                                              }
+                                          }
+                                      });
+                   });
+
+    return percentile_range(values, low, high);
 }
 
 SciQLopColorMapFunction::SciQLopColorMapFunction(QCustomPlot* parent, SciQLopPlotAxis* xAxis,

--- a/src/SciQLopColorMapBase.cpp
+++ b/src/SciQLopColorMapBase.cpp
@@ -21,6 +21,9 @@
 ----------------------------------------------------------------------------*/
 #include "SciQLopPlots/Plotables/SciQLopColorMapBase.hpp"
 #include "SciQLopPlots/Plotables/AxisHelpers.hpp"
+#include <algorithm>
+#include <cmath>
+#include <vector>
 
 SciQLopColorMapBase::SciQLopColorMapBase(SciQLopPlotAxis* keyAxis, SciQLopPlotAxis* valueAxis,
                                          SciQLopPlotColorScaleAxis* colorScaleAxis,
@@ -34,7 +37,11 @@ SciQLopColorMapBase::SciQLopColorMapBase(SciQLopPlotAxis* keyAxis, SciQLopPlotAx
 
 // Derived destructors null their QPointer then remove the plottable,
 // preventing double-removal when the base destructor runs.
-SciQLopColorMapBase::~SciQLopColorMapBase() = default;
+SciQLopColorMapBase::~SciQLopColorMapBase()
+{
+    if (_colorScaleAxis)
+        _colorScaleAxis->set_rescale_range_provider(nullptr);
+}
 
 void SciQLopColorMapBase::set_selected(bool selected) noexcept
 {
@@ -51,6 +58,56 @@ void SciQLopColorMapBase::set_selected(bool selected) noexcept
 bool SciQLopColorMapBase::selected() const noexcept
 {
     return _selected;
+}
+
+void SciQLopColorMapBase::set_autoscale_percentile_low(double percentile) noexcept
+{
+    _autoscale_percentile_low = std::clamp(percentile, 0., 100.);
+}
+
+void SciQLopColorMapBase::set_autoscale_percentile_high(double percentile) noexcept
+{
+    _autoscale_percentile_high = std::clamp(percentile, 0., 100.);
+}
+
+SciQLopPlotRange SciQLopColorMapBase::percentile_range(std::vector<double>& values, double low,
+                                                       double high) noexcept
+{
+    if (values.empty())
+        return SciQLopPlotRange();
+
+    const auto rank = [n = values.size()](double p) -> std::size_t
+    {
+        const double clamped = std::clamp(p, 0., 100.);
+        const long idx = std::lround(clamped / 100. * static_cast<double>(n - 1));
+        return static_cast<std::size_t>(std::clamp<long>(idx, 0, static_cast<long>(n - 1)));
+    };
+    const std::size_t lo_idx = rank(low);
+    const std::size_t hi_idx = rank(high);
+    std::nth_element(values.begin(), values.begin() + lo_idx, values.end());
+    const double lo_val = values[lo_idx];
+    std::nth_element(values.begin(), values.begin() + hi_idx, values.end());
+    const double hi_val = values[hi_idx];
+    return SciQLopPlotRange(std::min(lo_val, hi_val), std::max(lo_val, hi_val));
+}
+
+std::optional<SciQLopPlotRange> SciQLopColorMapBase::z_rescale_range() const noexcept
+{
+    if (_autoscale_percentile_low <= 0. && _autoscale_percentile_high >= 100.)
+        return std::nullopt;
+    if (!_keyAxis || !_valueAxis)
+        return std::nullopt;
+    auto r = z_percentile_range(_keyAxis->range(), _valueAxis->range(),
+                                _autoscale_percentile_low, _autoscale_percentile_high);
+    if (std::isnan(r.start()) || std::isnan(r.stop()))
+        return std::nullopt;
+    return r;
+}
+
+void SciQLopColorMapBase::install_rescale_provider() noexcept
+{
+    if (_colorScaleAxis)
+        _colorScaleAxis->set_rescale_range_provider([this]() { return z_rescale_range(); });
 }
 
 void SciQLopColorMapBase::set_x_axis(SciQLopPlotAxisInterface* axis) noexcept

--- a/src/SciQLopColorMapBaseDelegate.cpp
+++ b/src/SciQLopColorMapBaseDelegate.cpp
@@ -23,6 +23,10 @@
 #include "SciQLopPlots/Inspector/PropertiesDelegates/Delegates/ColorGradientDelegate.hpp"
 #include "SciQLopPlots/Plotables/SciQLopColorMapBase.hpp"
 
+#include <QDoubleSpinBox>
+#include <QFormLayout>
+#include <QGroupBox>
+
 SciQLopColorMapBase* SciQLopColorMapBaseDelegate::color_map_base() const
 {
     return as_type<SciQLopColorMapBase>(m_object);
@@ -40,4 +44,39 @@ SciQLopColorMapBaseDelegate::SciQLopColorMapBaseDelegate(SciQLopColorMapBase* ob
                 if (auto* cm = color_map_base())
                     cm->set_gradient(g);
             });
+
+    // Robust autoscale: clamp the color (z) range to a percentile of the
+    // visible data. Defaults to 0/100, i.e. plain min/max.
+    auto* percentileBox = new QGroupBox("Color scale percentile", this);
+    auto* percentileLayout = new QFormLayout(percentileBox);
+
+    auto* lowSpin = new QDoubleSpinBox(percentileBox);
+    lowSpin->setRange(0., 100.);
+    lowSpin->setDecimals(1);
+    lowSpin->setSingleStep(0.5);
+    lowSpin->setSuffix(" %");
+    lowSpin->setValue(object->autoscale_percentile_low());
+    percentileLayout->addRow("Low", lowSpin);
+    connect(lowSpin, QOverload<double>::of(&QDoubleSpinBox::valueChanged), this,
+            [this](double v)
+            {
+                if (auto* cm = color_map_base())
+                    cm->set_autoscale_percentile_low(v);
+            });
+
+    auto* highSpin = new QDoubleSpinBox(percentileBox);
+    highSpin->setRange(0., 100.);
+    highSpin->setDecimals(1);
+    highSpin->setSingleStep(0.5);
+    highSpin->setSuffix(" %");
+    highSpin->setValue(object->autoscale_percentile_high());
+    percentileLayout->addRow("High", highSpin);
+    connect(highSpin, QOverload<double>::of(&QDoubleSpinBox::valueChanged), this,
+            [this](double v)
+            {
+                if (auto* cm = color_map_base())
+                    cm->set_autoscale_percentile_high(v);
+            });
+
+    m_layout->addRow(percentileBox);
 }

--- a/src/SciQLopHistogram2D.cpp
+++ b/src/SciQLopHistogram2D.cpp
@@ -21,6 +21,10 @@
 ----------------------------------------------------------------------------*/
 #include "SciQLopPlots/Plotables/SciQLopHistogram2D.hpp"
 #include "SciQLopPlots/constants.hpp"
+#include <algorithm>
+#include <cmath>
+#include <plottables/plottable-colormap.h>
+#include <vector>
 
 void SciQLopHistogram2D::_hist_got_destroyed()
 {
@@ -41,6 +45,8 @@ SciQLopHistogram2D::SciQLopHistogram2D(QCustomPlot* parent, SciQLopPlotAxis* xAx
             this, &SciQLopPlottableInterface::busy_changed);
     SciQLopHistogram2D::set_gradient(ColorGradient::Jet);
     SciQLopHistogram2D::set_name(name);
+
+    install_rescale_provider();
 
     if (auto legend_item = _legend_item(); legend_item)
     {
@@ -149,6 +155,45 @@ void SciQLopHistogram2D::set_normalization(int normalization)
 int SciQLopHistogram2D::normalization() const
 {
     return _hist ? static_cast<int>(_hist->normalization()) : 0;
+}
+
+SciQLopPlotRange SciQLopHistogram2D::z_percentile_range(const SciQLopPlotRange& x_range,
+                                                        const SciQLopPlotRange& y_range, double low,
+                                                        double high) const noexcept
+{
+    if (!_hist)
+        return SciQLopPlotRange();
+    // The binned grid (cell counts) is produced asynchronously; if it isn't
+    // ready yet, fall back to the plain min/max path (empty range ⇒ nullopt).
+    const QCPColorMapData* grid = _hist->pipeline().result();
+    if (!grid)
+        return SciQLopPlotRange();
+    const int nkey = grid->keySize();
+    const int nval = grid->valueSize();
+    if (nkey <= 0 || nval <= 0)
+        return SciQLopPlotRange();
+
+    const double x_lo = std::min(x_range.start(), x_range.stop());
+    const double x_hi = std::max(x_range.start(), x_range.stop());
+    const double y_lo = std::min(y_range.start(), y_range.stop());
+    const double y_hi = std::max(y_range.start(), y_range.stop());
+
+    std::vector<double> values;
+    values.reserve(static_cast<std::size_t>(nkey) * static_cast<std::size_t>(nval));
+    for (int i = 0; i < nkey; ++i)
+    {
+        for (int j = 0; j < nval; ++j)
+        {
+            double kx = 0., vy = 0.;
+            grid->cellToCoord(i, j, &kx, &vy);
+            if (kx < x_lo || kx > x_hi || vy < y_lo || vy > y_hi)
+                continue;
+            const double zv = grid->cell(i, j);
+            if (std::isfinite(zv))
+                values.push_back(zv);
+        }
+    }
+    return percentile_range(values, low, high);
 }
 
 SciQLopHistogram2DFunction::SciQLopHistogram2DFunction(QCustomPlot* parent, SciQLopPlotAxis* xAxis,

--- a/src/SciQLopPlotAxis.cpp
+++ b/src/SciQLopPlotAxis.cpp
@@ -524,6 +524,15 @@ void SciQLopPlotColorScaleAxis::rescale() noexcept
 {
     if (!m_axis.isNull())
     {
+        if (m_rescale_range_provider)
+        {
+            if (auto r = m_rescale_range_provider(); r.has_value())
+            {
+                set_range(*r);
+                m_axis->parentPlot()->replot(QCustomPlot::rpQueuedReplot);
+                return;
+            }
+        }
         // QCPColorScale::rescaleDataRange only finds QCPColorMap, not QCPColorMap2/QCPHistogram2D.
         auto* plot = m_axis->parentPlot();
         for (int i = 0; i < plot->plottableCount(); ++i)

--- a/tests/integration/test_colormap_autoscale_percentile.py
+++ b/tests/integration/test_colormap_autoscale_percentile.py
@@ -1,0 +1,193 @@
+"""Robust (percentile-based) autoscale for the colormap z (color) axis.
+
+A few extreme cells in a spectrogram blow out the color scale, especially on a
+log color axis. A percentile autoscale clamps the z range to e.g. the 2.5/97.5
+percentile of the *visible* data, making it robust against outliers. Default
+percentiles are 0/100, so the behaviour is identical to plain min/max unless
+configured.
+"""
+import pytest
+import numpy as np
+from PySide6.QtCore import QCoreApplication
+from PySide6.QtWidgets import QGroupBox
+
+from SciQLopPlots import SciQLopPlotRange, DelegateRegistry
+
+
+def _pump_events(n=50):
+    for _ in range(n):
+        QCoreApplication.processEvents()
+
+
+def _make_colormap_with_outliers(plot):
+    """Colormap whose z is 0.5 everywhere except two extreme cells.
+
+    z is laid out x-outer (row-major, x is the slow axis): shape (nx, ny).
+    The +1e6 outlier sits at x-index 10 (x=10), the -1e6 at x-index 20 (x=20),
+    both well inside the y window.
+    """
+    nx, ny = 50, 40
+    x = np.linspace(0, 49, nx).astype(np.float64)
+    y = np.linspace(0, 39, ny).astype(np.float64)
+    z = np.full((nx, ny), 0.5, dtype=np.float64)
+    z[10, 5] = 1.0e6
+    z[20, 7] = -1.0e6
+    cmap = plot.colormap(x, y, z.ravel())
+    return cmap, x, y
+
+
+class TestZPercentileRange:
+
+    def test_full_range_includes_outliers(self, plot):
+        cmap, x, y = _make_colormap_with_outliers(plot)
+        r = cmap.z_percentile_range(
+            SciQLopPlotRange(x[0], x[-1]), SciQLopPlotRange(y[0], y[-1]), 0.0, 100.0
+        )
+        assert r.start() == pytest.approx(-1.0e6)
+        assert r.stop() == pytest.approx(1.0e6)
+
+    def test_percentile_excludes_outliers(self, plot):
+        cmap, x, y = _make_colormap_with_outliers(plot)
+        r = cmap.z_percentile_range(
+            SciQLopPlotRange(x[0], x[-1]), SciQLopPlotRange(y[0], y[-1]), 2.5, 97.5
+        )
+        # two extremes out of 2000 cells are far below the 2.5% tails
+        assert abs(r.start()) < 1.0
+        assert abs(r.stop()) < 1.0
+
+    def test_visible_filter_excludes_out_of_range_cells(self, plot):
+        cmap, x, y = _make_colormap_with_outliers(plot)
+        # restrict visible x so the +1e6 cell (x=10) is outside; -1e6 (x=20) stays
+        r = cmap.z_percentile_range(
+            SciQLopPlotRange(15.0, 49.0), SciQLopPlotRange(y[0], y[-1]), 0.0, 100.0
+        )
+        assert r.stop() == pytest.approx(0.5)
+        assert r.start() == pytest.approx(-1.0e6)
+
+    def test_nan_and_inf_cells_ignored(self, plot):
+        nx, ny = 30, 20
+        x = np.linspace(0, 29, nx).astype(np.float64)
+        y = np.linspace(0, 19, ny).astype(np.float64)
+        z = np.full((nx, ny), 2.0, dtype=np.float64)
+        z[0, 0] = np.nan
+        z[1, 1] = np.inf
+        z[2, 2] = -np.inf
+        cmap = plot.colormap(x, y, z.ravel())
+        r = cmap.z_percentile_range(
+            SciQLopPlotRange(x[0], x[-1]), SciQLopPlotRange(y[0], y[-1]), 0.0, 100.0
+        )
+        assert np.isfinite(r.start()) and np.isfinite(r.stop())
+        assert r.start() == pytest.approx(2.0)
+        assert r.stop() == pytest.approx(2.0)
+
+
+class TestPercentileConfig:
+
+    def test_default_percentiles(self, plot, sample_colormap_data):
+        x, y, z = sample_colormap_data
+        cmap = plot.colormap(x, y, z)
+        assert cmap.autoscale_percentile_low() == 0.0
+        assert cmap.autoscale_percentile_high() == 100.0
+
+    def test_set_percentiles(self, plot, sample_colormap_data):
+        x, y, z = sample_colormap_data
+        cmap = plot.colormap(x, y, z)
+        cmap.set_autoscale_percentile_low(2.5)
+        cmap.set_autoscale_percentile_high(97.5)
+        assert cmap.autoscale_percentile_low() == 2.5
+        assert cmap.autoscale_percentile_high() == 97.5
+
+
+class TestRescaleRouting:
+
+    def test_rescale_uses_percentile_when_configured(self, plot):
+        cmap, x, y = _make_colormap_with_outliers(plot)
+        cmap.set_autoscale_percentile_low(2.5)
+        cmap.set_autoscale_percentile_high(97.5)
+        zaxis = cmap.z_axis()
+        zaxis.rescale()
+        r = zaxis.range()
+        assert abs(r.start()) < 1.0
+        assert abs(r.stop()) < 1.0
+
+
+def _make_histogram_with_spike(plot):
+    """Histogram whose counts are roughly uniform except one densely packed bin.
+
+    5000 points spread over [-5, 5]^2 give a low, even count per bin; an extra
+    3000 points piled at the origin make a single extreme-count bin.
+    """
+    rng = np.random.default_rng(7)
+    spread_x = rng.uniform(-5, 5, 5000)
+    spread_y = rng.uniform(-5, 5, 5000)
+    spike_x = rng.normal(0, 0.01, 3000)
+    spike_y = rng.normal(0, 0.01, 3000)
+    x = np.concatenate([spread_x, spike_x]).astype(np.float64)
+    y = np.concatenate([spread_y, spike_y]).astype(np.float64)
+    hist = plot.add_histogram2d("spike", 50, 50)
+    hist.set_data(x, y)
+    _pump_events()
+    plot.replot(True)
+    _pump_events()
+    return hist
+
+
+class TestHistogram2DPercentile:
+
+    def test_default_percentiles_on_histogram(self, plot):
+        hist = plot.add_histogram2d("h", 20, 20)
+        assert hist.autoscale_percentile_low() == 0.0
+        assert hist.autoscale_percentile_high() == 100.0
+
+    def test_full_range_includes_spike(self, plot):
+        hist = _make_histogram_with_spike(plot)
+        r = hist.z_percentile_range(
+            SciQLopPlotRange(-6.0, 6.0), SciQLopPlotRange(-6.0, 6.0), 0.0, 100.0
+        )
+        # the dense origin bin holds hundreds/thousands of points
+        assert r.stop() > 100.0
+
+    def test_percentile_excludes_spike(self, plot):
+        hist = _make_histogram_with_spike(plot)
+        full = hist.z_percentile_range(
+            SciQLopPlotRange(-6.0, 6.0), SciQLopPlotRange(-6.0, 6.0), 0.0, 100.0
+        )
+        clamped = hist.z_percentile_range(
+            SciQLopPlotRange(-6.0, 6.0), SciQLopPlotRange(-6.0, 6.0), 2.5, 97.5
+        )
+        assert np.isfinite(clamped.stop())
+        assert clamped.stop() < full.stop()
+
+    def test_rescale_uses_percentile_when_configured(self, plot):
+        hist = _make_histogram_with_spike(plot)
+        full_max = hist.z_percentile_range(
+            SciQLopPlotRange(-6.0, 6.0), SciQLopPlotRange(-6.0, 6.0), 0.0, 100.0
+        ).stop()
+        hist.set_autoscale_percentile_low(2.5)
+        hist.set_autoscale_percentile_high(97.5)
+        zaxis = hist.z_axis()
+        zaxis.rescale()
+        clamped_max = zaxis.range().stop()
+        assert np.isfinite(clamped_max)
+        assert clamped_max < full_max
+
+
+class TestInspectorUI:
+    """The percentile spinboxes live in the shared base delegate, so both the
+    colormap and histogram inspectors expose them."""
+
+    def _percentile_group(self, target, qtbot):
+        delegate = DelegateRegistry.instance().create_delegate(target, None)
+        assert delegate is not None
+        qtbot.addWidget(delegate)
+        titles = [g.title() for g in delegate.findChildren(QGroupBox)]
+        return titles
+
+    def test_colormap_delegate_has_percentile_group(self, plot, qtbot, sample_colormap_data):
+        x, y, z = sample_colormap_data
+        cmap = plot.colormap(x, y, z)
+        assert "Color scale percentile" in self._percentile_group(cmap, qtbot)
+
+    def test_histogram_delegate_has_percentile_group(self, plot, qtbot):
+        hist = plot.add_histogram2d("h", 20, 20)
+        assert "Color scale percentile" in self._percentile_group(hist, qtbot)


### PR DESCRIPTION
## Summary

Adds an optional **percentile-based robust autoscale** for the colormap/spectrogram z (color) axis. A few extreme cells (hot/cold pixels) currently blow out the color scale, especially on a log color axis. Instead of plain min/max, the z range can be clamped to the `[low, high]` percentiles of the data **visible in the current x/y window**.

- `M` remains the single autoscale trigger and does whatever the per-colormap config says.
- Percentiles default to **0/100**, i.e. byte-for-byte identical to today's min/max behavior. Set e.g. **2.5/97.5** for outlier-robust scaling.
- The percentile is computed over **raw values** (colormap) or **binned counts** (histogram), filtered to the visible range, skipping non-finite cells, via `std::nth_element`.

## Design

- Shared config (`autoscale_percentile_low/high`), the percentile math, and the color-scale rescale provider live in `SciQLopColorMapBase`, so both `SciQLopColorMap` and `SciQLopHistogram2D` inherit the behavior; each only overrides how it gathers the visible cells.
- `SciQLopPlotColorScaleAxis` gained a rescale-range provider hook: at 0/100 it keeps the existing fast `rescaleDataRange` path; otherwise it uses the percentile range and `set_range()`.
- The inspector (`SciQLopColorMapBaseDelegate`) exposes **Low/High** percentile spinboxes for both colormap and histogram.
- No NeoQCP changes required — uses existing read-only APIs (`QCPHistogram2D::pipeline().result()`, `QCPColorMapData::cell()/cellToCoord()`).

## Test plan

- [x] New `tests/integration/test_colormap_autoscale_percentile.py` (13 tests): percentile range, visible x/y filtering, NaN/inf skipping, default config, rescale routing, and inspector-delegate UI — for **both** colormap and Histogram2D.
- [x] Regression: existing colormap/histogram/inspector suites (82 tests) still pass.
- [x] Optional manual check in the SciQLop app: open a spectrogram with outliers, set 2.5/97.5 in the inspector, press `M`, confirm the color scale tightens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)