### PR TITLE
fix(inspector): expose colormap z/y2 axes when added after registration

### DIFF
--- a/src/Registrations.cpp
+++ b/src/Registrations.cpp
@@ -128,6 +128,15 @@ void register_all_types()
             return {
                 QObject::connect(plot, &SciQLopPlot::graph_list_changed, plot,
                     [plot, add]() {
+                        // has_colormap() flips from false to true on the first
+                        // colormap/histogram add — re-publish the colormap axes
+                        // so they appear under the plot node. addNode is
+                        // idempotent (no-op if the axis is already a child).
+                        if (plot->has_colormap())
+                        {
+                            add(plot->z_axis());
+                            add(plot->y2_axis());
+                        }
                         for (auto p : plot->plottables())
                             add(p);
                     }),

--- a/tests/integration/test_inspector_model.py
+++ b/tests/integration/test_inspector_model.py
@@ -61,6 +61,45 @@ class TestTreeDeletion:
         force_gc()
 
 
+class TestColormapAxesExposed:
+    """When a colormap is added to a plot already registered in the inspector
+    tree, the colormap axes (z and y2) must appear under the plot node.
+
+    Regression: TypeDescriptor.children was evaluated only once at addNode
+    time, when has_colormap() was still false. graph_list_changed re-published
+    plottables but not the new axes, so y2/z stayed invisible.
+    """
+
+    def _child_names(self, model, plot_idx):
+        return {
+            model.data(model.index(r, 0, plot_idx))
+            for r in range(model.rowCount(plot_idx))
+        }
+
+    def test_colormap_added_after_panel_attached(self, qtbot, sample_colormap_data):
+        from SciQLopPlots import PlotsModel, SciQLopPlot
+        panel = SciQLopMultiPlotPanel()
+        qtbot.addWidget(panel)
+
+        plot = SciQLopPlot()
+        panel.add_plot(plot)
+        process_events()
+
+        model = PlotsModel.instance()
+        panel_idx = model.index(0, 0)
+        plot_idx = model.index(0, 0, panel_idx)
+        assert "Color Scale" not in self._child_names(model, plot_idx)
+        assert "Y Axis 2" not in self._child_names(model, plot_idx)
+
+        x, y, z = sample_colormap_data
+        plot.colormap(x, y, z)
+        process_events()
+
+        names = self._child_names(model, plot_idx)
+        assert "Color Scale" in names, names
+        assert "Y Axis 2" in names, names
+
+
 class TestNoDoubleDelete:
     """Ensure no double-delete or use-after-free on destruction cascades."""
 

--- a/tests/integration/test_inspector_model.py
+++ b/tests/integration/test_inspector_model.py
@@ -70,14 +70,24 @@ class TestColormapAxesExposed:
     plottables but not the new axes, so y2/z stayed invisible.
     """
 
-    def _child_names(self, model, plot_idx):
+    def _child_names(self, model, parent_idx):
         return {
-            model.data(model.index(r, 0, plot_idx))
-            for r in range(model.rowCount(plot_idx))
+            model.data(model.index(r, 0, parent_idx))
+            for r in range(model.rowCount(parent_idx))
         }
+
+    def _find_child(self, model, parent_idx, target):
+        from SciQLopPlots import PlotsModel
+        from PySide6.QtCore import QModelIndex
+        for r in range(model.rowCount(parent_idx)):
+            idx = model.index(r, 0, parent_idx)
+            if PlotsModel.object(idx) is target:
+                return idx
+        raise AssertionError(f"{target!r} not found")
 
     def test_colormap_added_after_panel_attached(self, qtbot, sample_colormap_data):
         from SciQLopPlots import PlotsModel, SciQLopPlot
+        from PySide6.QtCore import QModelIndex
         panel = SciQLopMultiPlotPanel()
         qtbot.addWidget(panel)
 
@@ -85,9 +95,11 @@ class TestColormapAxesExposed:
         panel.add_plot(plot)
         process_events()
 
+        # PlotsModel is a singleton — sibling panels from earlier tests may
+        # still be at row 0, so look up by object identity rather than index.
         model = PlotsModel.instance()
-        panel_idx = model.index(0, 0)
-        plot_idx = model.index(0, 0, panel_idx)
+        panel_idx = self._find_child(model, QModelIndex(), panel)
+        plot_idx = self._find_child(model, panel_idx, plot)
         assert "Color Scale" not in self._child_names(model, plot_idx)
         assert "Y Axis 2" not in self._child_names(model, plot_idx)
 


### PR DESCRIPTION
## Summary

- `PlotsModel::addNode` evaluates `TypeDescriptor.children()` exactly once at registration time. When a `SciQLopPlot` is registered, `has_colormap()` is still false, so the `z_axis()` and `y2_axis()` are never published — and remain invisible in the inspector tree even after `add_color_map` / `add_histogram2d` runs.
- Fix re-publishes both axes from the existing `graph_list_changed` lambda once `has_colormap()` flips to true. `addNode` is idempotent (`src/Model.cpp:163`), so the no-op case is free.

## Test plan

- [x] New regression `tests/integration/test_inspector_model.py::TestColormapAxesExposed::test_colormap_added_after_panel_attached` — fails on `main` (`{'ColorMap', 'X Axis', 'Y Axis'}`), passes after the fix.
- [x] Full `test_inspector_model.py` suite (6 tests) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)