### PR TITLE
docs: add audit backlog 2026-05-16 (H1 destruction-time segfault)

### DIFF
--- a/docs/backlog-2026-05-16.md
+++ b/docs/backlog-2026-05-16.md
@@ -1,0 +1,119 @@
+# Audit Backlog — 2026-05-16
+
+Single-item entry from a downstream SciQLop crash investigation. Tracked
+separately because the root cause is in the Python binding layer and the
+practical mitigation is small.
+
+---
+
+## HIGH
+
+### H1 — Calling `SciQLopPlot.x_axis()` (and likely siblings) from Python during a `~SciQLopPlot` cascade segfaults inside `QWidget::sharedPainter()`
+
+- **Reported from:** SciQLop, panel-with-layer + dock-close flow. Verified
+  by user instrumentation; gdb shows the crash at
+  `Sbk_SciQLopPlotFunc_x_axis` → `QWidget::sharedPainter()`. Full stack:
+
+  ```
+  #0  QWidget::sharedPainter() const
+  #1  Sbk_SciQLopPlotFunc_x_axis              (sciqlopplot_wrapper.cpp:4067)
+  ...
+  #9  QObject::destroyed(QObject*)
+  #10 QObject::~QObject()
+  #11 InspectorExtensionWrapper::~InspectorExtensionWrapper
+  #13 QWidget::~QWidget()
+  #14 SciQLopTimeSeriesPlot::~SciQLopTimeSeriesPlot
+  ...
+  #36 ads::CDockWidget::~CDockWidget
+  ```
+
+- **Trigger:** a Python slot wired to `child.destroyed` (here, an
+  `InspectorExtension` child of the plot) calls `plot.x_axis()` while
+  the parent `SciQLopTimeSeriesPlot` is mid `~QWidget` (children being
+  deleted by `~QObject::deleteChildren()`, widget-specific state torn
+  down). The C++ implementation of `x_axis()`
+  (`SciQLopPlot.hpp:364`, `return m_impl->axis(0)`) is trivial and safe
+  — the segfault is **inside the generated Shiboken wrapper**, which
+  touches widget paint state during conversion / validity checks.
+
+- **Why this matters:** the bug class is "any Python slot connected to
+  `destroyed` that dereferences the dying parent through a Shiboken
+  wrapper". It's invisible in headless / pytest-xvfb runs (QRhi paint
+  state doesn't init) and only surfaces in live GUI sessions. SciQLop's
+  layer renderer hit this; the workaround landed downstream
+  (`commit eb87dc34` in SciQLop: cache `x_axis` at connect time, skip
+  the disconnect at dispose when no slot is wired), but every future
+  consumer is one `destroyed` lambda away from the same crash.
+
+- **Suggested fixes (cheapest first):**
+  1. **Make `Sbk_*Func_*_axis` not touch paint state.** Inspect the
+     generated wrapper at `sciqlopplot_wrapper.cpp:~4067` and the
+     conversion path for `SciQLopPlotAxisInterface*` — work out whether
+     it's the `Shiboken::Object::isValid(self)` check (walks Qt
+     parents?) or the `pointerToPython` conversion of the returned
+     axis that calls `sharedPainter()`. Patch via an `<inject-code>`
+     in `bindings.xml` for the four axis getters (`x_axis`, `y_axis`,
+     `y2_axis`, `z_axis`, plus `x2_axis`, `z_axis`, `time_axis`) so
+     they short-circuit when the C++ object is being destroyed.
+  2. **Emit `aboutToBeDestroyed()` from `~SciQLopPlot`** before
+     `~QWidget` runs `deleteChildren`. Qt deliberately doesn't provide
+     this; SciQLopPlot can. Downstream Python code wires its cleanup
+     to that signal instead of child-`destroyed`, which fires while
+     the plot is still fully alive. Cleanest architectural fix.
+  3. **Document the rule** in the SciQLopPlots Python bindings docs
+     (CLAUDE.md or a "Python lifetime" note): "Do not call axis or
+     other QWidget-state-dependent methods from a slot wired to a
+     child's `destroyed` signal. Cache the axis reference at the time
+     you connect, or use `aboutToBeDestroyed` once it exists."
+
+- **Files:**
+  - `include/SciQLopPlots/SciQLopPlot.hpp:364` — `x_axis()` impl
+  - `SciQLopPlots/bindings/bindings.xml` — binding spec for `SciQLopPlot`
+  - `src/SciQLopPlot.cpp` — destructor would gain `aboutToBeDestroyed`
+    emission for option 2
+
+- **Verification:** there is no headless reproducer (xvfb + xcb + offscreen
+  don't init the paint state that crashes). Manual GUI repro: add a layer
+  with a knob to a plot, close the dock containing the plot — pre-fix
+  SciQLop branch SIGSEGVs at the gdb path above. Downstream `commit
+  eb87dc34` blocks the call site but the binding remains unsafe for any
+  future consumer.
+
+---
+
+## MEDIUM
+
+### M1 — `SciQLopHorizontalLine` cannot be bound to a secondary y-axis
+
+- **Reported from:** SciQLop, y2-axis user_api work (2026-05-19). The
+  downstream wrapper added a full secondary-y-axis surface
+  (`set_y2_range`, `y2_scale_type`, `Graph.y_axis="y2"` retarget,
+  `plot(..., y_axis="y2")`). Graphs can move to y2 via the existing
+  `set_y_axis(axis)`, but horizontal lines cannot.
+
+- **Gap:** `SciQLopHorizontalLine` exposes no `set_y_axis` / axis-binding
+  method (verified via Python `dir()` on the binding — only `position`,
+  `set_position`, `color`, `line_width` are present). A line is implicitly
+  tied to the primary y-axis at construction, so `add_hline` on the
+  SciQLop side can't offer an `axis="y2"` kwarg.
+
+- **Suggested fix:** give `SciQLopHorizontalLine` (and, by symmetry, any
+  vertical-line / range-marker item that anchors to an axis) a
+  `set_y_axis(SciQLopPlotAxisInterface*)` setter mirroring the graph API,
+  and accept an optional target axis in its constructor. Expose both in
+  `bindings.xml`.
+
+- **Unblocks:** SciQLop backlog item **A5** (`add_hline(value, axis="y2")`),
+  see `docs/plans/2026-05-03-code-review-backlog.md`.
+
+- **Files:**
+  - the `SciQLopHorizontalLine` header/impl (axis member + setter)
+  - `SciQLopPlots/bindings/bindings.xml` — expose `set_y_axis` + ctor arg
+
+---
+
+## Memory updates needed
+
+- New: `python_lifetime_destruction_signals.md` — capture the rule and
+  the downstream incident as a worked example. Cross-link from
+  `known_issues.md`.


### PR DESCRIPTION
## Summary

Adds `docs/backlog-2026-05-16.md` recording a downstream SciQLop crash investigation:

- **H1** — calling `SciQLopPlot.x_axis()` (and siblings) from Python during the `~SciQLopPlot` destruction cascade segfaults inside `QWidget::sharedPainter()`. Triggered by a Python slot wired to a child's `destroyed()` signal (e.g. an inspector extension). gdb stack included in the doc.

Documentation only — no code change. Tracked separately because the root cause is in the binding layer and the practical mitigation is small.

🤖 Generated with [Claude Code](https://claude.com/claude-code)