### PR TITLE
fix(inspector): mirror panel order on insert + drop duplicate gradient row

### DIFF
--- a/include/SciQLopPlots/Inspector/Model/Model.hpp
+++ b/include/SciQLopPlots/Inspector/Model/Model.hpp
@@ -46,7 +46,7 @@ public:
     bool removeRows(int row, int count,
         const QModelIndex& parent = QModelIndex()) override;
 
-    void addNode(PlotsModelNode* parent, QObject* obj);
+    void addNode(PlotsModelNode* parent, QObject* obj, int row = -1);
     void removeChildByObject(PlotsModelNode* parent, QObject* obj);
     void moveChildByObject(PlotsModelNode* parent, QObject* obj, int dest_row);
 

--- a/include/SciQLopPlots/Inspector/Model/TypeDescriptor.hpp
+++ b/include/SciQLopPlots/Inspector/Model/TypeDescriptor.hpp
@@ -31,8 +31,11 @@ struct TypeDescriptor
 {
     std::function<QList<QObject*>(QObject*)> children;
 
+    // add_child(child, row): row == -1 appends, otherwise inserts at that
+    // position in the inspector children list. Use the row form when the
+    // underlying container preserves an insertion index (e.g. a splitter).
     std::function<QList<QMetaObject::Connection>(QObject* obj,
-        std::function<void(QObject*)> add_child,
+        std::function<void(QObject*, int)> add_child,
         std::function<void(QObject*)> remove_child)>
         connect_children;
 

--- a/include/SciQLopPlots/MultiPlots/SciQLopMultiPlotPanel.hpp
+++ b/include/SciQLopPlots/MultiPlots/SciQLopMultiPlotPanel.hpp
@@ -324,6 +324,7 @@ signals:
     Q_SIGNAL void span_created(MultiPlotsVerticalSpan* span);
     Q_SIGNAL void span_creation_canceled();
     Q_SIGNAL void panel_added(SciQLopPlotPanelInterface* panel);
+    Q_SIGNAL void panel_inserted(SciQLopPlotPanelInterface* panel, int at);
     Q_SIGNAL void panel_removed(SciQLopPlotPanelInterface* panel);
     Q_SIGNAL void inspector_extensions_changed();
     Q_SIGNAL void inspector_extension_added(InspectorExtension* extension);

--- a/src/Model.cpp
+++ b/src/Model.cpp
@@ -156,7 +156,7 @@ bool PlotsModel::removeRows(int row, int count, const QModelIndex& parent)
     return true;
 }
 
-void PlotsModel::addNode(PlotsModelNode* parent, QObject* obj)
+void PlotsModel::addNode(PlotsModelNode* parent, QObject* obj, int row)
 {
     if (!obj)
         return;
@@ -164,10 +164,11 @@ void PlotsModel::addNode(PlotsModelNode* parent, QObject* obj)
         return;
     auto desc = TypeRegistry::instance().descriptor(obj);
     auto parentIndex = make_index(parent);
-    int row = parent->children_count();
+    int count = parent->children_count();
+    int dest_row = (row < 0 || row > count) ? count : row;
 
-    beginInsertRows(parentIndex, row, row);
-    auto node = parent->insert_child(obj, desc);
+    beginInsertRows(parentIndex, dest_row, dest_row);
+    auto node = parent->insert_child(obj, desc, dest_row);
     endInsertRows();
 
     QPointer<PlotsModelNode> guardedNode = node;
@@ -207,10 +208,10 @@ void PlotsModel::addNode(PlotsModelNode* parent, QObject* obj)
 
     if (desc && desc->connect_children)
     {
-        auto add_child = [this, guardedNode](QObject* child)
+        auto add_child = [this, guardedNode](QObject* child, int row)
         {
             if (guardedNode)
-                addNode(guardedNode, child);
+                addNode(guardedNode, child, row);
         };
         auto remove_child = [this, guardedNode](QObject* child)
         {

--- a/src/Registrations.cpp
+++ b/src/Registrations.cpp
@@ -72,16 +72,19 @@ void register_all_types()
             auto panel = qobject_cast<SciQLopMultiPlotPanel*>(obj);
             if (!panel) return {};
             return {
-                QObject::connect(panel, &SciQLopMultiPlotPanel::plot_added, panel,
-                    [add](SciQLopPlotInterface* p) { add(p); }),
+                // plot_inserted / panel_inserted carry the splitter index so the
+                // inspector row matches the panel UI when insert_plot(0, p) is
+                // used (otherwise we'd always append).
+                QObject::connect(panel, &SciQLopMultiPlotPanel::plot_inserted, panel,
+                    [add](SciQLopPlotInterface* p, int at) { add(p, at); }),
                 QObject::connect(panel, &SciQLopMultiPlotPanel::plot_removed, panel,
                     [remove](SciQLopPlotInterface* p) { remove(p); }),
-                QObject::connect(panel, &SciQLopMultiPlotPanel::panel_added, panel,
-                    [add](SciQLopPlotPanelInterface* p) { add(p); }),
+                QObject::connect(panel, &SciQLopMultiPlotPanel::panel_inserted, panel,
+                    [add](SciQLopPlotPanelInterface* p, int at) { add(p, at); }),
                 QObject::connect(panel, &SciQLopMultiPlotPanel::panel_removed, panel,
                     [remove](SciQLopPlotPanelInterface* p) { remove(p); }),
                 QObject::connect(panel, &SciQLopMultiPlotPanel::inspector_extension_added, panel,
-                    [add](InspectorExtension* ext) { add(ext); }),
+                    [add](InspectorExtension* ext) { add(ext, -1); }),
                 QObject::connect(panel, &SciQLopMultiPlotPanel::inspector_extension_removed, panel,
                     [remove](InspectorExtension* ext) { remove(ext); }),
             };
@@ -134,14 +137,14 @@ void register_all_types()
                         // idempotent (no-op if the axis is already a child).
                         if (plot->has_colormap())
                         {
-                            add(plot->z_axis());
-                            add(plot->y2_axis());
+                            add(plot->z_axis(), -1);
+                            add(plot->y2_axis(), -1);
                         }
                         for (auto p : plot->plottables())
-                            add(p);
+                            add(p, -1);
                     }),
                 QObject::connect(plot, &SciQLopPlot::inspector_extension_added, plot,
-                    [add](InspectorExtension* ext) { add(ext); }),
+                    [add](InspectorExtension* ext) { add(ext, -1); }),
                 QObject::connect(plot, &SciQLopPlot::inspector_extension_removed, plot,
                     [remove](InspectorExtension* ext) { remove(ext); }),
             };
@@ -171,7 +174,7 @@ void register_all_types()
             if (!plot) return {};
             return {
                 QObject::connect(plot, &SciQLopNDProjectionPlot::inspector_extension_added, plot,
-                    [add](InspectorExtension* ext) { add(ext); }),
+                    [add](InspectorExtension* ext) { add(ext, -1); }),
                 QObject::connect(plot, &SciQLopNDProjectionPlot::inspector_extension_removed, plot,
                     [remove](InspectorExtension* ext) { remove(ext); }),
             };
@@ -200,7 +203,7 @@ void register_all_types()
                 QObject::connect(graph, &SciQLopGraphInterface::component_list_changed, graph,
                     [graph, add]() {
                         for (auto comp : graph->components())
-                            add(comp);
+                            add(comp, -1);
                     }),
             };
         },

--- a/src/SciQLopColorMapBaseDelegate.cpp
+++ b/src/SciQLopColorMapBaseDelegate.cpp
@@ -20,7 +20,6 @@
 -- Mail : alexis.jeandet@member.fsf.org
 ----------------------------------------------------------------------------*/
 #include "SciQLopPlots/Inspector/PropertiesDelegates/SciQLopColorMapBaseDelegate.hpp"
-#include "SciQLopPlots/Inspector/PropertiesDelegates/Delegates/ColorGradientDelegate.hpp"
 #include "SciQLopPlots/Plotables/SciQLopColorMapBase.hpp"
 
 #include <QDoubleSpinBox>
@@ -36,17 +35,8 @@ SciQLopColorMapBaseDelegate::SciQLopColorMapBaseDelegate(SciQLopColorMapBase* ob
                                                          QWidget* parent)
         : PropertyDelegateBase(object, parent)
 {
-    auto* gradient = new ColorGradientDelegate(object->gradient(), this);
-    m_layout->addRow("Gradient", gradient);
-    connect(gradient, &ColorGradientDelegate::gradientChanged, this,
-            [this](ColorGradient g)
-            {
-                if (auto* cm = color_map_base())
-                    cm->set_gradient(g);
-            });
-
-    // Robust autoscale: clamp the color (z) range to a percentile of the
-    // visible data. Defaults to 0/100, i.e. plain min/max.
+    // Gradient is owned by the color-scale axis (SciQLopPlotColorScaleAxis) and
+    // edited from the z-axis delegate. Don't duplicate it here.
     auto* percentileBox = new QGroupBox("Color scale percentile", this);
     auto* percentileLayout = new QFormLayout(percentileBox);
 

--- a/src/SciQLopMultiPlotPanel.cpp
+++ b/src/SciQLopMultiPlotPanel.cpp
@@ -64,6 +64,8 @@ SciQLopMultiPlotPanel::SciQLopMultiPlotPanel(QWidget* parent, bool synchronize_x
             &SciQLopMultiPlotPanel::plot_inserted);
     connect(_container, &SciQLopPlotContainer::plot_moved, this,
             &SciQLopMultiPlotPanel::plot_moved);
+    connect(_container, &SciQLopPlotContainer::panel_inserted, this,
+            &SciQLopMultiPlotPanel::panel_inserted);
 
     setWidget(_container);
     this->setWidgetResizable(true);

--- a/tests/fuzzing/graph_actions.py
+++ b/tests/fuzzing/graph_actions.py
@@ -28,8 +28,9 @@ def add_line_graph(panel, model, plot_index):
     precondition=lambda model: model.has_plots,
     bundles={"plot_index": "plot_indices"},
     narrate="Added colormap to plot {plot_index}",
-    # Only one colormap per plot is supported; don't track count
-    model_update=lambda model, plot_index: None,
+    model_update=lambda model, plot_index: model.graph_counts.__setitem__(
+        plot_index, model.graph_counts.get(plot_index, 0) + 1
+    ),
     verify=lambda panel, model, plot_index: True,
     settle_timeout_ms=100,
 )

--- a/tests/integration/test_inspector_insert_order.py
+++ b/tests/integration/test_inspector_insert_order.py
@@ -1,0 +1,138 @@
+"""Inspector row order must mirror the panel's splitter order when plots/panels
+are inserted at non-end positions via insert_plot / create_plot(index=...) /
+insert_panel.
+
+Regression: PlotsModel::addNode always appended to the end of children,
+so insert_plot(0, plot) made the inspector show the new plot at the bottom
+while the panel UI placed it at the top.
+"""
+import pytest
+
+from PySide6.QtCore import QModelIndex
+
+from SciQLopPlots import (
+    PlotsModel,
+    PlotType,
+    SciQLopMultiPlotPanel,
+    SciQLopPlot,
+    SciQLopTimeSeriesPlot,
+)
+from conftest import process_events
+
+
+def _panel_index(model, panel):
+    for row in range(model.rowCount(QModelIndex())):
+        idx = model.index(row, 0, QModelIndex())
+        if PlotsModel.object(idx) is panel:
+            return idx
+    raise AssertionError("panel not found in model")
+
+
+def _plot_row_in_model(model, panel_idx, plot):
+    for row in range(model.rowCount(panel_idx)):
+        idx = model.index(row, 0, panel_idx)
+        if PlotsModel.object(idx) is plot:
+            return row
+    return -1
+
+
+def _model_plot_order(model, panel_idx, plots):
+    return [_plot_row_in_model(model, panel_idx, p) for p in plots]
+
+
+def _panel_plot_order(panel, plots):
+    return [panel.index(p) for p in plots]
+
+
+class TestInsertPlotOrder:
+    def test_insert_at_zero_matches_panel(self, qtbot):
+        panel = SciQLopMultiPlotPanel()
+        qtbot.addWidget(panel)
+        p0 = SciQLopPlot()
+        p1 = SciQLopPlot()
+        p2 = SciQLopPlot()
+        panel.add_plot(p0)
+        panel.add_plot(p1)
+        panel.insert_plot(0, p2)
+        process_events()
+
+        model = PlotsModel.instance()
+        panel_idx = _panel_index(model, panel)
+
+        assert _panel_plot_order(panel, [p0, p1, p2]) == [1, 2, 0]
+        assert _model_plot_order(model, panel_idx, [p0, p1, p2]) == [1, 2, 0]
+
+    def test_insert_in_middle_matches_panel(self, qtbot):
+        panel = SciQLopMultiPlotPanel()
+        qtbot.addWidget(panel)
+        p0 = SciQLopPlot()
+        p1 = SciQLopPlot()
+        p2 = SciQLopPlot()
+        panel.add_plot(p0)
+        panel.add_plot(p1)
+        panel.insert_plot(1, p2)
+        process_events()
+
+        model = PlotsModel.instance()
+        panel_idx = _panel_index(model, panel)
+
+        assert _panel_plot_order(panel, [p0, p1, p2]) == [0, 2, 1]
+        assert _model_plot_order(model, panel_idx, [p0, p1, p2]) == [0, 2, 1]
+
+    def test_create_plot_with_index_matches_panel(self, qtbot):
+        panel = SciQLopMultiPlotPanel(synchronize_time=True)
+        qtbot.addWidget(panel)
+        p0 = panel.create_plot(plot_type=PlotType.TimeSeries)
+        p1 = panel.create_plot(plot_type=PlotType.TimeSeries)
+        p_top = panel.create_plot(index=0, plot_type=PlotType.TimeSeries)
+        process_events()
+
+        model = PlotsModel.instance()
+        panel_idx = _panel_index(model, panel)
+        plots = [p0, p1, p_top]
+        assert _panel_plot_order(panel, plots) == [1, 2, 0]
+        assert _model_plot_order(model, panel_idx, plots) == [1, 2, 0]
+
+    def test_append_still_works(self, qtbot):
+        panel = SciQLopMultiPlotPanel()
+        qtbot.addWidget(panel)
+        p0 = SciQLopPlot()
+        p1 = SciQLopPlot()
+        panel.add_plot(p0)
+        panel.add_plot(p1)
+        process_events()
+
+        model = PlotsModel.instance()
+        panel_idx = _panel_index(model, panel)
+        assert _model_plot_order(model, panel_idx, [p0, p1]) == [0, 1]
+
+
+class TestInsertPanelOrder:
+    def test_insert_panel_at_zero_matches_splitter(self, qtbot):
+        parent = SciQLopMultiPlotPanel()
+        qtbot.addWidget(parent)
+        plot0 = SciQLopPlot()
+        sub = SciQLopMultiPlotPanel(parent=parent)
+        parent.add_plot(plot0)
+        parent.insert_panel(0, sub)
+        process_events()
+
+        # In the splitter, sub is at widget index 0, plot0 at index 1
+        widgets = parent.child_widgets()
+        assert widgets[0] is sub
+        assert widgets[1] is plot0
+
+        model = PlotsModel.instance()
+        parent_idx = _panel_index(model, parent)
+        # Inspector children should match splitter order
+        row_sub = -1
+        row_plot = -1
+        for row in range(model.rowCount(parent_idx)):
+            idx = model.index(row, 0, parent_idx)
+            obj = PlotsModel.object(idx)
+            if obj is sub:
+                row_sub = row
+            elif obj is plot0:
+                row_plot = row
+        assert row_sub == 0
+        assert row_plot == 1

--- a/tests/manual-tests/test_inspector_properties.py
+++ b/tests/manual-tests/test_inspector_properties.py
@@ -53,7 +53,10 @@ class TestHarnessSanity(unittest.TestCase):
 
 
 class TestHistogram2DDelegate(unittest.TestCase):
-    """Histogram2D delegate: gradient (inherited), bins, normalization."""
+    """Histogram2D delegate: bins, normalization, Color scale percentile.
+
+    Gradient is exposed on the color-scale (z) axis delegate, not here.
+    """
 
     def setUp(self):
         self.panel = SciQLopMultiPlotPanel(synchronize_x=False)
@@ -73,10 +76,9 @@ class TestHistogram2DDelegate(unittest.TestCase):
         self.panel.deleteLater()
 
     def _norm_combo(self):
-        # The Histogram2D delegate has two QComboBox children: the inherited
-        # ColorGradientDelegate combo (5+ items) and the normalization combo
-        # (exactly 2 items: 'None' and 'Per-column'). Identify by item count
-        # and first-item text rather than by findChild order.
+        # The normalization combo has exactly 2 items ('None' / 'Per-column').
+        # Identify by item count + first-item text to stay robust against
+        # incidental sibling combos.
         for combo in self.delegate.findChildren(QComboBox):
             if combo.count() == 2 and combo.itemText(0) == 'None':
                 return combo
@@ -165,7 +167,10 @@ class TestHistogram2DDelegate(unittest.TestCase):
 
 
 class TestColorMapDelegate(unittest.TestCase):
-    """ColorMap delegate: gradient (inherited), auto_scale_y, Contours group."""
+    """ColorMap delegate: Color scale percentile, auto_scale_y, Contours group.
+
+    Gradient lives on the color-scale (z) axis delegate, not here.
+    """
 
     def setUp(self):
         self.panel = SciQLopMultiPlotPanel(synchronize_x=False)
@@ -265,6 +270,74 @@ class TestColorMapDelegate(unittest.TestCase):
         self.cmap.set_auto_contour_levels(0)
         spin = self._contours_box().findChildren(QSpinBox)[0]
         self.assertEqual(spin.value(), 0)
+
+
+class TestColorMapGradientLivesOnAxis(unittest.TestCase):
+    """Gradient appears only on the color-scale (z) axis delegate.
+
+    Previously the row was duplicated on both the colormap product node and
+    the z-axis node — same underlying state, two widgets. Regression test for
+    that dedupe.
+    """
+
+    def setUp(self):
+        self.panel = SciQLopMultiPlotPanel(synchronize_x=False)
+        x = np.linspace(0, 10, 20)
+        y = np.linspace(0, 10, 20)
+        z = np.outer(np.sin(x), np.cos(y))
+        self.plot, self.cmap = self.panel.plot(
+            x, y, z,
+            plot_type=PlotType.BasicXY,
+            graph_type=GraphType.ColorMap,
+        )
+
+    def tearDown(self):
+        self.panel.deleteLater()
+
+    @staticmethod
+    def _gradient_combo(widget):
+        from SciQLopPlots import ColorGradient
+        for combo in widget.findChildren(QComboBox):
+            if combo.count() > 0 and isinstance(combo.itemData(0), ColorGradient):
+                return combo
+        return None
+
+    def test_colormap_delegate_has_no_gradient(self):
+        delegate = make_delegate_for(self.cmap)
+        try:
+            self.assertIsNone(
+                self._gradient_combo(delegate),
+                "ColorMap product node must NOT carry a gradient widget — "
+                "the color-scale axis node owns it",
+            )
+        finally:
+            delegate.deleteLater()
+
+    def test_z_axis_delegate_has_gradient(self):
+        delegate = make_delegate_for(self.plot.z_axis())
+        try:
+            self.assertIsNotNone(
+                self._gradient_combo(delegate),
+                "Color-scale (z) axis delegate must expose the gradient combo",
+            )
+        finally:
+            delegate.deleteLater()
+
+    def test_z_axis_gradient_edit_propagates_to_colormap(self):
+        from SciQLopPlots import ColorGradient
+        delegate = make_delegate_for(self.plot.z_axis())
+        try:
+            combo = self._gradient_combo(delegate)
+            self.assertIsNotNone(combo)
+            target = ColorGradient.Hot if self.cmap.gradient() != ColorGradient.Hot \
+                else ColorGradient.Cold
+            target_idx = next(i for i in range(combo.count())
+                              if combo.itemData(i) == target)
+            combo.setCurrentIndex(target_idx)
+            self.assertEqual(self.cmap.gradient(), target,
+                             "z-axis gradient edit must reach the colormap")
+        finally:
+            delegate.deleteLater()
 
 
 class TestGraphComponentDelegate(unittest.TestCase):


### PR DESCRIPTION
## Summary

Two inspector cleanups bundled together:

- **Insert-order mismatch**: `PlotsModel::addNode` always appended new children, so `insert_plot(0, p)` / `create_plot(index=0, ...)` / drop-to-create at non-end positions showed the plot at the top of the panel UI but at the bottom of the inspector tree. Drag-reorder was unaffected (it routes through `plot_moved` with an explicit index). Now the splitter index flows through `plot_inserted` / `panel_inserted` signals into `addNode`, so the inspector mirrors the panel.
  - `TypeDescriptor`'s `add_child` callback signature becomes `void(QObject*, int row)` (-1 = append).
  - `SciQLopMultiPlotPanel` forwards a new `panel_inserted(panel, int)` signal from its container, mirroring the existing `plot_inserted` forwarding.

- **Duplicate gradient row**: the gradient widget was shown both on the colormap product node and on the color-scale (z) axis node — same underlying state, two widgets. Keep it only on the axis delegate where the per-axis color-scale settings live.

- **Fuzzing fix** (caught while running the suite): `add_colormap`'s `model_update` was `None` even though the workflow tests asserted `graph_counts` increments. A colormap is a plottable, so it now increments `graph_counts` like `add_line_graph` does.

## Test plan

- [x] New reproducer test `tests/integration/test_inspector_insert_order.py` (5 cases covering `insert_plot(0, ...)`, mid-list insert, `create_plot(index=...)`, append, and `insert_panel(0, ...)`). Verified all 4 ordering tests fail on `main` and pass with the fix.
- [x] Integration suite: 654/654 pass.
- [x] Unit + fuzzing: 141/141 pass (was 139/141 before the `add_colormap` fuzzing fix).
- [x] Verified live in SciQLop session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)