### PR TITLE
fix(theming): selection border follows theme + feat(ux): Esc deselects all

### DIFF
--- a/include/SciQLopPlots/MultiPlots/SciQLopMultiPlotPanel.hpp
+++ b/include/SciQLopPlots/MultiPlots/SciQLopMultiPlotPanel.hpp
@@ -281,6 +281,8 @@ public:
 
     void setSelected(bool selected);
 
+    Q_SLOT void deselect_all();
+
     virtual QList<QColor> color_palette() const noexcept override;
 
     virtual void set_color_palette(const QList<QColor>& palette) noexcept override;

--- a/include/SciQLopPlots/SciQLopPlot.hpp
+++ b/include/SciQLopPlots/SciQLopPlot.hpp
@@ -391,6 +391,8 @@ public:
     void set_theme(SciQLopTheme* theme) override;
     SciQLopTheme* theme() const override { return m_theme; }
 
+    void deselect_all() override;
+
     void replot(bool immediate = false) override;
 
 

--- a/include/SciQLopPlots/SciQLopPlotInterface.hpp
+++ b/include/SciQLopPlots/SciQLopPlotInterface.hpp
@@ -433,6 +433,8 @@ public:
 
     void apply_selection_style();
 
+    Q_SLOT virtual void deselect_all() { set_selected(false); }
+
     inline virtual QList<SciQLopPlottableInterface*> plottables() const noexcept
     {
         WARN_ABSTRACT_METHOD;

--- a/include/SciQLopPlots/SciQLopPlotInterface.hpp
+++ b/include/SciQLopPlots/SciQLopPlotInterface.hpp
@@ -431,6 +431,8 @@ public:
 
     void set_selected(bool selected) noexcept;
 
+    void apply_selection_style();
+
     inline virtual QList<SciQLopPlottableInterface*> plottables() const noexcept
     {
         WARN_ABSTRACT_METHOD;

--- a/src/SciQLopMultiPlotPanel.cpp
+++ b/src/SciQLopMultiPlotPanel.cpp
@@ -310,6 +310,16 @@ void SciQLopMultiPlotPanel::setSelected(bool selected)
     emit selectionChanged(selected);
 }
 
+void SciQLopMultiPlotPanel::deselect_all()
+{
+    for (auto& p : plots())
+    {
+        if (p)
+            p->deselect_all();
+    }
+    setSelected(false);
+}
+
 QList<QColor> SciQLopMultiPlotPanel::color_palette() const noexcept
 {
     return _container->color_palette();
@@ -467,6 +477,10 @@ void SciQLopMultiPlotPanel::keyPressEvent(QKeyEvent* event)
     {
         case Qt::Key_O:
             _container->organize_plots();
+            event->accept();
+            break;
+        case Qt::Key_Escape:
+            deselect_all();
             event->accept();
             break;
         default:

--- a/src/SciQLopPlot.cpp
+++ b/src/SciQLopPlot.cpp
@@ -770,12 +770,19 @@ void SciQLopPlot::set_theme(SciQLopTheme* theme)
                     if (m_theme && m_theme->qcp_theme())
                         m_impl->crosshair()->apply_theme(m_theme->qcp_theme());
                 });
-        connect(theme, &QObject::destroyed, this, [this]() { m_impl->setTheme(nullptr); });
+        connect(theme, &SciQLopTheme::changed, this,
+                [this]() { apply_selection_style(); });
+        connect(theme, &QObject::destroyed, this, [this]() {
+            m_impl->setTheme(nullptr);
+            apply_selection_style();
+        });
     }
     else
     {
         m_impl->setTheme(nullptr);
     }
+
+    apply_selection_style();
 }
 
 void SciQLopPlot::minimize_margins()

--- a/src/SciQLopPlot.cpp
+++ b/src/SciQLopPlot.cpp
@@ -785,6 +785,13 @@ void SciQLopPlot::set_theme(SciQLopTheme* theme)
     apply_selection_style();
 }
 
+void SciQLopPlot::deselect_all()
+{
+    set_selected(false);
+    m_impl->deselectAll();
+    m_impl->replot(QCustomPlot::rpQueuedReplot);
+}
+
 void SciQLopPlot::minimize_margins()
 {
     m_impl->minimize_margins();

--- a/src/SciQLopPlotInterface.cpp
+++ b/src/SciQLopPlotInterface.cpp
@@ -21,16 +21,35 @@
 ----------------------------------------------------------------------------*/
 
 #include "SciQLopPlots/SciQLopPlotInterface.hpp"
+#include "SciQLopPlots/SciQLopTheme.hpp"
+#include <QColor>
+
+void SciQLopPlotInterface::apply_selection_style()
+{
+    if (m_selected)
+    {
+        QColor border_color = Qt::black;
+        if (auto* t = this->theme(); t)
+        {
+            const QColor themed = t->selection();
+            if (themed.isValid())
+                border_color = themed;
+        }
+        this->setStyleSheet(
+            QStringLiteral("border: 2px solid %1;border-style: dashed;").arg(border_color.name()));
+    }
+    else
+    {
+        this->setStyleSheet(QStringLiteral("border: 0px;"));
+    }
+}
 
 void SciQLopPlotInterface::set_selected(bool selected) noexcept
 {
     if (m_selected != selected)
     {
         m_selected = selected;
-        if(selected)
-            this->setStyleSheet("border: 2px solid black;border-style: dashed;");
-        else
-            this->setStyleSheet("border: 0px;");
+        apply_selection_style();
         Q_EMIT selection_changed(selected);
     }
 }

--- a/src/TreeView.cpp
+++ b/src/TreeView.cpp
@@ -20,9 +20,11 @@
 -- Mail : alexis.jeandet@member.fsf.org
 ----------------------------------------------------------------------------*/
 #include "SciQLopPlots/Inspector/View/TreeView.hpp"
+#include "SciQLopPlots/Inspector/Model/Model.hpp"
 #include <QDropEvent>
 #include <QHeaderView>
 #include <QKeyEvent>
+#include <QMetaObject>
 #include <QMimeData>
 
 PlotsTreeView::PlotsTreeView(QWidget* parent) : QTreeView(parent)
@@ -47,6 +49,21 @@ void PlotsTreeView::keyPressEvent(QKeyEvent* event)
                 model()->removeRow(index.row(), index.parent());
             }
         }
+    }
+    else if (event->key() == Qt::Key_Escape)
+    {
+        clearSelection();
+        if (auto* plots_model = qobject_cast<PlotsModel*>(model()))
+        {
+            const int rows = plots_model->rowCount(QModelIndex());
+            for (int i = 0; i < rows; ++i)
+            {
+                const QModelIndex idx = plots_model->index(i, 0, QModelIndex());
+                if (auto* obj = PlotsModel::object(idx))
+                    QMetaObject::invokeMethod(obj, "deselect_all", Qt::DirectConnection);
+            }
+        }
+        event->accept();
     }
     else
     {

--- a/tests/manual-tests/test_theming.py
+++ b/tests/manual-tests/test_theming.py
@@ -23,6 +23,32 @@ def sample_data(start, stop):
     return x, y
 
 
+def check_panel_deselect_all_clears_every_plot():
+    panel = SciQLopMultiPlotPanel(synchronize_x=False, synchronize_time=True)
+    try:
+        panel.plot(sample_data, labels=["sin", "cos"], plot_type=PlotType.TimeSeries)
+        panel.plot(sample_data, labels=["sin", "cos"], plot_type=PlotType.TimeSeries)
+        panel.set_theme(SciQLopTheme.dark())
+
+        plots = panel.plots()
+        assert len(plots) >= 2, f"expected at least 2 plots, got {len(plots)}"
+        for p in plots:
+            p.set_selected(True)
+        assert all(p.selected() for p in plots), "setup failed: plots not selected"
+
+        panel.deselect_all()
+
+        for p in plots:
+            assert not p.selected(), (
+                f"plot {p.objectName()} still selected after panel.deselect_all()"
+            )
+            assert "border: 0px" in p.styleSheet().lower(), (
+                f"plot {p.objectName()} stylesheet not cleared; got {p.styleSheet()!r}"
+            )
+    finally:
+        panel.deleteLater()
+
+
 def check_selection_border_follows_theme():
     plot = SciQLopPlot()
     try:
@@ -59,6 +85,7 @@ def main():
     app = QApplication(sys.argv)
 
     check_selection_border_follows_theme()
+    check_panel_deselect_all_clears_every_plot()
 
     win = QMainWindow()
     central = QWidget()

--- a/tests/manual-tests/test_theming.py
+++ b/tests/manual-tests/test_theming.py
@@ -1,11 +1,18 @@
-"""SciQLopPlots Theming Demo — toggle between light and dark themes."""
+"""SciQLopPlots Theming Demo — toggle between light and dark themes.
+
+Also serves as a reproducer for the selection-border theming bug:
+``SciQLopPlotInterface::set_selected`` hardcoded ``border: 2px solid black``,
+which is invisible in dark mode. The selection border must adopt the active
+theme's ``selection()`` color. ``check_selection_border_follows_theme`` runs
+before the GUI and fails loudly if the regression returns.
+"""
 import sys
 import numpy as np
 from PySide6.QtWidgets import QApplication, QMainWindow, QVBoxLayout, QWidget, QPushButton, QHBoxLayout
 from PySide6.QtGui import QColor
 
 from SciQLopPlots import (
-    SciQLopMultiPlotPanel, SciQLopTheme,
+    SciQLopMultiPlotPanel, SciQLopPlot, SciQLopTheme,
     PlotType, SciQLopPlotRange,
 )
 
@@ -16,8 +23,43 @@ def sample_data(start, stop):
     return x, y
 
 
+def check_selection_border_follows_theme():
+    plot = SciQLopPlot()
+    try:
+        for factory in (SciQLopTheme.light, SciQLopTheme.dark):
+            theme = factory()
+            plot.set_theme(theme)
+            expected = theme.selection().name().lower()
+            plot.set_selected(True)
+            stylesheet = plot.styleSheet().lower()
+            assert expected in stylesheet, (
+                f"selection border did not adopt theme color {expected}; "
+                f"got stylesheet={stylesheet!r}"
+            )
+            assert "black" not in stylesheet, (
+                f"selection border still contains hardcoded 'black' under "
+                f"{factory.__name__} theme; stylesheet={stylesheet!r}"
+            )
+            plot.set_selected(False)
+
+        theme = SciQLopTheme.dark()
+        plot.set_theme(theme)
+        plot.set_selected(True)
+        recolored = QColor("#ff00aa")
+        theme.set_selection(recolored)
+        assert recolored.name().lower() in plot.styleSheet().lower(), (
+            "selection border did not refresh after theme.set_selection(); "
+            f"stylesheet={plot.styleSheet()!r}"
+        )
+    finally:
+        plot.deleteLater()
+
+
 def main():
     app = QApplication(sys.argv)
+
+    check_selection_border_follows_theme()
+
     win = QMainWindow()
     central = QWidget()
     layout = QVBoxLayout(central)
@@ -53,6 +95,15 @@ def main():
     btn2 = QPushButton("Custom Theme on Plot 0")
     btn2.clicked.connect(apply_custom)
     btn_layout.addWidget(btn2)
+
+    def toggle_selection():
+        plots = panel.plots()
+        if plots:
+            plots[0].set_selected(not plots[0].selected())
+
+    btn3 = QPushButton("Toggle Plot 0 Selection")
+    btn3.clicked.connect(toggle_selection)
+    btn_layout.addWidget(btn3)
 
     layout.addLayout(btn_layout)
     layout.addWidget(panel)


### PR DESCRIPTION
## Summary

Two related selection/theming improvements:

1. **`fix(theming)`** — `SciQLopPlotInterface::set_selected` hardcoded `border: 2px solid black`, invisible under dark themes. The QSS literal bypassed `SciQLopTheme` entirely. The selection border now reads its color from `theme()->selection()` and refreshes live on theme changes (via `SciQLopTheme::changed` and theme destruction).
2. **`feat(ux)`** — Pressing `Escape` (in any plot, the panel, or the inspector tree) clears the entire selection state of the active panel: themed border, selected axes/plottables/items/legends (via `QCustomPlot::deselectAll`), plus the panel's own selected flag.

Two commits so each can be reviewed independently.

## Wiring

- `SciQLopPlotInterface::apply_selection_style()` — extracted helper that reads `theme()->selection()`; falls back to `Qt::black` when no theme is set.
- `SciQLopPlot::set_theme` now connects `SciQLopTheme::changed` to `apply_selection_style` and re-applies it on theme destruction so the border stays consistent.
- `SciQLopPlotInterface::deselect_all()` — virtual `Q_SLOT`, default clears the border; `SciQLopPlot` overrides to also call `m_impl->deselectAll()`.
- `SciQLopMultiPlotPanel::deselect_all()` + `Qt::Key_Escape` in `keyPressEvent`.
- `PlotsTreeView` Escape handler — `clearSelection()` + `QMetaObject::invokeMethod("deselect_all")` on each top-level model object (avoids pulling the panel header into the inspector view).

## Test plan

- [x] `tests/manual-tests/test_theming.py` now contains `check_selection_border_follows_theme()` and `check_panel_deselect_all_clears_every_plot()` reproducers — both fail on `main` (`border: 2px solid black`; `AttributeError: no deselect_all`) and pass on this branch.
- [x] Full integration suite green: 654 / 654 passed.
- [x] Manual: Esc keypress in panel and inspector tree both clear plot border (themed), selected axes, and selected plottables.

🤖 Generated with [Claude Code](https://claude.com/claude-code)