### PR TITLE
fix: data-producer GIL/threading hardening + race fixes

### DIFF
--- a/include/SciQLopPlots/DataProducer/DataProducer.hpp
+++ b/include/SciQLopPlots/DataProducer/DataProducer.hpp
@@ -48,11 +48,17 @@ using _NDdata = QList<PyBuffer>;
 class DataProviderInterface : public QObject
 {
     Q_OBJECT
-    std::variant<SciQLopPlotRange, _2D_data, _3D_data, _NDdata> m_next_state;
-    std::variant<SciQLopPlotRange, _2D_data, _3D_data, _NDdata> m_current_state;
+    // Range-based and data-based updates use independent pending slots so a
+    // call(range) and a call(x,y) racing on the same provider never overwrite
+    // each other (each is serviced; neither is dropped). A single shared slot
+    // used to let the second caller clobber the first and suppress its wake-up.
+    SciQLopPlotRange m_next_range;
+    std::variant<std::monostate, _2D_data, _3D_data, _NDdata> m_next_data;
+    SciQLopPlotRange m_current_range;
     QTimer* m_rate_limit_timer;
     QMutex m_mutex;
-    bool m_has_pending_change = false;
+    bool m_range_pending = false;
+    bool m_data_pending = false;
     bool m_force_next_update = false;
 
 #ifndef BINDINGS_H

--- a/include/SciQLopPlots/DataProducer/DataProducer.hpp
+++ b/include/SciQLopPlots/DataProducer/DataProducer.hpp
@@ -29,6 +29,7 @@
 #include <QPointer>
 #include <QThread>
 #include <QTimer>
+#include <memory>
 
 struct _2D_data
 {
@@ -154,12 +155,34 @@ public:
 class SimplePyCallablePWrapper : public DataProviderInterface
 {
     Q_OBJECT
-    GetDataPyCallable m_callable;
+    // Held by shared_ptr so the worker can take a stable snapshot under the
+    // mutex with a pure (C++ atomic) refcount bump — NO Python incref, so the
+    // GIL is never acquired while m_callable_mutex is held. Copying the callable
+    // directly used to incref under the lock (mutex→GIL), which deadlocks
+    // against set_callable()/callable() called from Python (GIL→mutex). The
+    // snapshot also lets us call into the old callable safely if it is swapped
+    // out concurrently: the snapshot keeps it alive until the call returns.
+    std::shared_ptr<GetDataPyCallable> m_callable;
     mutable QMutex m_callable_mutex;
+
+    inline std::shared_ptr<GetDataPyCallable> _snapshot_callable() const
+    {
+        QMutexLocker lock(&m_callable_mutex);
+        return m_callable; // atomic refcount bump, no GIL
+    }
+
+    static inline QList<PyBuffer> _to_qlist(std::vector<PyBuffer>&& r)
+    {
+        QList<PyBuffer> result;
+        for (auto& a : r)
+            result.emplace_back(std::move(a));
+        return result;
+    }
 
 public:
     SimplePyCallablePWrapper(GetDataPyCallable&& callable, QObject* parent = nullptr)
-            : DataProviderInterface(parent), m_callable(std::move(callable))
+            : DataProviderInterface(parent)
+            , m_callable(std::make_shared<GetDataPyCallable>(std::move(callable)))
     {
     }
 
@@ -167,47 +190,37 @@ public:
 
     inline virtual QList<PyBuffer> get_data(double lower, double upper) override
     {
-        GetDataPyCallable cb;
-        { QMutexLocker lock(&m_callable_mutex); cb = m_callable; }
-        auto r = cb.get_data(lower, upper);
-        QList<PyBuffer> result;
-        for (auto& a : r)
-            result.emplace_back(std::move(a));
-        return result;
+        auto cb = _snapshot_callable();
+        return cb ? _to_qlist(cb->get_data(lower, upper)) : QList<PyBuffer> {};
     }
 
     inline virtual QList<PyBuffer> get_data(PyBuffer x, PyBuffer y) override
     {
-        GetDataPyCallable cb;
-        { QMutexLocker lock(&m_callable_mutex); cb = m_callable; }
-        auto r = cb.get_data(x, y);
-        QList<PyBuffer> result;
-        for (auto& a : r)
-            result.emplace_back(std::move(a));
-        return result;
+        auto cb = _snapshot_callable();
+        return cb ? _to_qlist(cb->get_data(x, y)) : QList<PyBuffer> {};
     }
 
     inline virtual QList<PyBuffer> get_data(PyBuffer x, PyBuffer y, PyBuffer z) override
     {
-        GetDataPyCallable cb;
-        { QMutexLocker lock(&m_callable_mutex); cb = m_callable; }
-        auto r = cb.get_data(x, y, z);
-        QList<PyBuffer> result;
-        for (auto& a : r)
-            result.emplace_back(std::move(a));
-        return result;
+        auto cb = _snapshot_callable();
+        return cb ? _to_qlist(cb->get_data(x, y, z)) : QList<PyBuffer> {};
     }
 
     inline void set_callable(GetDataPyCallable&& callable)
     {
+        auto next = std::make_shared<GetDataPyCallable>(std::move(callable));
         QMutexLocker lock(&m_callable_mutex);
-        m_callable = std::move(callable);
+        m_callable.swap(next);
+        // `lock` (declared last) unlocks before `next` (the old callable) is
+        // destroyed at scope exit, so the old callable's Python decref happens
+        // outside the mutex — and defers if this thread lacks the GIL.
     }
 
     inline GetDataPyCallable callable() const
     {
-        QMutexLocker lock(&m_callable_mutex);
-        return m_callable;
+        auto cb = _snapshot_callable();
+        // Copy (Python incref) happens here, OUTSIDE the mutex — never mutex→GIL.
+        return cb ? *cb : GetDataPyCallable();
     }
 };
 

--- a/include/SciQLopPlots/Plotables/SciQLopCurve.hpp
+++ b/include/SciQLopPlots/Plotables/SciQLopCurve.hpp
@@ -43,8 +43,6 @@ class SciQLopCurve : public SQPQCPAbstractPlottableWrapper
 
     // inline QCustomPlot* _plot() const { return qobject_cast<QCustomPlot*>(this->parent()); }
 
-    void _range_changed(const QCPRange& newRange, const QCPRange& oldRange);
-
     void _setCurveData(QList<QVector<QCPCurveData>> data);
 
     void clear_curves(bool curve_already_removed = false);

--- a/include/SciQLopPlots/SciQLopNDProjectionPlot.hpp
+++ b/include/SciQLopPlots/SciQLopNDProjectionPlot.hpp
@@ -42,6 +42,7 @@ protected:
     QColor m_time_color_start { 0, 0, 255 };
     QColor m_time_color_end { 255, 0, 0 };
     QList<QCPItemEllipse*> m_time_markers;
+    QPointer<SciQLopTheme> m_theme;
 
     Q_SLOT void _enforce_equal_aspect();
     void _ensure_marker_layer();
@@ -118,4 +119,7 @@ public:
     {
         return m_time_axis;
     }
+
+    void set_theme(SciQLopTheme* theme) override;
+    inline SciQLopTheme* theme() const override { return m_theme; }
 };

--- a/src/DataProducer.cpp
+++ b/src/DataProducer.cpp
@@ -26,44 +26,41 @@
 
 void DataProviderInterface::_threaded_update()
 {
-    m_mutex.lock();
-    if (std::holds_alternative<SciQLopPlotRange>(m_next_state))
+    SciQLopPlotRange range;
+    bool do_range = false;
+    std::variant<std::monostate, _2D_data, _3D_data, _NDdata> data;
+    bool do_data = false;
     {
-        auto new_range = std::get<SciQLopPlotRange>(m_next_state);
-        m_has_pending_change = false;
-        m_mutex.unlock();
-        _range_based_update(new_range);
+        QMutexLocker lock(&m_mutex);
+        if (m_range_pending)
+        {
+            range = m_next_range;
+            m_range_pending = false;
+            do_range = true;
+        }
+        if (m_data_pending)
+        {
+            data = m_next_data;
+            m_data_pending = false;
+            do_data = true;
+        }
     }
-    else if (std::holds_alternative<_2D_data>(m_next_state))
-    {
-        auto new_data = std::get<_2D_data>(m_next_state);
-        m_has_pending_change = false;
-        m_mutex.unlock();
-        _data_based_update(new_data);
-    }
-    else if (std::holds_alternative<_3D_data>(m_next_state))
-    {
-        auto new_data = std::get<_3D_data>(m_next_state);
-        m_has_pending_change = false;
-        m_mutex.unlock();
-        _data_based_update(new_data);
-    }
-    else if (std::holds_alternative<_NDdata>(m_next_state))
-    {
-        auto new_data = std::get<_NDdata>(m_next_state);
-        m_has_pending_change = false;
-        m_mutex.unlock();
-        _data_based_update(new_data);
-    }
-    else
-    {
-        m_mutex.unlock();
-    }
+
+    if (do_range)
+        _range_based_update(range);
+    if (do_data)
+        std::visit(
+            [this](auto&& d)
+            {
+                if constexpr (!std::is_same_v<std::decay_t<decltype(d)>, std::monostate>)
+                    _data_based_update(d);
+            },
+            data);
 
     bool idle = false;
     {
         QMutexLocker lock(&m_mutex);
-        idle = !m_has_pending_change;
+        idle = !m_range_pending && !m_data_pending;
     }
     if (idle)
         Q_EMIT pipeline_idle();
@@ -93,11 +90,10 @@ void DataProviderInterface::_range_based_update(const SciQLopPlotRange& new_rang
         force = m_force_next_update;
         m_force_next_update = false;
     }
-    if (!force && std::holds_alternative<SciQLopPlotRange>(m_current_state)
-        && new_range == std::get<SciQLopPlotRange>(m_current_state))
+    if (!force && new_range == m_current_range)
         return;
     auto r = get_data(new_range.start(), new_range.stop());
-    m_current_state = new_range;
+    m_current_range = new_range;
     _notify_new_data(r);
 }
 
@@ -159,23 +155,29 @@ QList<PyBuffer> DataProviderInterface::get_data(QList<PyBuffer> values)
 
 void DataProviderInterface::set_range(SciQLopPlotRange new_state) noexcept
 {
-    m_mutex.lock();
-    m_next_state = new_state;
-    m_has_pending_change = true;
-    m_mutex.unlock();
+    {
+        QMutexLocker lock(&m_mutex);
+        m_next_range = new_state;
+        m_range_pending = true;
+    }
+    // Range fetches are rate-limited (panning spams them): the timer coalesces
+    // the wake-up. _threaded_update then services whichever slots are pending.
     QMetaObject::invokeMethod(m_rate_limit_timer, qOverload<>(&QTimer::start),
                               Qt::QueuedConnection);
 }
 
+// The data setters wake on their OWN pending flag only, independently of a
+// pending range fetch — so a range fetch in flight no longer suppresses the
+// data wake-up (and vice-versa). Consecutive data calls still coalesce.
 void DataProviderInterface::set_data(_2D_data new_state) noexcept
 {
     bool should_emit = false;
     {
         QMutexLocker lock(&m_mutex);
-        m_next_state = new_state;
-        if (!m_has_pending_change)
+        m_next_data = new_state;
+        if (!m_data_pending)
         {
-            m_has_pending_change = true;
+            m_data_pending = true;
             should_emit = true;
         }
     }
@@ -188,10 +190,10 @@ void DataProviderInterface::set_data(_3D_data new_state) noexcept
     bool should_emit = false;
     {
         QMutexLocker lock(&m_mutex);
-        m_next_state = new_state;
-        if (!m_has_pending_change)
+        m_next_data = new_state;
+        if (!m_data_pending)
         {
-            m_has_pending_change = true;
+            m_data_pending = true;
             should_emit = true;
         }
     }
@@ -204,10 +206,10 @@ void DataProviderInterface::set_data(_NDdata new_state) noexcept
     bool should_emit = false;
     {
         QMutexLocker lock(&m_mutex);
-        m_next_state = new_state;
-        if (!m_has_pending_change)
+        m_next_data = new_state;
+        if (!m_data_pending)
         {
-            m_has_pending_change = true;
+            m_data_pending = true;
             should_emit = true;
         }
     }

--- a/src/PythonInterface.cpp
+++ b/src/PythonInterface.cpp
@@ -167,10 +167,22 @@ inline void _inc_ref(PyObject* obj)
 #ifdef _TRACE_REF_COUNT
     std::cout << "Inc ref " << obj << " " << obj->ob_refcnt << std::endl;
 #endif
-    PyGILState_STATE state = PyGILState_Ensure();
-    _drain_deferred_queue();
-    Py_INCREF(obj);
-    PyGILState_Release(state);
+    // An incref must happen NOW (it keeps the object alive), so unlike _dec_ref
+    // it can never be deferred — if we don't hold the GIL we must acquire it.
+    // But when we already hold it, skip the redundant Ensure/Release pair and
+    // just drain + incref directly (mirrors _dec_ref's fast path).
+    if (_current_thread_holds_gil())
+    {
+        _drain_deferred_queue();
+        Py_INCREF(obj);
+    }
+    else
+    {
+        PyGILState_STATE state = PyGILState_Ensure();
+        _drain_deferred_queue();
+        Py_INCREF(obj);
+        PyGILState_Release(state);
+    }
 }
 
 inline void _dec_ref(PyObject* obj)

--- a/src/SciQLopCurve.cpp
+++ b/src/SciQLopCurve.cpp
@@ -26,11 +26,6 @@
 #include "SciQLopPlots/Python/DtypeDispatch.hpp"
 #include <cmath>
 
-void SciQLopCurve::_range_changed(const QCPRange& newRange, const QCPRange& oldRange)
-{
-    this->_resampler->resample(newRange);
-}
-
 void SciQLopCurve::_setCurveData(QList<QVector<QCPCurveData>> data)
 {
     // The resampler emits via QueuedConnection, so the component count may

--- a/src/SciQLopNDProjectionPlot.cpp
+++ b/src/SciQLopNDProjectionPlot.cpp
@@ -23,6 +23,14 @@
 #include "SciQLopPlots/Plotables/SciQLopNDProjectionCurves.hpp"
 #include <QHBoxLayout>
 
+void SciQLopNDProjectionPlot::set_theme(SciQLopTheme* theme)
+{
+    m_theme = theme;
+    for (auto* plot : m_plots)
+        if (plot)
+            plot->set_theme(theme);
+}
+
 SciQLopGraphInterface* SciQLopNDProjectionPlot::plot_impl(GetDataPyCallable callable,
                                                           QStringList labels, QList<QColor> colors,
                                                           GraphType graph_type, GraphMarkerShape marker, QObject* sync_with, QVariantMap metaData)

--- a/tests/fuzzing/callback_actions.py
+++ b/tests/fuzzing/callback_actions.py
@@ -111,3 +111,31 @@ def add_flaky_callback_spectrogram(panel, model, plot_index):
         name="flaky_spectra",
         y_log_scale=True,
     )
+
+
+@ui_action(
+    precondition=lambda model: model.has_graphs,
+    bundles={"plot_index": "plot_indices_with_graphs"},
+    narrate="Swapped the callable on a function graph in plot {plot_index}",
+    # Pure callable swap — does not change graph count
+    model_update=lambda model, plot_index: None,
+    verify=lambda panel, model, plot_index: True,
+    settle_timeout_ms=200,
+)
+def swap_callback(panel, model, plot_index):
+    """Replace the data callback on a live function graph.
+
+    Exercises SimplePyCallablePWrapper::set_callable / callable() while the
+    worker thread may be mid-fetch — the mutex<->GIL lock-ordering path. With
+    the old (copy-under-lock) code this could deadlock the worker; see
+    tests/integration/test_callback_swap_race.py for the focused regression.
+    """
+    plot = panel.plot_at(plot_index)
+    graphs = plot.plottables() if hasattr(plot, "plottables") else []
+    target = next((g for g in graphs if hasattr(g, "set_callable")), None)
+    if target is None:
+        return
+    target.set_callable(make_timeseries(3))
+    # Read it straight back — the getter copies under the same lock.
+    if hasattr(target, "callable"):
+        target.callable()

--- a/tests/fuzzing/test_fuzzing.py
+++ b/tests/fuzzing/test_fuzzing.py
@@ -15,6 +15,7 @@ from tests.fuzzing.axis_actions import set_axis_range, toggle_y_log_scale
 from tests.fuzzing.callback_actions import (
     add_callback_line_3c, add_callback_line_1c, add_callback_spectrogram,
     add_slow_callback_line, add_flaky_callback_line, add_flaky_callback_spectrogram,
+    swap_callback,
 )
 from tests.fuzzing.torture_actions import (
     rapid_zoom_burst, rapid_pan_burst, rescale_y, rapid_log_toggle,
@@ -35,6 +36,7 @@ for action in [
     # Callback-based graphs (SciQLop-style)
     add_callback_line_3c, add_callback_line_1c, add_callback_spectrogram,
     add_slow_callback_line, add_flaky_callback_line, add_flaky_callback_spectrogram,
+    swap_callback,
     # Viewport torture
     rapid_zoom_burst, rapid_pan_burst, rescale_y, rapid_log_toggle,
     set_panel_time_range, zoom_pan_zoom, resize_panel, rapid_resize_burst,

--- a/tests/integration/test_callback_swap_race.py
+++ b/tests/integration/test_callback_swap_race.py
@@ -1,0 +1,148 @@
+"""Regression guard for the mutex<->GIL lock-ordering hazard in
+``SimplePyCallablePWrapper``.
+
+The data-provider worker runs on a C++ ``QThread``. To service a fetch it used
+to copy the stored callable *while holding* ``m_callable_mutex``:
+
+    { QMutexLocker lock(&m_callable_mutex); cb = m_callable; }   // copy = Py_INCREF
+
+Copying a ``GetDataPyCallable`` does a Python **incref**, which needs the GIL.
+So the worker took the path **mutex -> GIL**. Meanwhile ``set_callable`` /
+``callable`` are called from Python (GIL already held) and take the mutex:
+**GIL -> mutex**. Inverted lock order => a real deadlock window:
+
+    worker:  holds m_callable_mutex, blocks on PyGILState_Ensure()
+    python:  holds GIL (in set_callable), blocks on m_callable_mutex
+
+The fix stores the callable behind a ``shared_ptr`` and snapshots it under the
+mutex with a pure C++ atomic refcount bump (no GIL); the Python incref/decref
+then happens *outside* the lock. So the worker never takes mutex->GIL.
+
+This test hammers ``set_callable`` / ``callable()`` from a background Python
+thread while the main thread drives fetches (``set_range``) and pumps the event
+loop. On the pre-fix build this tends to **hang** (caught by ``--timeout``); on
+the fixed build it completes and the graph keeps producing data.
+
+Note (honest): a deadlock repro is inherently probabilistic — a clean pass is
+strong evidence, not a proof. The value is as a fast hang-detector under the
+suite's ``--timeout`` plus a liveness assertion afterwards.
+"""
+import threading
+import time
+
+import numpy as np
+import pytest
+
+from SciQLopPlots import SciQLopPlot, SciQLopPlotRange
+
+
+def _make_provider(tag):
+    """A cheap (start, stop) -> (x, y) provider tagged so we can tell which
+    callable produced the last batch."""
+    def cb(start, stop):
+        n = 16
+        x = np.linspace(start, stop, n, dtype=np.float64)
+        # encode the tag in the data so a liveness check can confirm flow
+        y = (np.sin(x) + tag).astype(np.float64)
+        return x, y
+    cb.tag = tag
+    return cb
+
+
+@pytest.mark.timeout(30)
+def test_concurrent_set_callable_during_fetch_does_not_deadlock(qtbot):
+    """Swap the callable from a worker Python thread while the main thread
+    fetches; must not deadlock and must stay live."""
+    plot = SciQLopPlot()
+    qtbot.addWidget(plot)
+
+    g = plot.line(_make_provider(0.0))
+    qtbot.wait(40)
+
+    stop = threading.Event()
+    swap_count = [0]
+    errors = []
+
+    def swapper():
+        i = 0
+        try:
+            while not stop.is_set():
+                i += 1
+                # set_callable: GIL -> mutex (the side that used to deadlock
+                # against the worker's mutex -> GIL copy)
+                g.set_callable(_make_provider(float(i % 7)))
+                # callable(): also copies under the lock in the old code
+                _ = g.callable()
+                swap_count[0] = i
+        except Exception as e:  # pragma: no cover - surfaced via assert below
+            errors.append(repr(e))
+
+    t = threading.Thread(target=swapper, name="callable-swapper", daemon=True)
+    t.start()
+    try:
+        # Main thread: keep the worker busy fetching while swaps happen.
+        deadline = time.monotonic() + 3.0
+        r = 0.0
+        while time.monotonic() < deadline:
+            r += 1.0
+            g.set_range(SciQLopPlotRange(r, r + 100.0))
+            qtbot.wait(5)  # pumps the event loop and releases the GIL
+    finally:
+        stop.set()
+        t.join(timeout=10.0)
+
+    assert not t.is_alive(), "swapper thread is stuck (deadlock on mutex<->GIL)"
+    assert not errors, f"swapper raised: {errors}"
+    assert swap_count[0] > 0, "no callable swaps happened — test did not exercise the path"
+
+    # Liveness: the pipeline still services a fresh fetch after all the churn.
+    seen = []
+
+    def final_cb(start, stop):
+        seen.append((start, stop))
+        x = np.linspace(start, stop, 8, dtype=np.float64)
+        return x, np.cos(x)
+
+    g.set_callable(final_cb)
+    g.set_range(SciQLopPlotRange(10_000.0, 10_100.0))
+    qtbot.waitUntil(lambda: len(seen) >= 1, timeout=5000)
+
+
+@pytest.mark.timeout(30)
+def test_callable_getter_during_fetch_is_safe(qtbot):
+    """The ``callable()`` getter (copy under lock in the old code) hammered
+    concurrently with fetches must not deadlock or corrupt refcounts."""
+    plot = SciQLopPlot()
+    qtbot.addWidget(plot)
+    g = plot.line(_make_provider(1.0))
+    qtbot.wait(40)
+
+    stop = threading.Event()
+    got = [0]
+    errors = []
+
+    def reader():
+        try:
+            while not stop.is_set():
+                c = g.callable()  # incref/decref churn from a non-GIL-owner path
+                del c
+                got[0] += 1
+        except Exception as e:  # pragma: no cover
+            errors.append(repr(e))
+
+    t = threading.Thread(target=reader, daemon=True)
+    t.start()
+    try:
+        deadline = time.monotonic() + 2.0
+        r = 0.0
+        while time.monotonic() < deadline:
+            r += 1.0
+            g.set_range(SciQLopPlotRange(r, r + 50.0))
+            qtbot.wait(5)
+    finally:
+        stop.set()
+        t.join(timeout=10.0)
+
+    assert not t.is_alive(), "reader thread stuck (deadlock)"
+    assert not errors, f"reader raised: {errors}"
+    assert got[0] > 0

--- a/tests/integration/test_dataproducer_mode_race.py
+++ b/tests/integration/test_dataproducer_mode_race.py
@@ -1,0 +1,94 @@
+"""Reproducer for D-003: DataProviderInterface drops a queued request when a
+range-based and a data-based update race.
+
+`SimplePyCallablePipeline::call(range)` arms a 20ms rate-limit timer WITHOUT
+emitting `_state_changed`; `call(x, y)` emits `_state_changed` only when
+`m_has_pending_change` was false. So a `call(range)` immediately followed by a
+`call(x, y)` overwrites the shared `m_next_state` and suppresses the second
+wake-up — the worker eventually runs once and services only the *last* variant.
+The other fetch is silently dropped.
+
+Both fetch paths are reachable on a single provider in real use: every
+SciQLopFunctionGraph wires `range_changed -> call(range)` in its constructor,
+and `observe(graph)` adds `data_changed -> call(x, y)`. Here we drive the two
+overloads of `call` directly, which is the same code path.
+"""
+import numpy as np
+import pytest
+from conftest import process_events
+from SciQLopPlots import SciQLopPlot, SciQLopPlotRange
+
+
+def _make_graph(qtbot, events):
+    p = SciQLopPlot()
+    qtbot.addWidget(p)
+
+    def cb(*a):
+        if len(a) == 2 and np.isscalar(a[0]):       # range path: (lower, upper)
+            events.append(("range", round(float(a[0]), 1)))
+            x = np.linspace(a[0], a[1], 8, dtype=np.float64)
+            return x, np.sin(x)
+        events.append(("data", len(a)))             # data path: (x, y) buffers
+        x = np.asarray(a[0], dtype=np.float64)
+        return x, np.asarray(a[1], dtype=np.float64)
+
+    g = p.line(cb)
+    qtbot.wait(60)
+    events.clear()
+    return p, g
+
+
+def _settle(qtbot, ms=120):
+    # The rate-limit timer is 20ms; give it room plus event-loop turns.
+    deadline = ms
+    while deadline > 0:
+        process_events()
+        qtbot.wait(10)
+        deadline -= 10
+
+
+def test_range_then_data_keeps_both(qtbot):
+    """A range fetch followed immediately by a data fetch must service BOTH."""
+    events = []
+    p, g = _make_graph(qtbot, events)
+
+    xb = np.linspace(0.0, 1.0, 8, dtype=np.float64)
+    yb = np.cos(xb)
+
+    g.call(SciQLopPlotRange(100.0, 200.0))   # arms 20ms timer, pending=True
+    g.call(xb, yb)                           # overwrites m_next_state, no wake
+    _settle(qtbot)
+
+    modes = [e[0] for e in events]
+    assert "data" in modes, f"data fetch missing: {events}"
+    assert "range" in modes, f"range fetch was DROPPED: {events}"
+
+
+def test_fuzz_no_request_is_dropped(qtbot):
+    """Fuzz: over many randomized range/data bursts, every distinct request the
+    caller makes must produce at least one callback invocation of that mode."""
+    import random
+    rng = random.Random(1234)
+
+    events = []
+    p, g = _make_graph(qtbot, events)
+    xb = np.linspace(0.0, 1.0, 8, dtype=np.float64)
+    yb = np.cos(xb)
+
+    drops = 0
+    trials = 60
+    for i in range(trials):
+        events.clear()
+        ops = [("range", 1000.0 + i), ("data", None)]
+        rng.shuffle(ops)
+        for kind, val in ops:
+            if kind == "range":
+                g.call(SciQLopPlotRange(val, val + 50.0))
+            else:
+                g.call(xb, yb)
+        _settle(qtbot, ms=120)
+        modes = {e[0] for e in events}
+        if not {"range", "data"}.issubset(modes):
+            drops += 1
+
+    assert drops == 0, f"{drops}/{trials} mixed bursts dropped a request"

--- a/tests/integration/test_projection_theme.py
+++ b/tests/integration/test_projection_theme.py
@@ -1,0 +1,37 @@
+"""Reproducer for D-002: SciQLopNDProjectionPlot must forward theming to its
+sub-plots, like SciQLopPlot does.
+
+Before the fix, SciQLopNDProjectionPlot inherited the no-op
+SciQLopPlotInterface::set_theme/theme stubs, so theme() returned None and the
+child plots in m_plots were never themed (SciQLop worked around this with
+findChildren(SciQLopPlot)).
+"""
+import pytest
+from PySide6.QtWidgets import QApplication
+
+from SciQLopPlots import SciQLopNDProjectionPlot, SciQLopTheme
+
+
+@pytest.fixture
+def nd_plot(qtbot):
+    p = SciQLopNDProjectionPlot()
+    qtbot.addWidget(p)
+    return p
+
+
+def test_theme_returns_set_theme(nd_plot):
+    theme = SciQLopTheme.dark()
+    nd_plot.set_theme(theme)
+    QApplication.processEvents()
+    assert nd_plot.theme() is not None
+
+
+def test_set_theme_propagates_to_subplots(nd_plot):
+    assert nd_plot.subplot_count() > 0
+    theme = SciQLopTheme.dark()
+    nd_plot.set_theme(theme)
+    QApplication.processEvents()
+    for i in range(nd_plot.subplot_count()):
+        sub = nd_plot.subplot(i)
+        assert sub is not None
+        assert sub.theme() is not None, f"subplot {i} was not themed"


### PR DESCRIPTION
## Summary

Hardening batch from a deep review of the data-producer / Python-bridge paths. The headline change is a real (latent) **mutex↔GIL lock-ordering deadlock** in the callable pipeline; the branch also carries three smaller review fixes already on it.

### Commits

- **fix(producer): avoid mutex→GIL deadlock when swapping the data callable**
  `SimplePyCallablePWrapper` copied `m_callable` *inside* the `QMutexLocker` in each `get_data()` overload. Copying a `GetDataPyCallable` does a Python incref → needs the GIL, so the worker thread took the order **mutex→GIL**, while `set_callable()`/`callable()` (called from Python with the GIL held) take **GIL→mutex**. Inverted ordering = deadlock window.
  Fix: hold the callable behind a `std::shared_ptr` and snapshot it under the mutex with a pure C++ atomic refcount bump (no GIL while locked); the Python call + incref/decref happen outside the lock. `set_callable` swaps the pointer under the lock and lets the old callable's decref run after unlock. The snapshot also keeps an in-flight callable alive if swapped concurrently.
  Also: `_inc_ref` gains the `_current_thread_holds_gil()` fast path `_dec_ref` already has, skipping a redundant `Ensure/Release` when the GIL is already held (an incref can't be deferred, so the slow path still acquires the GIL).

- **refactor(curve): remove dead `SciQLopCurve::_range_changed`**
- **feat(projection): forward `set_theme`/`theme` to child plots**
- **fix(producer): stop range/data mode-race from dropping fetches**

### Tests

- `tests/integration/test_callback_swap_race.py` — hammers `set_callable`/`callable()` from a background Python thread during fetches; timeout-guarded hang detector + post-churn liveness assertion. Passes on the fixed build; exercised the deadlock path on the pre-fix build.
- `tests/fuzzing/callback_actions.py::swap_callback` — Hypothesis fuzzer action that swaps the callable on a live function graph mid-run.

### Notes

- A deadlock reproducer is inherently probabilistic — a clean pass is strong evidence, not a proof. The value is a fast hang-detector plus a liveness guard.
- `pytest-timeout` is not currently in the dev venv, so the `@pytest.mark.timeout` markers are no-ops locally (they work in CI via `.[test]`). The outer `--timeout` covers local runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)