### PR TITLE
feat(histogram2d): logarithmic bin spacing coupled to the axis

### DIFF
--- a/SciQLopPlots/__init__.py
+++ b/SciQLopPlots/__init__.py
@@ -58,7 +58,7 @@ def _reject_waterfall_kwargs(kwargs, graph_type):
             f"got graph_type={graph_type!r}")
 
 
-_HISTOGRAM2D_KWARGS = ("key_bins", "value_bins")
+_HISTOGRAM2D_KWARGS = ("key_bins", "value_bins", "x_bins_log", "y_bins_log")
 
 
 def _reject_histogram2d_kwargs(kwargs, graph_type):

--- a/SciQLopPlots/bindings/bindings.xml
+++ b/SciQLopPlots/bindings/bindings.xml
@@ -347,7 +347,7 @@
                 <rename to="metaData"/>
             </modify-argument>
         </modify-function>
-        <modify-function signature="histogram2d(const SciQLopPyBuffer&amp;,const SciQLopPyBuffer&amp;,QString,int,int,QVariantMap)">
+        <modify-function signature="histogram2d(const SciQLopPyBuffer&amp;,const SciQLopPyBuffer&amp;,QString,int,int,bool,bool,QVariantMap)">
             <modify-argument index="3">
                 <rename to="name"/>
             </modify-argument>
@@ -358,10 +358,16 @@
                 <rename to="value_bins"/>
             </modify-argument>
             <modify-argument index="6">
+                <rename to="x_bins_log"/>
+            </modify-argument>
+            <modify-argument index="7">
+                <rename to="y_bins_log"/>
+            </modify-argument>
+            <modify-argument index="8">
                 <rename to="metaData"/>
             </modify-argument>
         </modify-function>
-        <modify-function signature="histogram2d(GetDataPyCallable,QString,int,int,QObject*,QVariantMap)">
+        <modify-function signature="histogram2d(GetDataPyCallable,QString,int,int,bool,bool,QObject*,QVariantMap)">
             <modify-argument index="2">
                 <rename to="name"/>
             </modify-argument>
@@ -372,9 +378,15 @@
                 <rename to="value_bins"/>
             </modify-argument>
             <modify-argument index="5">
-                <rename to="sync_with"/>
+                <rename to="x_bins_log"/>
             </modify-argument>
             <modify-argument index="6">
+                <rename to="y_bins_log"/>
+            </modify-argument>
+            <modify-argument index="7">
+                <rename to="sync_with"/>
+            </modify-argument>
+            <modify-argument index="8">
                 <rename to="metaData"/>
             </modify-argument>
         </modify-function>
@@ -733,7 +745,7 @@
                 <rename to="metaData"/>
             </modify-argument>
         </modify-function>
-        <modify-function signature="histogram2d(const SciQLopPyBuffer&amp;,const SciQLopPyBuffer&amp;,QString,int,int,PlotType,int,QVariantMap)">
+        <modify-function signature="histogram2d(const SciQLopPyBuffer&amp;,const SciQLopPyBuffer&amp;,QString,int,int,bool,bool,PlotType,int,QVariantMap)">
             <modify-argument index="3">
                 <rename to="name"/>
             </modify-argument>
@@ -744,16 +756,22 @@
                 <rename to="value_bins"/>
             </modify-argument>
             <modify-argument index="6">
-                <rename to="plot_type"/>
+                <rename to="x_bins_log"/>
             </modify-argument>
             <modify-argument index="7">
-                <rename to="index"/>
+                <rename to="y_bins_log"/>
             </modify-argument>
             <modify-argument index="8">
+                <rename to="plot_type"/>
+            </modify-argument>
+            <modify-argument index="9">
+                <rename to="index"/>
+            </modify-argument>
+            <modify-argument index="10">
                 <rename to="metaData"/>
             </modify-argument>
         </modify-function>
-        <modify-function signature="histogram2d(GetDataPyCallable,QString,int,int,PlotType,QObject*,int,QVariantMap)">
+        <modify-function signature="histogram2d(GetDataPyCallable,QString,int,int,bool,bool,PlotType,QObject*,int,QVariantMap)">
             <modify-argument index="2">
                 <rename to="name"/>
             </modify-argument>
@@ -764,15 +782,21 @@
                 <rename to="value_bins"/>
             </modify-argument>
             <modify-argument index="5">
-                <rename to="plot_type"/>
+                <rename to="x_bins_log"/>
             </modify-argument>
             <modify-argument index="6">
-                <rename to="sync_with"/>
+                <rename to="y_bins_log"/>
             </modify-argument>
             <modify-argument index="7">
-                <rename to="index"/>
+                <rename to="plot_type"/>
             </modify-argument>
             <modify-argument index="8">
+                <rename to="sync_with"/>
+            </modify-argument>
+            <modify-argument index="9">
+                <rename to="index"/>
+            </modify-argument>
+            <modify-argument index="10">
                 <rename to="metaData"/>
             </modify-argument>
         </modify-function>

--- a/SciQLopPlots/meson.build
+++ b/SciQLopPlots/meson.build
@@ -306,9 +306,13 @@ python3.install_sources(sciqlopplots_python_sources, pure: false, subdir: 'SciQL
 # DSP Python extension module (no Qt/Shiboken dependency — pure computation)
 numpy_inc = run_command(python3, ['-c', 'import numpy; print(numpy.get_include())'], check: true).stdout().strip()
 
+# Pass numpy's include via -I rather than include_directories(): the latter
+# rejects an absolute path that lives inside the source tree, which happens when
+# the build venv (hence numpy) sits in-tree (e.g. ./.venv).
 sciqlop_dsp_ext = python3.extension_module('_sciqlop_dsp',
     '../src/DSP/python_module.cpp',
-    include_directories: [includes, include_directories(numpy_inc)],
+    include_directories: [includes],
+    cpp_args: ['-I' + numpy_inc],
     dependencies: [python3_dep, dsp_dep],
     subdir: 'SciQLopPlots',
     install: true,

--- a/include/SciQLopPlots/MultiPlots/SciQLopMultiPlotPanel.hpp
+++ b/include/SciQLopPlots/MultiPlots/SciQLopMultiPlotPanel.hpp
@@ -184,11 +184,13 @@ protected:
 
     virtual QPair<SciQLopPlotInterface*, SciQLopColorMapInterface*>
     plot_impl(const SciQLopPyBuffer& x, const SciQLopPyBuffer& y, QString name, int key_bins, int value_bins,
+              bool x_bins_log = false, bool y_bins_log = false,
               ::PlotType plot_type = ::PlotType::BasicXY, int index = -1,
               QVariantMap metaData = {}) Q_DECL_OVERRIDE;
 
     virtual QPair<SciQLopPlotInterface*, SciQLopColorMapInterface*>
     plot_impl(GetDataPyCallable callable, QString name, int key_bins, int value_bins,
+              bool x_bins_log = false, bool y_bins_log = false,
               ::PlotType plot_type = ::PlotType::BasicXY, QObject* sync_with = nullptr,
               int index = -1, QVariantMap metaData = {}) Q_DECL_OVERRIDE;
 

--- a/include/SciQLopPlots/MultiPlots/SciQLopPlotCollection.hpp
+++ b/include/SciQLopPlots/MultiPlots/SciQLopPlotCollection.hpp
@@ -134,6 +134,7 @@ protected:
 
     inline virtual QPair<SciQLopPlotInterface*, SciQLopColorMapInterface*>
     plot_impl(const SciQLopPyBuffer& x, const SciQLopPyBuffer& y, QString name, int key_bins, int value_bins,
+              bool x_bins_log = false, bool y_bins_log = false,
               ::PlotType plot_type = ::PlotType::BasicXY, int index = -1,
               QVariantMap metaData = {})
     {
@@ -142,6 +143,7 @@ protected:
 
     inline virtual QPair<SciQLopPlotInterface*, SciQLopColorMapInterface*>
     plot_impl(GetDataPyCallable callable, QString name, int key_bins, int value_bins,
+              bool x_bins_log = false, bool y_bins_log = false,
               ::PlotType plot_type = ::PlotType::BasicXY, QObject* sync_with = nullptr,
               int index = -1, QVariantMap metaData = {})
     {
@@ -359,20 +361,23 @@ public:
     inline virtual QPair<SciQLopPlotInterface*, SciQLopColorMapInterface*>
     histogram2d(const SciQLopPyBuffer& x, const SciQLopPyBuffer& y,
                 QString name = QStringLiteral("Histogram2D"), int key_bins = 100,
-                int value_bins = 100, ::PlotType plot_type = ::PlotType::BasicXY,
+                int value_bins = 100, bool x_bins_log = false, bool y_bins_log = false,
+                ::PlotType plot_type = ::PlotType::BasicXY,
                 int index = -1, QVariantMap metaData = {})
     {
-        return plot_impl(x, y, name, key_bins, value_bins, plot_type, index, metaData);
+        return plot_impl(x, y, name, key_bins, value_bins, x_bins_log, y_bins_log, plot_type,
+                         index, metaData);
     }
 
     inline virtual QPair<SciQLopPlotInterface*, SciQLopColorMapInterface*>
     histogram2d(GetDataPyCallable callable, QString name = QStringLiteral("Histogram2D"),
-                int key_bins = 100, int value_bins = 100,
+                int key_bins = 100, int value_bins = 100, bool x_bins_log = false,
+                bool y_bins_log = false,
                 ::PlotType plot_type = ::PlotType::BasicXY, QObject* sync_with = nullptr,
                 int index = -1, QVariantMap metaData = {})
     {
-        return plot_impl(callable, name, key_bins, value_bins, plot_type, sync_with, index,
-                         metaData);
+        return plot_impl(callable, name, key_bins, value_bins, x_bins_log, y_bins_log, plot_type,
+                         sync_with, index, metaData);
     }
 
     inline virtual QPair<SciQLopPlotInterface*, SciQLopGraphInterface*>

--- a/include/SciQLopPlots/Plotables/SciQLopHistogram2D.hpp
+++ b/include/SciQLopPlots/Plotables/SciQLopHistogram2D.hpp
@@ -72,6 +72,13 @@ public:
     void set_normalization(int normalization);
     int normalization() const;
 
+    // Logarithmic bin spacing per axis. Bins are spaced evenly in log10 and
+    // non-positive samples are dropped; meant to accompany a log-scaled axis.
+    void set_x_bins_log(bool log);
+    void set_y_bins_log(bool log);
+    bool x_bins_log() const;
+    bool y_bins_log() const;
+
     SciQLopPlotRange z_percentile_range(const SciQLopPlotRange& x_range,
                                         const SciQLopPlotRange& y_range, double low,
                                         double high) const noexcept override;
@@ -82,6 +89,8 @@ signals:
 #endif
     Q_SIGNAL void bins_changed(int key_bins, int value_bins);
     Q_SIGNAL void normalization_changed(int normalization);
+    Q_SIGNAL void x_bins_log_changed(bool log);
+    Q_SIGNAL void y_bins_log_changed(bool log);
 };
 
 

--- a/include/SciQLopPlots/SciQLopPlot.hpp
+++ b/include/SciQLopPlots/SciQLopPlot.hpp
@@ -286,11 +286,13 @@ protected:
     virtual SciQLopColorMapInterface*
     plot_impl(const SciQLopPyBuffer& x, const SciQLopPyBuffer& y,
               QString name = QStringLiteral("Histogram2D"), int key_bins = 100,
-              int value_bins = 100, QVariantMap metaData = {}) override;
+              int value_bins = 100, bool x_bins_log = false, bool y_bins_log = false,
+              QVariantMap metaData = {}) override;
 
     virtual SciQLopColorMapInterface*
     plot_impl(GetDataPyCallable callable, QString name = QStringLiteral("Histogram2D"),
-              int key_bins = 100, int value_bins = 100, QObject* sync_with = nullptr,
+              int key_bins = 100, int value_bins = 100, bool x_bins_log = false,
+              bool y_bins_log = false, QObject* sync_with = nullptr,
               QVariantMap metaData = {}) override;
 
     virtual void toggle_selected_objects_visibility() noexcept override;

--- a/include/SciQLopPlots/SciQLopPlot.hpp
+++ b/include/SciQLopPlots/SciQLopPlot.hpp
@@ -95,10 +95,12 @@ public:
                                            bool y_log_scale = false, bool z_log_scale = false);
 
     SciQLopHistogram2D* add_histogram2d(const QString& name, int key_bins = 100,
-                                        int value_bins = 100);
+                                        int value_bins = 100, bool x_bins_log = false,
+                                        bool y_bins_log = false);
     SciQLopHistogram2DFunction* add_histogram2d(GetDataPyCallable&& callable,
                                                  const QString& name, int key_bins = 100,
-                                                 int value_bins = 100);
+                                                 int value_bins = 100, bool x_bins_log = false,
+                                                 bool y_bins_log = false);
 
     inline void set_scroll_factor(double factor) noexcept { m_scroll_factor = factor; }
 
@@ -331,10 +333,12 @@ public:
     void minimize_margins() override;
 
     SciQLopHistogram2D* add_histogram2d(const QString& name, int key_bins = 100,
-                                        int value_bins = 100);
+                                        int value_bins = 100, bool x_bins_log = false,
+                                        bool y_bins_log = false);
     SciQLopHistogram2DFunction* add_histogram2d(GetDataPyCallable&& callable,
                                                  const QString& name, int key_bins = 100,
-                                                 int value_bins = 100);
+                                                 int value_bins = 100, bool x_bins_log = false,
+                                                 bool y_bins_log = false);
 
     SciQLopWaterfallGraph* add_waterfall(const QString& name,
                                          const QStringList& labels = {},

--- a/include/SciQLopPlots/SciQLopPlotInterface.hpp
+++ b/include/SciQLopPlots/SciQLopPlotInterface.hpp
@@ -96,14 +96,16 @@ protected:
     inline virtual SciQLopColorMapInterface*
     plot_impl(const SciQLopPyBuffer& x, const SciQLopPyBuffer& y,
               QString name = QStringLiteral("Histogram2D"), int key_bins = 100,
-              int value_bins = 100, QVariantMap metaData = {})
+              int value_bins = 100, bool x_bins_log = false, bool y_bins_log = false,
+              QVariantMap metaData = {})
     {
         throw std::runtime_error("Not implemented");
     }
 
     inline virtual SciQLopColorMapInterface*
     plot_impl(GetDataPyCallable callable, QString name = QStringLiteral("Histogram2D"),
-              int key_bins = 100, int value_bins = 100, QObject* sync_with = nullptr,
+              int key_bins = 100, int value_bins = 100, bool x_bins_log = false,
+              bool y_bins_log = false, QObject* sync_with = nullptr,
               QVariantMap metaData = {})
     {
         throw std::runtime_error("Not implemented");
@@ -389,17 +391,20 @@ public:
     inline virtual SciQLopColorMapInterface*
     histogram2d(const SciQLopPyBuffer& x, const SciQLopPyBuffer& y,
                 QString name = QStringLiteral("Histogram2D"), int key_bins = 100,
-                int value_bins = 100, QVariantMap metaData = {})
+                int value_bins = 100, bool x_bins_log = false, bool y_bins_log = false,
+                QVariantMap metaData = {})
     {
-        return plot_impl(x, y, name, key_bins, value_bins, metaData);
+        return plot_impl(x, y, name, key_bins, value_bins, x_bins_log, y_bins_log, metaData);
     }
 
     inline virtual SciQLopColorMapInterface*
     histogram2d(GetDataPyCallable callable, QString name = QStringLiteral("Histogram2D"),
-                int key_bins = 100, int value_bins = 100, QObject* sync_with = nullptr,
+                int key_bins = 100, int value_bins = 100, bool x_bins_log = false,
+                bool y_bins_log = false, QObject* sync_with = nullptr,
                 QVariantMap metaData = {})
     {
-        return plot_impl(callable, name, key_bins, value_bins, sync_with, metaData);
+        return plot_impl(callable, name, key_bins, value_bins, x_bins_log, y_bins_log,
+                         sync_with, metaData);
     }
 
     inline virtual SciQLopPlottableInterface* plottable(int index = -1)

--- a/src/SciQLopHistogram2D.cpp
+++ b/src/SciQLopHistogram2D.cpp
@@ -47,6 +47,26 @@ SciQLopHistogram2D::SciQLopHistogram2D(QCustomPlot* parent, SciQLopPlotAxis* xAx
     SciQLopHistogram2D::set_gradient(ColorGradient::Jet);
     SciQLopHistogram2D::set_name(name);
 
+    // The bin scale follows the axis scale. SciQLopPlotAxis::set_log blocks the
+    // underlying QCPAxis::scaleTypeChanged, so drive the re-bin (and the UI
+    // signal) from the wrapper's log_changed instead.
+    if (_keyAxis)
+        connect(_keyAxis, &SciQLopPlotAxis::log_changed, this,
+                [this](bool on)
+                {
+                    if (_hist)
+                        _hist->refreshBinning();
+                    Q_EMIT x_bins_log_changed(on);
+                });
+    if (_valueAxis)
+        connect(_valueAxis, &SciQLopPlotAxis::log_changed, this,
+                [this](bool on)
+                {
+                    if (_hist)
+                        _hist->refreshBinning();
+                    Q_EMIT y_bins_log_changed(on);
+                });
+
     install_rescale_provider();
 
     if (auto legend_item = _legend_item(); legend_item)
@@ -158,36 +178,28 @@ int SciQLopHistogram2D::normalization() const
     return _hist ? static_cast<int>(_hist->normalization()) : 0;
 }
 
+// Log binning is just the axis being logarithmic. Driving the axis re-bins (and
+// updates the inspector) through the log_changed connection in the constructor.
 void SciQLopHistogram2D::set_x_bins_log(bool log)
 {
-    if (!_hist)
-        return;
-    const auto type = log ? QCPAxis::stLogarithmic : QCPAxis::stLinear;
-    if (_hist->keyBinScale() == type)
-        return;
-    _hist->setKeyBinScale(type);
-    Q_EMIT x_bins_log_changed(log);
+    if (_keyAxis)
+        _keyAxis->set_log(log);
 }
 
 void SciQLopHistogram2D::set_y_bins_log(bool log)
 {
-    if (!_hist)
-        return;
-    const auto type = log ? QCPAxis::stLogarithmic : QCPAxis::stLinear;
-    if (_hist->valueBinScale() == type)
-        return;
-    _hist->setValueBinScale(type);
-    Q_EMIT y_bins_log_changed(log);
+    if (_valueAxis)
+        _valueAxis->set_log(log);
 }
 
 bool SciQLopHistogram2D::x_bins_log() const
 {
-    return _hist && _hist->keyBinScale() == QCPAxis::stLogarithmic;
+    return _keyAxis && _keyAxis->log();
 }
 
 bool SciQLopHistogram2D::y_bins_log() const
 {
-    return _hist && _hist->valueBinScale() == QCPAxis::stLogarithmic;
+    return _valueAxis && _valueAxis->log();
 }
 
 SciQLopPlotRange SciQLopHistogram2D::z_percentile_range(const SciQLopPlotRange& x_range,

--- a/src/SciQLopHistogram2D.cpp
+++ b/src/SciQLopHistogram2D.cpp
@@ -211,6 +211,19 @@ SciQLopPlotRange SciQLopHistogram2D::z_percentile_range(const SciQLopPlotRange& 
     const double y_lo = std::min(y_range.start(), y_range.stop());
     const double y_hi = std::max(y_range.start(), y_range.stop());
 
+    // Cells are uniform in coordinate space, but under log binning the renderer
+    // places them at log positions. Remap each cell centre the same way so the
+    // viewport filter matches what is actually drawn.
+    const QCPRange kr = grid->keyRange();
+    const QCPRange vr = grid->valueRange();
+    const bool x_log = x_bins_log() && kr.lower > 0. && kr.upper > kr.lower;
+    const bool y_log = y_bins_log() && vr.lower > 0. && vr.upper > vr.lower;
+    const auto to_log = [](double linear, const QCPRange& r)
+    {
+        const double t = (linear - r.lower) / (r.upper - r.lower);
+        return std::pow(10., std::log10(r.lower) + t * (std::log10(r.upper) - std::log10(r.lower)));
+    };
+
     std::vector<double> values;
     values.reserve(static_cast<std::size_t>(nkey) * static_cast<std::size_t>(nval));
     for (int i = 0; i < nkey; ++i)
@@ -219,6 +232,10 @@ SciQLopPlotRange SciQLopHistogram2D::z_percentile_range(const SciQLopPlotRange& 
         {
             double kx = 0., vy = 0.;
             grid->cellToCoord(i, j, &kx, &vy);
+            if (x_log)
+                kx = to_log(kx, kr);
+            if (y_log)
+                vy = to_log(vy, vr);
             if (kx < x_lo || kx > x_hi || vy < y_lo || vy > y_hi)
                 continue;
             const double zv = grid->cell(i, j);

--- a/src/SciQLopHistogram2D.cpp
+++ b/src/SciQLopHistogram2D.cpp
@@ -158,6 +158,38 @@ int SciQLopHistogram2D::normalization() const
     return _hist ? static_cast<int>(_hist->normalization()) : 0;
 }
 
+void SciQLopHistogram2D::set_x_bins_log(bool log)
+{
+    if (!_hist)
+        return;
+    const auto type = log ? QCPAxis::stLogarithmic : QCPAxis::stLinear;
+    if (_hist->keyBinScale() == type)
+        return;
+    _hist->setKeyBinScale(type);
+    Q_EMIT x_bins_log_changed(log);
+}
+
+void SciQLopHistogram2D::set_y_bins_log(bool log)
+{
+    if (!_hist)
+        return;
+    const auto type = log ? QCPAxis::stLogarithmic : QCPAxis::stLinear;
+    if (_hist->valueBinScale() == type)
+        return;
+    _hist->setValueBinScale(type);
+    Q_EMIT y_bins_log_changed(log);
+}
+
+bool SciQLopHistogram2D::x_bins_log() const
+{
+    return _hist && _hist->keyBinScale() == QCPAxis::stLogarithmic;
+}
+
+bool SciQLopHistogram2D::y_bins_log() const
+{
+    return _hist && _hist->valueBinScale() == QCPAxis::stLogarithmic;
+}
+
 SciQLopPlotRange SciQLopHistogram2D::z_percentile_range(const SciQLopPlotRange& x_range,
                                                         const SciQLopPlotRange& y_range, double low,
                                                         double high) const noexcept

--- a/src/SciQLopHistogram2DDelegate.cpp
+++ b/src/SciQLopHistogram2DDelegate.cpp
@@ -23,6 +23,7 @@
 #include "SciQLopPlots/Inspector/PropertiesDelegates/SciQLopHistogram2DDelegate.hpp"
 #include "SciQLopPlots/Plotables/SciQLopHistogram2D.hpp"
 
+#include <QCheckBox>
 #include <QComboBox>
 #include <QFormLayout>
 #include <QGroupBox>
@@ -59,6 +60,18 @@ SciQLopHistogram2DDelegate::SciQLopHistogram2DDelegate(SciQLopHistogram2D* objec
     connect(valueBinsSpin, QOverload<int>::of(&QSpinBox::valueChanged), this,
             [push_bins](int) { push_bins(); });
 
+    auto* keyLogCheck = new QCheckBox(binningBox);
+    keyLogCheck->setChecked(object->x_bins_log());
+    binningLayout->addRow("X log bins", keyLogCheck);
+    connect(keyLogCheck, &QCheckBox::toggled, this,
+            [object](bool on) { object->set_x_bins_log(on); });
+
+    auto* valueLogCheck = new QCheckBox(binningBox);
+    valueLogCheck->setChecked(object->y_bins_log());
+    binningLayout->addRow("Y log bins", valueLogCheck);
+    connect(valueLogCheck, &QCheckBox::toggled, this,
+            [object](bool on) { object->set_y_bins_log(on); });
+
     m_layout->addRow(binningBox);
 
     auto* normCombo = new QComboBox(this);
@@ -86,6 +99,18 @@ SciQLopHistogram2DDelegate::SciQLopHistogram2DDelegate(SciQLopHistogram2D* objec
             {
                 QSignalBlocker b(normCombo);
                 normCombo->setCurrentIndex(normCombo->findData(n));
+            });
+    connect(object, &SciQLopHistogram2D::x_bins_log_changed, this,
+            [keyLogCheck](bool on)
+            {
+                QSignalBlocker b(keyLogCheck);
+                keyLogCheck->setChecked(on);
+            });
+    connect(object, &SciQLopHistogram2D::y_bins_log_changed, this,
+            [valueLogCheck](bool on)
+            {
+                QSignalBlocker b(valueLogCheck);
+                valueLogCheck->setChecked(on);
             });
 
     append_inspector_extensions();

--- a/src/SciQLopMultiPlotPanel.cpp
+++ b/src/SciQLopMultiPlotPanel.cpp
@@ -431,18 +431,18 @@ SciQLopMultiPlotPanel::plot_impl(GetDataPyCallable callable, QString name, bool 
 
 QPair<SciQLopPlotInterface*, SciQLopColorMapInterface*>
 SciQLopMultiPlotPanel::plot_impl(const SciQLopPyBuffer& x, const SciQLopPyBuffer& y, QString name, int key_bins,
-                                 int value_bins, PlotType plot_type, int index,
-                                 QVariantMap metaData)
+                                 int value_bins, bool x_bins_log, bool y_bins_log,
+                                 PlotType plot_type, int index, QVariantMap metaData)
 {
     switch (plot_type)
     {
         case ::PlotType::BasicXY:
             return _plot_histogram2d<SciQLopPlot>(
-                index, x, y, name, key_bins, value_bins, metaData);
+                index, x, y, name, key_bins, value_bins, x_bins_log, y_bins_log, metaData);
             break;
         case ::PlotType::TimeSeries:
             return _plot_histogram2d<SciQLopTimeSeriesPlot>(
-                index, x, y, name, key_bins, value_bins, metaData);
+                index, x, y, name, key_bins, value_bins, x_bins_log, y_bins_log, metaData);
             break;
         default:
             break;
@@ -452,18 +452,21 @@ SciQLopMultiPlotPanel::plot_impl(const SciQLopPyBuffer& x, const SciQLopPyBuffer
 
 QPair<SciQLopPlotInterface*, SciQLopColorMapInterface*>
 SciQLopMultiPlotPanel::plot_impl(GetDataPyCallable callable, QString name, int key_bins,
-                                 int value_bins, PlotType plot_type, QObject* sync_with,
+                                 int value_bins, bool x_bins_log, bool y_bins_log,
+                                 PlotType plot_type, QObject* sync_with,
                                  int index, QVariantMap metaData)
 {
     switch (plot_type)
     {
         case ::PlotType::BasicXY:
             return _plot_histogram2d<SciQLopPlot>(
-                index, std::move(callable), name, key_bins, value_bins, sync_with, metaData);
+                index, std::move(callable), name, key_bins, value_bins, x_bins_log, y_bins_log,
+                sync_with, metaData);
             break;
         case ::PlotType::TimeSeries:
             return _plot_histogram2d<SciQLopTimeSeriesPlot>(
-                index, std::move(callable), name, key_bins, value_bins, sync_with, metaData);
+                index, std::move(callable), name, key_bins, value_bins, x_bins_log, y_bins_log,
+                sync_with, metaData);
             break;
         default:
             break;

--- a/src/SciQLopPlot.cpp
+++ b/src/SciQLopPlot.cpp
@@ -156,11 +156,14 @@ SciQLopColorMap* SciQLopPlot::add_color_map(const QString& name, bool y_log_scal
     return nullptr;
 }
 
-SciQLopHistogram2D* SciQLopPlot::add_histogram2d(const QString& name, int key_bins, int value_bins)
+SciQLopHistogram2D* SciQLopPlot::add_histogram2d(const QString& name, int key_bins, int value_bins,
+                                                  bool x_bins_log, bool y_bins_log)
 {
     auto hist = new SciQLopHistogram2D(
         this, this->m_axes[0], this->m_axes[1],
         static_cast<SciQLopPlotColorScaleAxis*>(this->m_axes[4]), name, key_bins, value_bins);
+    hist->set_x_bins_log(x_bins_log);
+    hist->set_y_bins_log(y_bins_log);
     _ensure_colorscale_is_visible(hist);
     _register_plottable_wrapper(hist);
     return hist;
@@ -168,12 +171,15 @@ SciQLopHistogram2D* SciQLopPlot::add_histogram2d(const QString& name, int key_bi
 
 SciQLopHistogram2DFunction* SciQLopPlot::add_histogram2d(GetDataPyCallable&& callable,
                                                           const QString& name, int key_bins,
-                                                          int value_bins)
+                                                          int value_bins, bool x_bins_log,
+                                                          bool y_bins_log)
 {
     auto hist = new SciQLopHistogram2DFunction(
         this, this->m_axes[0], this->m_axes[1],
         static_cast<SciQLopPlotColorScaleAxis*>(this->m_axes[4]), std::move(callable), name,
         key_bins, value_bins);
+    hist->set_x_bins_log(x_bins_log);
+    hist->set_y_bins_log(y_bins_log);
     _ensure_colorscale_is_visible(hist);
     _register_plottable_wrapper(hist);
     return hist;
@@ -666,9 +672,10 @@ SciQLopPlot::~SciQLopPlot()
     }
 }
 
-SciQLopHistogram2D* SciQLopPlot::add_histogram2d(const QString& name, int key_bins, int value_bins)
+SciQLopHistogram2D* SciQLopPlot::add_histogram2d(const QString& name, int key_bins, int value_bins,
+                                                  bool x_bins_log, bool y_bins_log)
 {
-    auto hist = m_impl->add_histogram2d(name, key_bins, value_bins);
+    auto hist = m_impl->add_histogram2d(name, key_bins, value_bins, x_bins_log, y_bins_log);
     if (hist)
     {
         _configure_color_map(hist, false, false);
@@ -678,9 +685,11 @@ SciQLopHistogram2D* SciQLopPlot::add_histogram2d(const QString& name, int key_bi
 
 SciQLopHistogram2DFunction* SciQLopPlot::add_histogram2d(GetDataPyCallable&& callable,
                                                           const QString& name, int key_bins,
-                                                          int value_bins)
+                                                          int value_bins, bool x_bins_log,
+                                                          bool y_bins_log)
 {
-    auto hist = m_impl->add_histogram2d(std::move(callable), name, key_bins, value_bins);
+    auto hist = m_impl->add_histogram2d(std::move(callable), name, key_bins, value_bins,
+                                        x_bins_log, y_bins_log);
     if (hist)
     {
         _configure_color_map(hist, false, false);

--- a/src/SciQLopPlot.cpp
+++ b/src/SciQLopPlot.cpp
@@ -967,9 +967,10 @@ SciQLopColorMapInterface* SciQLopPlot::plot_impl(GetDataPyCallable callable, QSt
 
 SciQLopColorMapInterface* SciQLopPlot::plot_impl(const SciQLopPyBuffer& x, const SciQLopPyBuffer& y,
                                                   QString name, int key_bins, int value_bins,
+                                                  bool x_bins_log, bool y_bins_log,
                                                   QVariantMap metaData)
 {
-    auto* hist = m_impl->add_histogram2d(name, key_bins, value_bins);
+    auto* hist = m_impl->add_histogram2d(name, key_bins, value_bins, x_bins_log, y_bins_log);
     if (hist)
     {
         hist->set_meta_data(metaData);
@@ -981,9 +982,11 @@ SciQLopColorMapInterface* SciQLopPlot::plot_impl(const SciQLopPyBuffer& x, const
 
 SciQLopColorMapInterface* SciQLopPlot::plot_impl(GetDataPyCallable callable, QString name,
                                                   int key_bins, int value_bins,
+                                                  bool x_bins_log, bool y_bins_log,
                                                   QObject* sync_with, QVariantMap metaData)
 {
-    auto* hist = m_impl->add_histogram2d(std::move(callable), name, key_bins, value_bins);
+    auto* hist = m_impl->add_histogram2d(std::move(callable), name, key_bins, value_bins,
+                                         x_bins_log, y_bins_log);
     if (hist)
     {
         hist->set_meta_data(metaData);

--- a/src/SciQLopPlot.cpp
+++ b/src/SciQLopPlot.cpp
@@ -678,7 +678,7 @@ SciQLopHistogram2D* SciQLopPlot::add_histogram2d(const QString& name, int key_bi
     auto hist = m_impl->add_histogram2d(name, key_bins, value_bins, x_bins_log, y_bins_log);
     if (hist)
     {
-        _configure_color_map(hist, false, false);
+        _configure_color_map(hist, y_bins_log, false);
     }
     return hist;
 }
@@ -692,7 +692,7 @@ SciQLopHistogram2DFunction* SciQLopPlot::add_histogram2d(GetDataPyCallable&& cal
                                         x_bins_log, y_bins_log);
     if (hist)
     {
-        _configure_color_map(hist, false, false);
+        _configure_color_map(hist, y_bins_log, false);
         _connect_callable_sync(hist, nullptr);
     }
     return hist;
@@ -974,7 +974,7 @@ SciQLopColorMapInterface* SciQLopPlot::plot_impl(const SciQLopPyBuffer& x, const
     if (hist)
     {
         hist->set_meta_data(metaData);
-        _configure_color_map(hist, false, false);
+        _configure_color_map(hist, y_bins_log, false);
         hist->set_data(x, y);
     }
     return hist;
@@ -990,7 +990,7 @@ SciQLopColorMapInterface* SciQLopPlot::plot_impl(GetDataPyCallable callable, QSt
     if (hist)
     {
         hist->set_meta_data(metaData);
-        _configure_color_map(hist, false, false);
+        _configure_color_map(hist, y_bins_log, false);
         _connect_callable_sync(hist, sync_with);
     }
     return hist;

--- a/tests/integration/test_histogram2d_log_bins.py
+++ b/tests/integration/test_histogram2d_log_bins.py
@@ -1,0 +1,89 @@
+"""Histogram2D logarithmic bin spacing (set_x_bins_log / set_y_bins_log)."""
+import numpy as np
+import pytest
+from PySide6.QtWidgets import QApplication
+from PySide6.QtCore import QCoreApplication
+
+from SciQLopPlots import SciQLopPlot
+
+
+@pytest.fixture(scope="module")
+def app():
+    instance = QApplication.instance()
+    if instance is None:
+        instance = QApplication([])
+    return instance
+
+
+@pytest.fixture()
+def plot(app):
+    p = SciQLopPlot()
+    yield p
+    del p
+
+
+def _pump_events(n=50):
+    for _ in range(n):
+        QCoreApplication.processEvents()
+
+
+class TestLogBinScale:
+    def test_defaults_linear(self, plot):
+        hist = plot.add_histogram2d("defaults", 20, 20)
+        assert hist.x_bins_log() is False
+        assert hist.y_bins_log() is False
+
+    def test_set_x_bins_log_roundtrips(self, plot):
+        hist = plot.add_histogram2d("xlog", 20, 20)
+        hist.set_x_bins_log(True)
+        assert hist.x_bins_log() is True
+        assert hist.y_bins_log() is False
+        hist.set_x_bins_log(False)
+        assert hist.x_bins_log() is False
+
+    def test_set_y_bins_log_roundtrips(self, plot):
+        hist = plot.add_histogram2d("ylog", 20, 20)
+        hist.set_y_bins_log(True)
+        assert hist.y_bins_log() is True
+        assert hist.x_bins_log() is False
+
+    def test_log_bins_changed_signal(self, plot):
+        hist = plot.add_histogram2d("sig", 20, 20)
+        seen = []
+        hist.x_bins_log_changed.connect(seen.append)
+        hist.set_x_bins_log(True)
+        _pump_events(5)
+        assert seen == [True]
+        # No re-emit when unchanged.
+        hist.set_x_bins_log(True)
+        _pump_events(5)
+        assert seen == [True]
+
+    def test_log_bins_render_decade_data_no_crash(self, plot):
+        """Log bins on log axes with decade-spanning data must render cleanly."""
+        rng = np.random.default_rng(3)
+        x = 10.0 ** rng.uniform(0, 4, 5000)
+        y = 10.0 ** rng.uniform(0, 4, 5000)
+
+        hist = plot.add_histogram2d("logdata", 40, 40)
+        plot.x_axis().set_log(True)
+        plot.y_axis().set_log(True)
+        hist.set_x_bins_log(True)
+        hist.set_y_bins_log(True)
+        hist.set_data(x, y)
+        _pump_events()
+        plot.replot(True)
+        _pump_events()
+        assert hist.visible() is True
+
+    def test_non_positive_with_log_bins_no_crash(self, plot):
+        """Non-positive samples are dropped under log binning without crashing."""
+        x = np.array([-5.0, 1.0, 10.0, 100.0, 0.0, 1000.0])
+        y = np.array([1.0, 2.0, 3.0, 4.0, 5.0, 6.0])
+
+        hist = plot.add_histogram2d("nonpos", 10, 10)
+        hist.set_x_bins_log(True)
+        hist.set_data(x, y)
+        _pump_events()
+        plot.replot(True)
+        _pump_events()

--- a/tests/integration/test_histogram2d_log_bins.py
+++ b/tests/integration/test_histogram2d_log_bins.py
@@ -4,7 +4,7 @@ import pytest
 from PySide6.QtWidgets import QApplication
 from PySide6.QtCore import QCoreApplication
 
-from SciQLopPlots import SciQLopPlot
+from SciQLopPlots import SciQLopPlot, SciQLopMultiPlotPanel, GraphType
 
 
 @pytest.fixture(scope="module")
@@ -56,6 +56,29 @@ class TestLogBinScale:
         hist = plot.add_histogram2d("kw2", 20, 20, x_bins_log=False, y_bins_log=True)
         assert hist.x_bins_log() is False
         assert hist.y_bins_log() is True
+
+    def test_plot_dispatcher_kwarg(self, plot):
+        x = np.array([1.0, 2.0, 3.0, 4.0])
+        y = np.array([1.0, 2.0, 3.0, 4.0])
+        hist = plot.plot(x, y, graph_type=GraphType.Histogram2D,
+                         x_bins_log=True, y_bins_log=True)
+        assert hist.x_bins_log() is True
+        assert hist.y_bins_log() is True
+
+    def test_panel_dispatcher_kwarg(self, app):
+        panel = SciQLopMultiPlotPanel()
+        x = np.array([1.0, 2.0, 3.0, 4.0])
+        y = np.array([1.0, 2.0, 3.0, 4.0])
+        _, hist = panel.plot(x, y, graph_type=GraphType.Histogram2D, x_bins_log=True)
+        assert hist.x_bins_log() is True
+        assert hist.y_bins_log() is False
+        del panel
+
+    def test_log_kwarg_rejected_for_non_histogram(self, plot):
+        x = np.array([1.0, 2.0, 3.0, 4.0])
+        y = np.array([1.0, 2.0, 3.0, 4.0])
+        with pytest.raises(TypeError):
+            plot.plot(x, y, graph_type=GraphType.Line, x_bins_log=True)
 
     def test_log_bins_changed_signal(self, plot):
         hist = plot.add_histogram2d("sig", 20, 20)

--- a/tests/integration/test_histogram2d_log_bins.py
+++ b/tests/integration/test_histogram2d_log_bins.py
@@ -74,6 +74,18 @@ class TestLogBinScale:
         assert hist.y_bins_log() is False
         del panel
 
+    def test_bins_log_couples_to_axis(self, plot):
+        """Bin scale and axis scale are the same thing, driven from either side."""
+        hist = plot.add_histogram2d("couple", 20, 20)
+        # setter drives the axis
+        hist.set_x_bins_log(True)
+        assert hist.x_axis().log() is True
+        # toggling the axis (as the 'l' shortcut does) drives the bins
+        hist.x_axis().set_log(False)
+        assert hist.x_bins_log() is False
+        hist.x_axis().set_log(True)
+        assert hist.x_bins_log() is True
+
     def test_log_kwarg_rejected_for_non_histogram(self, plot):
         x = np.array([1.0, 2.0, 3.0, 4.0])
         y = np.array([1.0, 2.0, 3.0, 4.0])

--- a/tests/integration/test_histogram2d_log_bins.py
+++ b/tests/integration/test_histogram2d_log_bins.py
@@ -47,6 +47,16 @@ class TestLogBinScale:
         assert hist.y_bins_log() is True
         assert hist.x_bins_log() is False
 
+    def test_creation_kwarg_x_bins_log(self, plot):
+        hist = plot.add_histogram2d("kw", 20, 20, x_bins_log=True)
+        assert hist.x_bins_log() is True
+        assert hist.y_bins_log() is False
+
+    def test_creation_kwarg_y_bins_log(self, plot):
+        hist = plot.add_histogram2d("kw2", 20, 20, x_bins_log=False, y_bins_log=True)
+        assert hist.x_bins_log() is False
+        assert hist.y_bins_log() is True
+
     def test_log_bins_changed_signal(self, plot):
         hist = plot.add_histogram2d("sig", 20, 20)
         seen = []


### PR DESCRIPTION
## Summary

Exposes **logarithmic bin spacing** for Histogram2D, coupled to the axis scale so that toggling an axis between linear and log re-bins and redistributes the cells. Requires NeoQCP's histogram log-binning + axis-coupling (merged: SciQLop/NeoQCP#28, #29; the wrap tracks `main`).

## Behaviour

Log binning *is* the axis being logarithmic — a single source of truth:

- hitting `l` on the axis, the inspector "X/Y log bins" checkboxes, the creation kwargs, and `set_x/y_bins_log()` all flow through the axis scale and stay in sync.
- toggling the scale actually changes the picture (the colormap renderer only stretches cells uniformly in pixels, so the bin layout must follow the axis — same approach as the spectrogram resampler).

## API

```python
plot.add_histogram2d("h", 40, 40, x_bins_log=True, y_bins_log=True)
plot.plot(x, y, graph_type=GraphType.Histogram2D, x_bins_log=True)   # + panel.plot(...)
hist.set_x_bins_log(True); hist.x_bins_log()                          # == hist.x_axis().log()
```

## Notable changes

- `SciQLopHistogram2D`: `set_x/y_bins_log` drive `_keyAxis/_valueAxis->set_log`; the axis `log_changed` re-bins (`QCPHistogram2D::refreshBinning`) and re-emits `*_bins_log_changed` (so `set_log`'s signal-blocking is handled). Inspector delegate gains the checkboxes.
- `x_bins_log`/`y_bins_log` threaded through `add_histogram2d`, the `histogram2d()` interface, `plot()`/panel dispatcher, bindings.xml, and `_HISTOGRAM2D_KWARGS`.
- `z_percentile_range` remaps cell centres to log so the percentile viewport filter matches what is drawn under log bins.
- `_configure_color_map` now receives `y_bins_log` at the histogram sites (it previously forced the value axis back to linear).
- Build: numpy include passed via `-I` so an in-tree build venv (`./.venv`) configures.

## Tests

`tests/integration/test_histogram2d_log_bins.py` (12): setter/kwarg/dispatcher/round-trip, axis↔bins coupling from either side, signal, non-positive + decade-render smoke. Full integration suite: **674 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)