### PR TITLE
feat(axis): percentile-based robust autoscale for value (y) axes

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -130,6 +130,15 @@ jobs:
           CIBW_SKIP: "*-win32 *i686 *38-* *39-* pp* *musllinux* *314t*"
           CIBW_BUILD_VERBOSITY: 3
           CIBW_ARCH: ${{ matrix.arch }}
+          # Smoke test: install the freshly-repaired wheel and import it. This
+          # catches "DLL load failed" / missing-runtime / broken-bundle classes
+          # of regressions that the build step itself can't see (since it
+          # links against the build-machine Qt, not the bundled one). Three
+          # consecutive Windows-wheel fixes shipped in May 2026 would have
+          # been blocked by this. Headless import only — no QApplication.
+          # Command string contains no GitHub event data so it's not exposed
+          # to expression-injection.
+          CIBW_TEST_COMMAND: python -c "import SciQLopPlots; print('SciQLopPlots', SciQLopPlots.__version__, 'imports OK')"
 
       - uses: actions/upload-artifact@v7
         with:

--- a/SciQLopPlots/__init__.py
+++ b/SciQLopPlots/__init__.py
@@ -4,7 +4,6 @@ from .SciQLopPlotsBindings import (GraphType, SciQLopPlot, SciQLopTimeSeriesPlot
                                     SciQLopGraphInterface, AxisType, SciQLopPlotRange, SciQLopNDProjectionPlot)
 from .SciQLopPlotsBindings import *
 from datetime import datetime, timezone
-from dateutil.parser import parse as dateparse
 import traceback
 
 import sys

--- a/include/SciQLopPlots/PercentileMath.hpp
+++ b/include/SciQLopPlots/PercentileMath.hpp
@@ -1,0 +1,54 @@
+/*------------------------------------------------------------------------------
+-- This file is a part of the SciQLop Software
+-- Copyright (C) 2026, Plasma Physics Laboratory - CNRS
+--
+-- This program is free software; you can redistribute it and/or modify
+-- it under the terms of the GNU General Public License as published by
+-- the Free Software Foundation; either version 2 of the License, or
+-- (at your option) any later version.
+--
+-- This program is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+-- GNU General Public License for more details.
+--
+-- You should have received a copy of the GNU General Public License
+-- along with this program; if not, write to the Free Software
+-- Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+-------------------------------------------------------------------------------*/
+/*-- Author : Alexis Jeandet
+-- Mail : alexis.jeandet@member.fsf.org
+----------------------------------------------------------------------------*/
+#pragma once
+#include "SciQLopPlots/SciQLopPlotRange.hpp"
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <vector>
+
+namespace sciqlop::percentile
+{
+// [low, high] percentile cutoffs (nearest-rank) of `values`. The vector is
+// partially reordered by std::nth_element. Empty input yields a NaN range.
+// Shared by color-scale and value-axis robust-autoscale paths.
+inline SciQLopPlotRange percentile_range(std::vector<double>& values, double low,
+                                         double high) noexcept
+{
+    if (values.empty())
+        return SciQLopPlotRange();
+
+    const auto rank = [n = values.size()](double p) -> std::size_t
+    {
+        const double clamped = std::clamp(p, 0., 100.);
+        const long idx = std::lround(clamped / 100. * static_cast<double>(n - 1));
+        return static_cast<std::size_t>(std::clamp<long>(idx, 0, static_cast<long>(n - 1)));
+    };
+    const std::size_t lo_idx = rank(low);
+    const std::size_t hi_idx = rank(high);
+    std::nth_element(values.begin(), values.begin() + lo_idx, values.end());
+    const double lo_val = values[lo_idx];
+    std::nth_element(values.begin(), values.begin() + hi_idx, values.end());
+    const double hi_val = values[hi_idx];
+    return SciQLopPlotRange(std::min(lo_val, hi_val), std::max(lo_val, hi_val));
+}
+}

--- a/include/SciQLopPlots/Plotables/SciQLopColorMapBase.hpp
+++ b/include/SciQLopPlots/Plotables/SciQLopColorMapBase.hpp
@@ -166,11 +166,6 @@ public:
 
 protected:
 #ifndef BINDINGS_H
-    // [low, high] percentile cutoffs (nearest-rank) of the collected values.
-    // Empty input yields a NaN range. Shared by concrete z_percentile_range
-    // overrides, which differ only in how they gather the visible cells.
-    static SciQLopPlotRange percentile_range(std::vector<double>& values, double low,
-                                             double high) noexcept;
     // nullopt ⇒ caller should use the plain min/max fast path (default 0/100).
     std::optional<SciQLopPlotRange> z_rescale_range() const noexcept;
     // Installs z_rescale_range as the color-scale axis rescale provider.

--- a/include/SciQLopPlots/Plotables/SciQLopColorMapBase.hpp
+++ b/include/SciQLopPlots/Plotables/SciQLopColorMapBase.hpp
@@ -22,6 +22,7 @@
 #pragma once
 #include "SciQLopPlots/Plotables/SciQLopGraphInterface.hpp"
 #include "SciQLopPlots/SciQLopPlotAxis.hpp"
+#include <QPointer>
 #include <optional>
 #include <qcustomplot.h>
 
@@ -33,7 +34,9 @@ protected:
     bool _selected = false;
     SciQLopPlotAxis* _keyAxis;
     SciQLopPlotAxis* _valueAxis;
-    SciQLopPlotColorScaleAxis* _colorScaleAxis;
+    // QPointer because the color-scale axis is owned by the parent QCustomPlot
+    // and may be destroyed before us in atypical teardown orders.
+    QPointer<SciQLopPlotColorScaleAxis> _colorScaleAxis;
     double _autoscale_percentile_low = 0.;
     double _autoscale_percentile_high = 100.;
 
@@ -96,12 +99,13 @@ public:
 
     inline virtual ColorGradient gradient() const noexcept override
     {
-        return _colorScaleAxis->color_gradient();
+        return _colorScaleAxis ? _colorScaleAxis->color_gradient() : ColorGradient::Jet;
     }
 
     inline virtual void set_gradient(ColorGradient gradient) noexcept override
     {
-        _colorScaleAxis->set_color_gradient(gradient);
+        if (_colorScaleAxis)
+            _colorScaleAxis->set_color_gradient(gradient);
     }
 
     inline virtual void set_visible(bool visible) noexcept override

--- a/include/SciQLopPlots/Plotables/SciQLopCurve.hpp
+++ b/include/SciQLopPlots/Plotables/SciQLopCurve.hpp
@@ -96,6 +96,11 @@ public:
 
     virtual SciQLopPlotAxisInterface* y_axis() const noexcept override { return _valueAxis; }
 
+#ifndef BINDINGS_H
+    void collect_visible_values(const SciQLopPlotRange& visible_key_range,
+                                std::vector<double>& out) const noexcept override;
+#endif
+
 private:
 #ifdef BINDINGS_H
 #define Q_SIGNAL

--- a/include/SciQLopPlots/Plotables/SciQLopGraphInterface.hpp
+++ b/include/SciQLopPlots/Plotables/SciQLopGraphInterface.hpp
@@ -37,6 +37,7 @@
 #include <QWidget>
 #include <memory>
 #include <utility>
+#include <vector>
 
 class SciQLopPlotAxisInterface;
 class InspectorExtension;
@@ -259,6 +260,17 @@ public:
     }
 
 #ifndef BINDINGS_H
+    // Appends finite y-values whose x falls in visible_key_range to `out`.
+    // Multi-component graphs append every component. Default no-op — concrete
+    // graphs override. Used by value-axis percentile autoscale (it then runs
+    // nth_element over the pooled values).
+    virtual void collect_visible_values(const SciQLopPlotRange& visible_key_range,
+                                        std::vector<double>& out) const noexcept
+    {
+        Q_UNUSED(visible_key_range);
+        Q_UNUSED(out);
+    }
+
     Q_SIGNAL void labels_changed(const QStringList& labels);
     Q_SIGNAL void colors_changed(const QList<QColor>& colors);
     Q_SIGNAL void component_list_changed();

--- a/include/SciQLopPlots/Plotables/SciQLopMultiGraphBase.hpp
+++ b/include/SciQLopPlots/Plotables/SciQLopMultiGraphBase.hpp
@@ -64,4 +64,9 @@ public:
     SciQLopPlotAxisInterface* y_axis() const noexcept override { return _valueAxis; }
 
     void create_graphs(const QStringList& labels);
+
+#ifndef BINDINGS_H
+    void collect_visible_values(const SciQLopPlotRange& visible_key_range,
+                                std::vector<double>& out) const noexcept override;
+#endif
 };

--- a/include/SciQLopPlots/Plotables/SciQLopSingleLineGraph.hpp
+++ b/include/SciQLopPlots/Plotables/SciQLopSingleLineGraph.hpp
@@ -67,6 +67,11 @@ public:
     virtual SciQLopPlotAxisInterface* y_axis() const noexcept override { return _valueAxis; }
 
     void create_graph(const QStringList& labels);
+
+#ifndef BINDINGS_H
+    void collect_visible_values(const SciQLopPlotRange& visible_key_range,
+                                std::vector<double>& out) const noexcept override;
+#endif
 };
 
 class SciQLopSingleLineGraphFunction : public SciQLopSingleLineGraph,

--- a/include/SciQLopPlots/SciQLopPlotAxis.hpp
+++ b/include/SciQLopPlots/SciQLopPlotAxis.hpp
@@ -268,12 +268,19 @@ class SciQLopPlotAxis : public SciQLopPlotAxisInterface
     QPointer<QCPAxis> m_axis;
     SciQLopPlotRange m_last_valid_range;
     bool m_suppress_range_signals = false;
+    double m_autoscale_percentile_low = 0.;
+    double m_autoscale_percentile_high = 100.;
     friend class _impl::SciQLopPlot;
 
 public:
     explicit SciQLopPlotAxis(QCPAxis* axis, QObject* parent = nullptr, bool is_time_axis = false,
                              const QString& name = "Axis");
     virtual ~SciQLopPlotAxis() = default;
+
+    void set_autoscale_percentile_low(double percentile) noexcept;
+    void set_autoscale_percentile_high(double percentile) noexcept;
+    inline double autoscale_percentile_low() const noexcept { return m_autoscale_percentile_low; }
+    inline double autoscale_percentile_high() const noexcept { return m_autoscale_percentile_high; }
 
     void set_range(const SciQLopPlotRange& range) noexcept override;
     void set_visible(bool visible) noexcept override;

--- a/src/PythonInterface.cpp
+++ b/src/PythonInterface.cpp
@@ -492,6 +492,11 @@ std::size_t PyBuffer::flat_size() const
 // here drops the whole batch instead of letting the exception escape into the
 // worker-thread event loop and call std::terminate. The caller treats an
 // empty vector as "no data this round".
+//
+// Caller must hold the GIL (true for the three _GetDataPyCallable_impl::get_data
+// overloads via PyAutoScopedGIL). Failures surface as a Python RuntimeWarning
+// (via PyErr_WarnEx) so users can see, at the Python level, why their plot
+// is empty; we also keep the qWarning for non-Python-facing logs.
 inline std::vector<PyBuffer> _collect_buffers(PyObject* res)
 {
     std::vector<PyBuffer> data;
@@ -518,6 +523,16 @@ inline std::vector<PyBuffer> _collect_buffers(PyObject* res)
     catch (const std::exception& e)
     {
         qWarning() << "[GetDataPyCallable] dropping data provider result:" << e.what();
+        const std::string msg
+            = std::string("SciQLopPlots data provider returned an unsupported buffer "
+                          "(dropping batch): ")
+            + e.what();
+        // PyErr_WarnEx returns -1 if the warning is upgraded to an exception by
+        // Python's warning filters. In that case clear it so the next callable
+        // invocation starts with a clean error state — the C++-side recovery
+        // is the same either way.
+        if (PyErr_WarnEx(PyExc_RuntimeWarning, msg.c_str(), 1) < 0)
+            PyErr_Clear();
         data.clear();
     }
     return data;

--- a/src/SciQLopColorMap.cpp
+++ b/src/SciQLopColorMap.cpp
@@ -195,35 +195,47 @@ SciQLopPlotRange SciQLopColorMap::z_percentile_range(const SciQLopPlotRange& x_r
 
     std::vector<double> values;
     values.reserve(nz);
-    dispatch_dtype(yb.format_code(),
-                   [&](auto y_tag)
-                   {
-                       dispatch_dtype(zb.format_code(),
-                                      [&](auto z_tag)
-                                      {
-                                          using Y = typename decltype(y_tag)::type;
-                                          using Z = typename decltype(z_tag)::type;
-                                          const auto* y_ptr = static_cast<const Y*>(yb.raw_data());
-                                          const auto* z_ptr = static_cast<const Z*>(zb.raw_data());
-                                          for (std::size_t i = 0; i < nx; ++i)
+    // noexcept gather: dispatch_dtype throws std::invalid_argument on
+    // unsupported codes. _dataHolder is only assigned after set_data's own
+    // dispatch succeeds, so reaching here with an unknown dtype is
+    // unreachable today — catch it anyway to keep the noexcept contract
+    // honest for any future dtype that lands in set_data before this fn.
+    try
+    {
+        dispatch_dtype(yb.format_code(),
+                       [&](auto y_tag)
+                       {
+                           dispatch_dtype(zb.format_code(),
+                                          [&](auto z_tag)
                                           {
-                                              const double xi = x_ptr[i];
-                                              if (xi < x_lo || xi > x_hi)
-                                                  continue;
-                                              for (std::size_t j = 0; j < y_per_row; ++j)
+                                              using Y = typename decltype(y_tag)::type;
+                                              using Z = typename decltype(z_tag)::type;
+                                              const auto* y_ptr = static_cast<const Y*>(yb.raw_data());
+                                              const auto* z_ptr = static_cast<const Z*>(zb.raw_data());
+                                              for (std::size_t i = 0; i < nx; ++i)
                                               {
-                                                  const std::size_t idx = i * y_per_row + j;
-                                                  const double yj = static_cast<double>(
-                                                      y_is_2d ? y_ptr[idx] : y_ptr[j]);
-                                                  if (yj < y_lo || yj > y_hi)
+                                                  const double xi = x_ptr[i];
+                                                  if (xi < x_lo || xi > x_hi)
                                                       continue;
-                                                  const double zv = static_cast<double>(z_ptr[idx]);
-                                                  if (std::isfinite(zv))
-                                                      values.push_back(zv);
+                                                  for (std::size_t j = 0; j < y_per_row; ++j)
+                                                  {
+                                                      const std::size_t idx = i * y_per_row + j;
+                                                      const double yj = static_cast<double>(
+                                                          y_is_2d ? y_ptr[idx] : y_ptr[j]);
+                                                      if (yj < y_lo || yj > y_hi)
+                                                          continue;
+                                                      const double zv = static_cast<double>(z_ptr[idx]);
+                                                      if (std::isfinite(zv))
+                                                          values.push_back(zv);
+                                                  }
                                               }
-                                          }
-                                      });
-                   });
+                                          });
+                       });
+    }
+    catch (const std::invalid_argument&)
+    {
+        return SciQLopPlotRange();
+    }
 
     return sciqlop::percentile::percentile_range(values, low, high);
 }

--- a/src/SciQLopColorMap.cpp
+++ b/src/SciQLopColorMap.cpp
@@ -20,6 +20,7 @@
 -- Mail : alexis.jeandet@member.fsf.org
 ----------------------------------------------------------------------------*/
 #include "SciQLopPlots/Plotables/SciQLopColorMap.hpp"
+#include "SciQLopPlots/PercentileMath.hpp"
 #include "SciQLopPlots/Profiling.hpp"
 #include "SciQLopPlots/Tracing.hpp"
 #include "SciQLopPlots/constants.hpp"
@@ -224,7 +225,7 @@ SciQLopPlotRange SciQLopColorMap::z_percentile_range(const SciQLopPlotRange& x_r
                                       });
                    });
 
-    return percentile_range(values, low, high);
+    return sciqlop::percentile::percentile_range(values, low, high);
 }
 
 SciQLopColorMapFunction::SciQLopColorMapFunction(QCustomPlot* parent, SciQLopPlotAxis* xAxis,

--- a/src/SciQLopColorMapBase.cpp
+++ b/src/SciQLopColorMapBase.cpp
@@ -23,7 +23,6 @@
 #include "SciQLopPlots/Plotables/AxisHelpers.hpp"
 #include <algorithm>
 #include <cmath>
-#include <vector>
 
 SciQLopColorMapBase::SciQLopColorMapBase(SciQLopPlotAxis* keyAxis, SciQLopPlotAxis* valueAxis,
                                          SciQLopPlotColorScaleAxis* colorScaleAxis,
@@ -68,27 +67,6 @@ void SciQLopColorMapBase::set_autoscale_percentile_low(double percentile) noexce
 void SciQLopColorMapBase::set_autoscale_percentile_high(double percentile) noexcept
 {
     _autoscale_percentile_high = std::clamp(percentile, 0., 100.);
-}
-
-SciQLopPlotRange SciQLopColorMapBase::percentile_range(std::vector<double>& values, double low,
-                                                       double high) noexcept
-{
-    if (values.empty())
-        return SciQLopPlotRange();
-
-    const auto rank = [n = values.size()](double p) -> std::size_t
-    {
-        const double clamped = std::clamp(p, 0., 100.);
-        const long idx = std::lround(clamped / 100. * static_cast<double>(n - 1));
-        return static_cast<std::size_t>(std::clamp<long>(idx, 0, static_cast<long>(n - 1)));
-    };
-    const std::size_t lo_idx = rank(low);
-    const std::size_t hi_idx = rank(high);
-    std::nth_element(values.begin(), values.begin() + lo_idx, values.end());
-    const double lo_val = values[lo_idx];
-    std::nth_element(values.begin(), values.begin() + hi_idx, values.end());
-    const double hi_val = values[hi_idx];
-    return SciQLopPlotRange(std::min(lo_val, hi_val), std::max(lo_val, hi_val));
 }
 
 std::optional<SciQLopPlotRange> SciQLopColorMapBase::z_rescale_range() const noexcept

--- a/src/SciQLopColorMapBase.cpp
+++ b/src/SciQLopColorMapBase.cpp
@@ -34,10 +34,11 @@ SciQLopColorMapBase::SciQLopColorMapBase(SciQLopPlotAxis* keyAxis, SciQLopPlotAx
 {
 }
 
-// Derived destructors null their QPointer then remove the plottable,
-// preventing double-removal when the base destructor runs.
 SciQLopColorMapBase::~SciQLopColorMapBase()
 {
+    // Unhook the rescale provider so the color-scale axis won't call back into
+    // our (half-destroyed) z_rescale_range. Safe if the axis has already been
+    // destroyed thanks to QPointer.
     if (_colorScaleAxis)
         _colorScaleAxis->set_rescale_range_provider(nullptr);
 }
@@ -61,11 +62,15 @@ bool SciQLopColorMapBase::selected() const noexcept
 
 void SciQLopColorMapBase::set_autoscale_percentile_low(double percentile) noexcept
 {
+    if (std::isnan(percentile))
+        return;
     _autoscale_percentile_low = std::clamp(percentile, 0., 100.);
 }
 
 void SciQLopColorMapBase::set_autoscale_percentile_high(double percentile) noexcept
 {
+    if (std::isnan(percentile))
+        return;
     _autoscale_percentile_high = std::clamp(percentile, 0., 100.);
 }
 

--- a/src/SciQLopCrosshair.cpp
+++ b/src/SciQLopCrosshair.cpp
@@ -212,10 +212,15 @@ QString SciQLopCrosshair::build_tooltip_html(double key, const QPointF& pixelPos
         // (formatting a time_point would promote to system_clock::duration's
         // resolution and emit trailing zeros). Local time matches the default
         // QCPAxisTickerDateTime spec (Qt::LocalTime).
+        // Floor-divide (not truncate-toward-zero) so pre-1970 keys land on the
+        // right second: e.g. us=-1_500_000 should give sec=-2 + frac=500_000,
+        // not sec=-1 + frac=500_000 which would render "23:59:59.5" instead
+        // of "23:59:58.5".
         const auto us = std::llround(key * 1'000'000.0);
-        const auto sec_part = static_cast<std::time_t>(us / 1'000'000);
-        const auto frac_us = static_cast<long>(
-            std::abs(us - static_cast<long long>(sec_part) * 1'000'000));
+        const long long sec_ll = (us >= 0) ? us / 1'000'000
+                                           : -((-us + 999'999) / 1'000'000);
+        const auto sec_part = static_cast<std::time_t>(sec_ll);
+        const auto frac_us = static_cast<long>(us - sec_ll * 1'000'000);
         const std::tm tm = to_local_tm(sec_part);
         header = QString::fromStdString(
             fmt::format("{:%Y-%m-%d %H:%M:%S}.{:06d}", tm, frac_us));

--- a/src/SciQLopCurve.cpp
+++ b/src/SciQLopCurve.cpp
@@ -23,6 +23,8 @@
 #include "SciQLopPlots/Plotables/SciQLopCurve.hpp"
 #include "SciQLopPlots/Plotables/SciQLopTimeColoredCurve.hpp"
 #include "SciQLopPlots/Plotables/Resamplers/SciQLopCurveResampler.hpp"
+#include "SciQLopPlots/Python/DtypeDispatch.hpp"
+#include <cmath>
 
 void SciQLopCurve::_range_changed(const QCPRange& newRange, const QCPRange& oldRange)
 {
@@ -100,6 +102,14 @@ SciQLopCurve::~SciQLopCurve()
 
 void SciQLopCurve::set_data(PyBuffer x, PyBuffer y)
 {
+    // CurveResampler reads y via PyBuffer::data() which only returns a valid
+    // double* for float64 buffers (see PythonInterface.hpp). Other dtypes
+    // would misrender silently — fail loudly instead, matching what
+    // SciQLopSingleLineGraph / SciQLopMultiGraphBase do for x.
+    if (x.is_valid() && x.format_code() != 'd')
+        throw std::runtime_error("Curve.set_data: x must be float64");
+    if (y.is_valid() && y.format_code() != 'd')
+        throw std::runtime_error("Curve.set_data: y must be float64");
     set_busy(true);
     this->_resampler->setData(x, y);
     Q_EMIT data_changed(x, y);
@@ -108,6 +118,52 @@ void SciQLopCurve::set_data(PyBuffer x, PyBuffer y)
 QList<PyBuffer> SciQLopCurve::data() const noexcept
 {
     return _resampler->get_data();
+}
+
+void SciQLopCurve::collect_visible_values(const SciQLopPlotRange& visible_key_range,
+                                          std::vector<double>& out) const noexcept
+{
+    if (!_resampler)
+        return;
+    const auto buffers = _resampler->get_data();
+    if (buffers.size() < 2)
+        return;
+    const auto& x = buffers[0];
+    const auto& y = buffers[1];
+    if (!x.is_valid() || !y.is_valid())
+        return;
+    if (x.format_code() != 'd')
+        return;
+    const std::size_t n = x.flat_size();
+    if (n == 0 || y.flat_size() < n)
+        return;
+
+    const double x_lo = visible_key_range.first;
+    const double x_hi = visible_key_range.second;
+    const double* xs = x.data();
+
+    out.reserve(out.size() + n);
+    try
+    {
+        dispatch_dtype(y.format_code(), [&](auto tag) {
+            using V = typename decltype(tag)::type;
+            const auto* ys = static_cast<const V*>(y.raw_data());
+            for (std::size_t i = 0; i < n; ++i)
+            {
+                const double xv = xs[i];
+                if (xv < x_lo || xv > x_hi)
+                    continue;
+                const double v = static_cast<double>(ys[i]);
+                if constexpr (std::is_floating_point_v<V>)
+                {
+                    if (!std::isfinite(v))
+                        continue;
+                }
+                out.push_back(v);
+            }
+        });
+    }
+    catch (const std::invalid_argument&) { /* unsupported dtype — skip */ }
 }
 
 void SciQLopCurve::set_x_axis(SciQLopPlotAxisInterface* axis) noexcept

--- a/src/SciQLopHistogram2D.cpp
+++ b/src/SciQLopHistogram2D.cpp
@@ -20,6 +20,7 @@
 -- Mail : alexis.jeandet@member.fsf.org
 ----------------------------------------------------------------------------*/
 #include "SciQLopPlots/Plotables/SciQLopHistogram2D.hpp"
+#include "SciQLopPlots/PercentileMath.hpp"
 #include "SciQLopPlots/constants.hpp"
 #include <algorithm>
 #include <cmath>
@@ -193,7 +194,7 @@ SciQLopPlotRange SciQLopHistogram2D::z_percentile_range(const SciQLopPlotRange& 
                 values.push_back(zv);
         }
     }
-    return percentile_range(values, low, high);
+    return sciqlop::percentile::percentile_range(values, low, high);
 }
 
 SciQLopHistogram2DFunction::SciQLopHistogram2DFunction(QCustomPlot* parent, SciQLopPlotAxis* xAxis,

--- a/src/SciQLopMultiGraphBase.cpp
+++ b/src/SciQLopMultiGraphBase.cpp
@@ -3,6 +3,7 @@
 #include "SciQLopPlots/Plotables/SciQLopGraphComponent.hpp"
 #include "SciQLopPlots/Profiling.hpp"
 #include "SciQLopPlots/Tracing.hpp"
+#include <cmath>
 #include <datasource/row-major-multi-datasource.h>
 #include <datasource/soa-multi-datasource.h>
 #include <vector>
@@ -142,6 +143,51 @@ void SciQLopMultiGraphBase::set_data(PyBuffer x, PyBuffer y)
 QList<PyBuffer> SciQLopMultiGraphBase::data() const noexcept
 {
     return {_x, _y};
+}
+
+void SciQLopMultiGraphBase::collect_visible_values(const SciQLopPlotRange& visible_key_range,
+                                                   std::vector<double>& out) const noexcept
+{
+    if (!_x.is_valid() || !_y.is_valid())
+        return;
+    if (_x.format_code() != 'd')
+        return;
+    const std::size_t n = _x.flat_size();
+    if (n == 0)
+        return;
+
+    const double x_lo = visible_key_range.first;
+    const double x_hi = visible_key_range.second;
+    const double* xs = _x.data();
+    const std::size_t k = (_y.ndim() == 1) ? 1 : _y.shape()[1];
+    const bool row_major = (_y.ndim() == 1) || _y.row_major();
+
+    out.reserve(out.size() + n * k);
+    try
+    {
+        dispatch_dtype(_y.format_code(), [&](auto tag) {
+            using V = typename decltype(tag)::type;
+            const auto* ys = static_cast<const V*>(_y.raw_data());
+            for (std::size_t i = 0; i < n; ++i)
+            {
+                const double x = xs[i];
+                if (x < x_lo || x > x_hi)
+                    continue;
+                for (std::size_t j = 0; j < k; ++j)
+                {
+                    const double v = static_cast<double>(
+                        row_major ? ys[i * k + j] : ys[j * n + i]);
+                    if constexpr (std::is_floating_point_v<V>)
+                    {
+                        if (!std::isfinite(v))
+                            continue;
+                    }
+                    out.push_back(v);
+                }
+            }
+        });
+    }
+    catch (const std::invalid_argument&) { /* unsupported dtype — skip */ }
 }
 
 void SciQLopMultiGraphBase::set_x_axis(SciQLopPlotAxisInterface* axis) noexcept

--- a/src/SciQLopPlotAxis.cpp
+++ b/src/SciQLopPlotAxis.cpp
@@ -21,11 +21,17 @@
 ----------------------------------------------------------------------------*/
 #include "SciQLopPlots/SciQLopPlotAxis.hpp"
 
+#include "SciQLopPlots/PercentileMath.hpp"
+#include "SciQLopPlots/Plotables/SciQLopGraphInterface.hpp"
+#include "SciQLopPlots/SciQLopPlot.hpp"
+#include "SciQLopPlots/Tracing.hpp"
 #include "SciQLopPlots/qcp_enums.hpp"
 #include "qcustomplot.h"
+#include <algorithm>
 #include <plottables/plottable-colormap2.h>
 #include <plottables/plottable-histogram2d.h>
 #include <cmath>
+#include <vector>
 
 SciQLopPlotRange SciQLopPlotAxisInterface::clamp_range(const SciQLopPlotRange& range) const noexcept
 {
@@ -317,6 +323,20 @@ bool SciQLopPlotAxis::selected() const noexcept
     return m_axis->selectedParts().testFlag(QCPAxis::spAxis);
 }
 
+void SciQLopPlotAxis::set_autoscale_percentile_low(double percentile) noexcept
+{
+    if (std::isnan(percentile))
+        return;
+    m_autoscale_percentile_low = std::clamp(percentile, 0., 100.);
+}
+
+void SciQLopPlotAxis::set_autoscale_percentile_high(double percentile) noexcept
+{
+    if (std::isnan(percentile))
+        return;
+    m_autoscale_percentile_high = std::clamp(percentile, 0., 100.);
+}
+
 void SciQLopPlotAxis::rescale() noexcept
 {
     if (m_axis.isNull())
@@ -327,8 +347,63 @@ void SciQLopPlotAxis::rescale() noexcept
     QCPRange newRange;
     bool haveRange = false;
     QCP::SignDomain signDomain = QCP::sdBoth;
-    if (m_axis->scaleType() == QCPAxis::stLogarithmic)
+    const bool is_log = m_axis->scaleType() == QCPAxis::stLogarithmic;
+    if (is_log)
         signDomain = (m_axis->range().upper < 0 ? QCP::sdNegative : QCP::sdPositive);
+
+    // Robust autoscale path: pool finite y-values across graphs on this axis,
+    // then clip to the configured percentile band. Uses the plot's own
+    // authoritative plottable list (sqp_plottables) so it can't miss anything
+    // the plot itself tracks. Only kicks in when percentiles deviate from
+    // 0/100; otherwise we fall through to the plain min/max loop below.
+    const bool wants_percentile
+        = (m_autoscale_percentile_low > 0. || m_autoscale_percentile_high < 100.);
+    if (auto* plot = qobject_cast<_impl::SciQLopPlot*>(m_axis->parentPlot()); wants_percentile && plot)
+    {
+        ::SciQLopPlots::tracing::ScopedZone _sz("axis.rescale.percentile", "rescale");
+        std::vector<double> pooled;
+        for (auto* p : plot->sqp_plottables())
+        {
+            // qobject_cast to SciQLopGraphInterface deliberately excludes
+            // colormaps/histograms: their y axis carries positional metadata
+            // (bin edges, frequency rows), not data values to pool. The
+            // legacy min/max fallthrough still considers them via QCP's own
+            // getValueRange path.
+            auto* graph = qobject_cast<SciQLopGraphInterface*>(p);
+            if (!graph || graph->y_axis() != this)
+                continue;
+            auto* keyAxis = qobject_cast<SciQLopPlotAxis*>(graph->x_axis());
+            if (!keyAxis || !keyAxis->qcp_axis())
+                continue;
+            const auto kr = keyAxis->qcp_axis()->range();
+            graph->collect_visible_values(SciQLopPlotRange(kr.lower, kr.upper), pooled);
+        }
+        if (is_log)
+        {
+            const auto cutoff
+                = [&](double v) { return signDomain == QCP::sdNegative ? v >= 0. : v <= 0.; };
+            pooled.erase(std::remove_if(pooled.begin(), pooled.end(), cutoff), pooled.end());
+        }
+        _sz.add_arg("pool_size", static_cast<int64_t>(pooled.size()));
+        if (!pooled.empty())
+        {
+            const auto r = sciqlop::percentile::percentile_range(
+                pooled, m_autoscale_percentile_low, m_autoscale_percentile_high);
+            // Degenerate (zero-width) percentile ranges happen when data has
+            // less precision than double inside the band (e.g. uint64 values
+            // larger than 2^53). QCPAxis::setRange silently rejects them, so
+            // we fall through to min/max rather than appear no-op.
+            if (!std::isnan(r.start()) && !std::isnan(r.stop()) && r.start() != r.stop())
+            {
+                // Route through set_range so clamp_range, m_last_valid_range,
+                // and the queued replot stay consistent with manual range
+                // changes (avoids the rangeChanged lambda reverting the new
+                // range when it exceeds m_max_range_size).
+                set_range(r);
+                return;
+            }
+        }
+    }
 
     for (auto* plottable : m_axis->plottables())
     {

--- a/src/SciQLopPlotAxisDelegate.cpp
+++ b/src/SciQLopPlotAxisDelegate.cpp
@@ -167,6 +167,50 @@ SciQLopPlotAxisDelegate::SciQLopPlotAxisDelegate(SciQLopPlotAxisInterface* objec
         m_layout->addRow(rangeBox);
     }
 
+    // Robust autoscale percentile: clamp the rescale range to a percentile of
+    // the visible data, so a single outlier doesn't blow up the y-axis. Only
+    // shown on **vertical** value axes — the rescale code pools graphs whose
+    // y_axis() matches `this`, so the group would be a no-op on a key (x)
+    // axis. The color-scale axis owns its own percentile group on the colormap
+    // delegate, and time axes don't autoscale on data extent.
+    if (auto* concrete = as_type<SciQLopPlotAxis>(m_object);
+        concrete && !ax->is_time_axis() && this->color_scale() == nullptr
+        && ax->orientation() == Qt::Vertical)
+    {
+        auto* percentileBox = new QGroupBox("Autoscale percentile", this);
+        auto* percentileLayout = new QFormLayout(percentileBox);
+
+        auto* lowSpin = new QDoubleSpinBox(percentileBox);
+        lowSpin->setRange(0., 100.);
+        lowSpin->setDecimals(1);
+        lowSpin->setSingleStep(0.5);
+        lowSpin->setSuffix(" %");
+        lowSpin->setValue(concrete->autoscale_percentile_low());
+        percentileLayout->addRow("Low", lowSpin);
+        connect(lowSpin, QOverload<double>::of(&QDoubleSpinBox::valueChanged), this,
+                [this](double v)
+                {
+                    if (auto* a = as_type<SciQLopPlotAxis>(m_object))
+                        a->set_autoscale_percentile_low(v);
+                });
+
+        auto* highSpin = new QDoubleSpinBox(percentileBox);
+        highSpin->setRange(0., 100.);
+        highSpin->setDecimals(1);
+        highSpin->setSingleStep(0.5);
+        highSpin->setSuffix(" %");
+        highSpin->setValue(concrete->autoscale_percentile_high());
+        percentileLayout->addRow("High", highSpin);
+        connect(highSpin, QOverload<double>::of(&QDoubleSpinBox::valueChanged), this,
+                [this](double v)
+                {
+                    if (auto* a = as_type<SciQLopPlotAxis>(m_object))
+                        a->set_autoscale_percentile_high(v);
+                });
+
+        m_layout->addRow(percentileBox);
+    }
+
     append_inspector_extensions();
 }
 

--- a/src/SciQLopSingleLineGraph.cpp
+++ b/src/SciQLopSingleLineGraph.cpp
@@ -157,6 +157,49 @@ QList<PyBuffer> SciQLopSingleLineGraph::data() const noexcept
     return {};
 }
 
+void SciQLopSingleLineGraph::collect_visible_values(const SciQLopPlotRange& visible_key_range,
+                                                    std::vector<double>& out) const noexcept
+{
+    if (!_dataHolder)
+        return;
+    const auto& x = _dataHolder->x;
+    const auto& y = _dataHolder->y;
+    if (!x.is_valid() || !y.is_valid())
+        return;
+    if (x.format_code() != 'd')
+        return;
+    const std::size_t n = x.flat_size();
+    if (n == 0 || y.flat_size() < n)
+        return;
+
+    const double x_lo = visible_key_range.first;
+    const double x_hi = visible_key_range.second;
+    const double* xs = x.data();
+
+    out.reserve(out.size() + n);
+    try
+    {
+        dispatch_dtype(y.format_code(), [&](auto tag) {
+            using V = typename decltype(tag)::type;
+            const auto* ys = static_cast<const V*>(y.raw_data());
+            for (std::size_t i = 0; i < n; ++i)
+            {
+                const double xv = xs[i];
+                if (xv < x_lo || xv > x_hi)
+                    continue;
+                const double v = static_cast<double>(ys[i]);
+                if constexpr (std::is_floating_point_v<V>)
+                {
+                    if (!std::isfinite(v))
+                        continue;
+                }
+                out.push_back(v);
+            }
+        });
+    }
+    catch (const std::invalid_argument&) { /* unsupported dtype — skip */ }
+}
+
 void SciQLopSingleLineGraph::set_x_axis(SciQLopPlotAxisInterface* axis) noexcept
 {
     apply_axis(_keyAxis, axis, [this](auto* a) { if (_graph) _graph->setKeyAxis(a); });

--- a/tests/integration/test_value_axis_autoscale_percentile.py
+++ b/tests/integration/test_value_axis_autoscale_percentile.py
@@ -1,0 +1,415 @@
+"""Robust (percentile-based) autoscale for the value (y) axis on line, curve,
+and scatter graphs.
+
+A single huge spike or extreme outlier blows up the y range and turns the rest
+of the trace into a flat line. A percentile autoscale clamps the y range to
+e.g. the 2.5/97.5 percentile of the *visible* data, making the rescale robust
+against outliers. Default percentiles are 0/100, so the behaviour is identical
+to plain min/max unless configured.
+
+Mirrors test_colormap_autoscale_percentile.py for the colormap z-axis case.
+"""
+import pytest
+import numpy as np
+from PySide6.QtCore import QCoreApplication
+from PySide6.QtWidgets import QGroupBox
+
+from SciQLopPlots import DelegateRegistry
+
+
+def _pump_events(n=50):
+    for _ in range(n):
+        QCoreApplication.processEvents()
+
+
+def _line_with_outliers(plot):
+    """1D line whose y is a smooth sine plus two extreme spikes inside the x window."""
+    n = 200
+    x = np.linspace(0., 199., n).astype(np.float64)
+    y = np.sin(x * 0.1).astype(np.float64)  # range roughly [-1, 1]
+    y[40] = 1.0e6
+    y[120] = -1.0e6
+    g = plot.line(x, y)
+    _pump_events()
+    plot.replot(True)
+    _pump_events()
+    return g, x, y
+
+
+def _multicomponent_line_with_outliers(plot):
+    """Multi-component line: 3 components, outliers on the third one only."""
+    n = 200
+    x = np.linspace(0., 199., n).astype(np.float64)
+    y = np.column_stack([
+        np.sin(x * 0.1),
+        np.cos(x * 0.1),
+        0.5 * np.sin(x * 0.2),
+    ]).astype(np.float64)  # all components in roughly [-1, 1]
+    y[40, 2] = 1.0e6
+    y[120, 2] = -1.0e6
+    g = plot.line(x, y)
+    _pump_events()
+    plot.replot(True)
+    _pump_events()
+    return g, x, y
+
+
+def _parametric_curve_with_outliers(plot):
+    """Parametric curve (x non-monotonic) with extreme y spikes.
+
+    A label is required so SciQLopCurve creates a QCPCurve component; without
+    labels the wrapper is silent (no components, visible() returns False) and
+    no rescale path would pool from it.
+    """
+    n = 200
+    t = np.linspace(0., 2. * np.pi, n).astype(np.float64)
+    x = np.cos(t).astype(np.float64)
+    y = np.sin(t).astype(np.float64)
+    y[40] = 1.0e6
+    y[120] = -1.0e6
+    g = plot.parametric_curve(x, y, labels=["curve"])
+    _pump_events()
+    plot.replot(True)
+    _pump_events()
+    return g, x, y
+
+
+class TestPercentileConfig:
+
+    def test_default_percentiles(self, plot):
+        ax = plot.y_axis()
+        assert ax.autoscale_percentile_low() == 0.0
+        assert ax.autoscale_percentile_high() == 100.0
+
+    def test_set_percentiles(self, plot):
+        ax = plot.y_axis()
+        ax.set_autoscale_percentile_low(2.5)
+        ax.set_autoscale_percentile_high(97.5)
+        assert ax.autoscale_percentile_low() == 2.5
+        assert ax.autoscale_percentile_high() == 97.5
+
+    def test_percentile_setters_clamp(self, plot):
+        ax = plot.y_axis()
+        ax.set_autoscale_percentile_low(-10.0)
+        ax.set_autoscale_percentile_high(200.0)
+        assert ax.autoscale_percentile_low() == 0.0
+        assert ax.autoscale_percentile_high() == 100.0
+
+
+class TestSingleLinePercentileRescale:
+
+    def test_full_range_includes_outliers(self, plot):
+        g, x, y = _line_with_outliers(plot)
+        plot.x_axis().set_range(float(x[0]), float(x[-1]))
+        _pump_events()
+        ax = plot.y_axis()
+        ax.rescale()
+        r = ax.range()
+        # 0/100 → plain min/max path; outliers stay in
+        assert r.start() <= -1.0e6 + 1.0
+        assert r.stop() >= 1.0e6 - 1.0
+
+    def test_percentile_excludes_outliers(self, plot):
+        g, x, y = _line_with_outliers(plot)
+        plot.x_axis().set_range(float(x[0]), float(x[-1]))
+        _pump_events()
+        ax = plot.y_axis()
+        ax.set_autoscale_percentile_low(2.5)
+        ax.set_autoscale_percentile_high(97.5)
+        ax.rescale()
+        r = ax.range()
+        # two extremes out of 200 are deep in the clipped tails; range stays
+        # well within the smooth-sine envelope of roughly [-1, 1].
+        assert abs(r.start()) < 1.5
+        assert abs(r.stop()) < 1.5
+
+
+class TestMultiComponentPercentileRescale:
+
+    def test_pools_across_components(self, plot):
+        g, x, y = _multicomponent_line_with_outliers(plot)
+        plot.x_axis().set_range(float(x[0]), float(x[-1]))
+        _pump_events()
+        ax = plot.y_axis()
+        ax.set_autoscale_percentile_low(2.5)
+        ax.set_autoscale_percentile_high(97.5)
+        ax.rescale()
+        r = ax.range()
+        # outliers are in component 2; both tails should be clipped
+        assert abs(r.start()) < 1.5
+        assert abs(r.stop()) < 1.5
+
+
+class TestVisibleKeyRangeFilter:
+
+    def test_outliers_outside_visible_range_already_excluded(self, plot):
+        g, x, y = _line_with_outliers(plot)
+        # restrict x window to skip both outlier indices (40 and 120)
+        plot.x_axis().set_range(60.0, 100.0)
+        _pump_events()
+        ax = plot.y_axis()
+        ax.rescale()
+        r = ax.range()
+        # without percentile filtering, the visible window has no outliers
+        assert abs(r.start()) < 1.5
+        assert abs(r.stop()) < 1.5
+
+    def test_percentile_with_restricted_range_still_clips(self, plot):
+        """If percentile is configured but the visible window has no outliers,
+        the percentile path runs over a small pool and still yields a sensible
+        range (no NaN, no infinity)."""
+        g, x, y = _line_with_outliers(plot)
+        plot.x_axis().set_range(60.0, 100.0)
+        _pump_events()
+        ax = plot.y_axis()
+        ax.set_autoscale_percentile_low(2.5)
+        ax.set_autoscale_percentile_high(97.5)
+        ax.rescale()
+        r = ax.range()
+        assert np.isfinite(r.start()) and np.isfinite(r.stop())
+        assert abs(r.start()) < 1.5
+        assert abs(r.stop()) < 1.5
+
+
+NUMERIC_DTYPES = [
+    np.float32, np.float64,
+    np.int8, np.uint8,
+    np.int16, np.uint16,
+    np.int32, np.uint32,
+    np.int64, np.uint64,
+]
+
+
+def _y_with_outliers(dtype, n=200):
+    """Smooth baseline in dtype's middle range, with two extreme outliers.
+
+    Outlier magnitudes are clamped to 2^52 so the int->double cast inside the
+    percentile pool stays exact for 64-bit dtypes (double has 53-bit mantissa).
+    """
+    if np.issubdtype(dtype, np.integer):
+        info = np.iinfo(dtype)
+        # Cap |value| at 2^52 so int->double is lossless for int64/uint64.
+        SAFE_DOUBLE = 1 << 52
+        type_max = min(int(info.max), SAFE_DOUBLE)
+        type_min = max(int(info.min), -SAFE_DOUBLE) if info.min < 0 else 0
+        mid = (type_min + type_max) // 2
+        amp = min(50, (type_max - type_min) // 8) or 1
+        baseline = mid + (np.sin(np.linspace(0., 2. * np.pi, n)) * amp)
+        y = baseline.astype(dtype)
+        lo, hi = type_min, type_max
+    else:
+        y = (np.sin(np.linspace(0., 2. * np.pi, n)) * 100.).astype(dtype)
+        lo, hi = -1.0e6, 1.0e6
+    y[40] = hi
+    y[120] = lo
+    return y
+
+
+def _single_line(plot, dtype):
+    n = 200
+    x = np.linspace(0., 199., n).astype(np.float64)
+    plot.line(x, _y_with_outliers(dtype, n))
+    _pump_events()
+    plot.x_axis().set_range(float(x[0]), float(x[-1]))
+    _pump_events()
+    return plot.y_axis()
+
+
+def _multi_line(plot, dtype):
+    n = 200
+    x = np.linspace(0., 199., n).astype(np.float64)
+    # 3-component y, outliers on the third column only. Sibling columns sit at
+    # the same baseline level so the percentile pool is dominated by the
+    # outlier-free middle band and the assertion can detect the clip.
+    third = _y_with_outliers(dtype, n)
+    baseline_val = int(third[100])  # any non-outlier index
+    col0 = np.full(n, baseline_val, dtype=dtype)
+    col1 = np.full(n, baseline_val, dtype=dtype)
+    y = np.column_stack([col0, col1, third]).astype(dtype)
+    plot.line(x, y)
+    _pump_events()
+    plot.x_axis().set_range(float(x[0]), float(x[-1]))
+    _pump_events()
+    return plot.y_axis()
+
+
+def _curve(plot, dtype, qtbot):
+    n = 200
+    t = np.linspace(0., 2. * np.pi, n).astype(np.float64)
+    x = np.cos(t).astype(np.float64)
+    y = _y_with_outliers(dtype, n)
+    g = plot.parametric_curve(x, y, labels=["c"])
+    qtbot.waitUntil(lambda: len(g.data()) >= 2
+                            and g.data()[0].size > 0
+                            and not g.busy(),
+                    timeout=5000)
+    plot.x_axis().set_range(-1.5, 1.5)
+    _pump_events()
+    return plot.y_axis()
+
+
+def _colormap(plot, dtype):
+    nx, ny = 50, 40
+    x = np.linspace(0., 49., nx).astype(np.float64)
+    y = np.linspace(0., 39., ny).astype(np.float64)
+    if np.issubdtype(dtype, np.integer):
+        info = np.iinfo(dtype)
+        mid = (int(info.min) + int(info.max)) // 2
+        z = np.full((nx, ny), mid, dtype=dtype)
+        z[10, 5] = info.max
+        z[20, 7] = info.min
+    else:
+        z = np.full((nx, ny), 0.5, dtype=dtype)
+        z[10, 5] = 1.0e6
+        z[20, 7] = -1.0e6
+    cmap = plot.colormap(x, y, z.ravel())
+    _pump_events()
+    return cmap  # percentile config + rescale go through the colormap, not the axis
+
+
+def _rescale_default(target):
+    if hasattr(target, "z_axis"):  # colormap
+        target.z_axis().rescale()
+    else:
+        target.rescale()
+
+
+def _rescale_with_percentile(target, low, high):
+    target.set_autoscale_percentile_low(low)
+    target.set_autoscale_percentile_high(high)
+    if hasattr(target, "z_axis"):
+        target.z_axis().rescale()
+    else:
+        target.rescale()
+
+
+def _span(target):
+    r = target.range() if hasattr(target, "z_axis") is False else target.z_axis().range()
+    return r.stop() - r.start()
+
+
+class TestPercentileMatrix:
+    """All graph kinds × all numeric dtypes: setting a non-trivial percentile
+    must clip the rescaled range tighter than the plain min/max would."""
+
+    @pytest.mark.parametrize("dtype", NUMERIC_DTYPES,
+                             ids=lambda d: np.dtype(d).name)
+    def test_single_line(self, plot, dtype):
+        ax = _single_line(plot, dtype)
+        _rescale_default(ax)
+        full = _span(ax)
+        _rescale_with_percentile(ax, 2.5, 97.5)
+        clipped = _span(ax)
+        assert np.isfinite(clipped)
+        assert clipped < full * 0.5
+
+    @pytest.mark.parametrize("dtype", NUMERIC_DTYPES,
+                             ids=lambda d: np.dtype(d).name)
+    def test_multi_line(self, plot, dtype):
+        ax = _multi_line(plot, dtype)
+        _rescale_default(ax)
+        full = _span(ax)
+        _rescale_with_percentile(ax, 2.5, 97.5)
+        clipped = _span(ax)
+        assert np.isfinite(clipped)
+        assert clipped < full * 0.5
+
+    # SciQLopCurve's CurveResampler reads y via PyBuffer::data() which is only
+    # valid for float64 (documented in PythonInterface.hpp). Non-double y crashes
+    # upstream of our percentile path, so the curve case is float64-only here.
+    @pytest.mark.parametrize("dtype", [np.float64], ids=lambda d: np.dtype(d).name)
+    def test_parametric_curve(self, plot, qtbot, dtype):
+        ax = _curve(plot, dtype, qtbot)
+        _rescale_default(ax)
+        full = _span(ax)
+        _rescale_with_percentile(ax, 2.5, 97.5)
+        clipped = _span(ax)
+        assert np.isfinite(clipped)
+        assert clipped < full * 0.5
+
+    @pytest.mark.parametrize("dtype", NUMERIC_DTYPES,
+                             ids=lambda d: np.dtype(d).name)
+    def test_colormap(self, plot, dtype):
+        cmap = _colormap(plot, dtype)
+        _rescale_default(cmap)
+        full = _span(cmap)
+        _rescale_with_percentile(cmap, 2.5, 97.5)
+        clipped = _span(cmap)
+        assert np.isfinite(clipped)
+        assert clipped < full * 0.5
+
+
+class TestParametricCurvePercentileRescale:
+
+    def test_percentile_excludes_outliers(self, plot, qtbot):
+        g, x, y = _parametric_curve_with_outliers(plot)
+        plot.x_axis().set_range(-1.5, 1.5)
+        # SciQLopCurve gathers from the resampler's committed data; wait until
+        # the worker thread has swapped _next_data into _data.
+        qtbot.waitUntil(lambda: len(g.data()) >= 2
+                                and g.data()[0].size > 0
+                                and not g.busy(),
+                        timeout=5000)
+        ax = plot.y_axis()
+        ax.set_autoscale_percentile_low(2.5)
+        ax.set_autoscale_percentile_high(97.5)
+        ax.rescale()
+        r = ax.range()
+        # the +/- 1e6 spikes must be clipped; the curve sits in [-1, 1]
+        assert abs(r.start()) < 1.5
+        assert abs(r.stop()) < 1.5
+
+
+class TestRescaleNoCrash:
+
+    def test_rescale_with_no_graphs(self, plot):
+        ax = plot.y_axis()
+        ax.set_autoscale_percentile_low(2.5)
+        ax.set_autoscale_percentile_high(97.5)
+        # empty plot — percentile path finds nothing, falls through to min/max
+        # which also finds nothing, must not crash
+        ax.rescale()
+
+    def test_rescale_nonfinite_values_ignored(self, plot):
+        n = 100
+        x = np.linspace(0., 99., n).astype(np.float64)
+        y = np.full(n, 0.5, dtype=np.float64)
+        y[10] = np.nan
+        y[20] = np.inf
+        y[30] = -np.inf
+        plot.line(x, y)
+        _pump_events()
+        plot.replot(True)
+        _pump_events()
+        plot.x_axis().set_range(float(x[0]), float(x[-1]))
+        _pump_events()
+        ax = plot.y_axis()
+        ax.set_autoscale_percentile_low(2.5)
+        ax.set_autoscale_percentile_high(97.5)
+        ax.rescale()
+        r = ax.range()
+        assert np.isfinite(r.start()) and np.isfinite(r.stop())
+
+
+class TestInspectorUI:
+    """The percentile spinboxes live on the value-axis delegate (numeric,
+    non-color-scale axes only)."""
+
+    def _group_titles(self, target, qtbot):
+        delegate = DelegateRegistry.instance().create_delegate(target, None)
+        assert delegate is not None
+        qtbot.addWidget(delegate)
+        return [g.title() for g in delegate.findChildren(QGroupBox)]
+
+    def test_value_axis_delegate_has_percentile_group(self, plot, qtbot):
+        assert "Autoscale percentile" in self._group_titles(plot.y_axis(), qtbot)
+
+    def test_x_axis_delegate_has_no_percentile_group(self, plot, qtbot):
+        # The rescale pool only collects graphs whose y_axis() == this, so the
+        # group is a no-op on key (x) axes. Hidden from the delegate to avoid
+        # the misleading control.
+        assert "Autoscale percentile" not in self._group_titles(plot.x_axis(), qtbot)
+
+    def test_time_axis_delegate_has_no_percentile_group(self, ts_plot, qtbot):
+        time_ax = ts_plot.time_axis()
+        assert "Autoscale percentile" not in self._group_titles(time_ax, qtbot)


### PR DESCRIPTION
## Summary

- Sibling of PR #62 (z-axis): adds an optional percentile clamp on the **value (y) axis** autoscale for line / curve / scatter graphs, so a single huge spike or extreme outlier no longer blows up the y range. Default 0/100 keeps today's min/max behavior; set e.g. 2.5/97.5 for outlier-robust rescaling.
- Shared percentile math extracted to `include/SciQLopPlots/PercentileMath.hpp` (`namespace sciqlop::percentile`) so the value-axis and color-scale paths use the same nearest-rank `std::nth_element` helper.
- Per-graph gather via virtual `SciQLopGraphInterface::collect_visible_values` with overrides on multi-line / single-line / curve graphs; each dispatches on the y buffer's dtype so Speasy's float32 data is pooled correctly.
- Bundled second commit: post-v0.24.0 review hardening (`QPointer` for color-scale axis, `noexcept` honesty in `z_percentile_range`, NaN guards on percentile setters, pre-1970 fix in Crosshair, `RuntimeWarning` on non-numeric provider callbacks, CI smoke-test on every wheel).

## Behavior

- `M` remains the single autoscale trigger; whether it pools min/max or percentile depends on the per-axis config.
- Inspector exposes Low/High `%` spinboxes on the value-axis delegate, **vertical axes only** (key axes would be no-ops because the rescale pool filters by `y_axis() == this`).
- `SciQLopCurve` stays float64-only (upstream `CurveResampler` limitation); `set_data` now rejects other dtypes loudly instead of silently misrendering.
- Log axes filter the pool to the active sign domain before applying the percentile.
- Degenerate (zero-width) percentile results fall through to the legacy min/max path — see `qcp_setrange_zero_width.md`.

## Test plan

- [x] All 648 existing integration tests pass.
- [x] 64 new tests in `tests/integration/test_value_axis_autoscale_percentile.py`:
  - Default 0/100 percentiles ≡ plain min/max.
  - Percentile config clamping + NaN rejection on setters.
  - Matrix: {single_line, multi_line, parametric_curve, colormap} × 10 numeric dtypes (curve restricted to float64).
  - Outlier exclusion at 2.5/97.5, visible-key-range filtering, NaN/inf skipping.
  - Empty-plot rescale doesn't crash; mixed-component pools dominated by sibling baselines.
  - Inspector UI: percentile group present on y-axis, **absent** on x-axis and time-axis.
- [x] Existing `tests/integration/test_colormap_autoscale_percentile.py` (z-axis path from PR #62) still passes — the namespace refactor preserved behavior.
- [x] `tests/integration/test_callback_non_numeric_dtype.py` confirms the `RuntimeWarning` reaches Python on bool/float16/str/object provider returns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)