### PR TITLE
feat(products): documented & settable search-bar help

### DIFF
--- a/docs/superpowers/plans/2026-06-07-search-bar-help.md
+++ b/docs/superpowers/plans/2026-06-07-search-bar-help.md
@@ -1,0 +1,398 @@
+# Search-bar Help Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Document the product-tree search keywords in-place (hover tooltip + `?`-button popup), auto-generated from the known fields, with a public Python API for SciQLop to override the whole help text.
+
+**Architecture:** Help content is owned by `QueryLineEdit` (it already holds the field data). It exposes `set_help_text()` / `help_text()` and keeps its own tooltip in sync. `ProductsView` adds a `?` toolbar button + a lazy `QTextBrowser` popup, and the public `set_search_help()` / `search_help()` override API that delegates to the line edit. The auto-generated body is built by a pure helper from a static builtin-field table plus discovered metadata fields.
+
+**Tech Stack:** C++20, Qt6 Widgets (`QTextEdit`, `QTextBrowser`, `QToolButton`), Shiboken6 bindings, pytest integration tests.
+
+---
+
+## File structure
+
+- `include/SciQLopPlots/Products/QueryLineEdit.hpp` — add help API (override string, getter, setter, signal, private builder).
+- `src/QueryLineEdit.cpp` — implement help builder, tooltip sync, signal emission.
+- `include/SciQLopPlots/Products/ProductsView.hpp` — add `?` button, popup, public `set_search_help`/`search_help`, `show_help_popup` slot.
+- `src/ProductsView.cpp` — wire button/popup, implement public API.
+- `SciQLopPlots/bindings/bindings.xml` — touch to force Shiboken regen (no new entry needed; methods are public on the already-exposed `ProductsView`).
+- `tests/integration/test_search_bar_help.py` — new integration test (create).
+
+---
+
+## Task 1: Failing integration test for the public help API
+
+**Files:**
+- Test: `tests/integration/test_search_bar_help.py` (create)
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+"""Tests for the product search-bar help (auto-generated + override)."""
+import pytest
+from PySide6.QtWidgets import QTextEdit
+from SciQLopPlots import (
+    ProductsView, ProductsModel, ProductsModelNode,
+    ProductsModelNodeType, ParameterType,
+)
+
+
+def test_auto_help_lists_builtin_fields_and_shortcut(qtbot):
+    view = ProductsView()
+    qtbot.addWidget(view)
+    help_text = view.search_help()
+    for field in ("provider", "type", "after", "before"):
+        assert field in help_text
+    assert "Ctrl+Space" in help_text
+
+
+def test_set_search_help_overrides_auto(qtbot):
+    view = ProductsView()
+    qtbot.addWidget(view)
+    view.set_search_help("<b>Custom help</b>")
+    assert view.search_help() == "<b>Custom help</b>"
+
+
+def test_empty_override_reverts_to_auto(qtbot):
+    view = ProductsView()
+    qtbot.addWidget(view)
+    view.set_search_help("<b>Custom help</b>")
+    view.set_search_help("")
+    assert "provider" in view.search_help()
+    assert view.search_help() != "<b>Custom help</b>"
+
+
+def test_search_bar_tooltip_reflects_help(qtbot):
+    view = ProductsView()
+    qtbot.addWidget(view)
+    view.set_search_help("<b>Custom help</b>")
+    bar = view.findChild(QTextEdit)
+    assert bar is not None
+    assert bar.toolTip() == "<b>Custom help</b>"
+
+
+def test_auto_help_includes_discovered_metadata_key(qtbot):
+    model = ProductsModel.instance()
+    root = ProductsModelNode("help_test_provider")
+    node = ProductsModelNode(
+        "HelpProbe", "help_test_provider",
+        {"mission": "helptest_mission"},
+        ProductsModelNodeType.PARAMETER, ParameterType.Scalar)
+    root.add_child(node)
+    model.add_node([], root)
+
+    # ProductsView ctor runs refresh_completions() synchronously over the model,
+    # so constructing after populating gives deterministic auto-help.
+    view = ProductsView()
+    qtbot.addWidget(view)
+    assert "mission" in view.search_help()
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `PYTHONPATH=build pytest tests/integration/test_search_bar_help.py -v`
+Expected: FAIL — `AttributeError: 'ProductsView' object has no attribute 'search_help'`.
+
+---
+
+## Task 2: Help content + tooltip in `QueryLineEdit`
+
+**Files:**
+- Modify: `include/SciQLopPlots/Products/QueryLineEdit.hpp`
+- Modify: `src/QueryLineEdit.cpp`
+
+- [ ] **Step 1: Add the help API to the header**
+
+In `QueryLineEdit.hpp`, add a member `QString m_help_override;` alongside the
+other members (after `QStringList m_product_names;`):
+
+```cpp
+    QStringList m_product_names;
+    QString m_help_override;
+```
+
+In the `public:` section, after `set_known_fields(...)`:
+
+```cpp
+    void set_help_text(const QString& html);
+    QString help_text() const;
+
+    Q_SIGNAL void helpTextChanged();
+```
+
+In the `private:` section, after `QString current_word() const;`:
+
+```cpp
+    QString build_help_html() const;
+    void refresh_help();
+```
+
+- [ ] **Step 2: Implement the help logic in the cpp**
+
+In `src/QueryLineEdit.cpp`, add `#include <QTextDocument>` is **not** needed; the
+builder uses only `QString`. Add the implementations at the end of the file
+(after `current_word()`):
+
+```cpp
+namespace
+{
+struct BuiltinField
+{
+    const char* name;
+    const char* description;
+    const char* example;
+};
+
+constexpr BuiltinField builtin_fields[] = {
+    { "provider", "data source", "provider:amda" },
+    { "type", "parameter kind", "type:vector" },
+    { "after", "start date (ISO)", "after:2015-01-01" },
+    { "before", "end date (ISO)", "before:2016" },
+};
+}
+
+QString QueryLineEdit::build_help_html() const
+{
+    QString html;
+    html += "<b>Search products</b><br/>";
+    html += "Type words to match product names, and combine with "
+            "<i>field:value</i> filters.<br/><br/>";
+    html += "<table cellspacing='4'>";
+
+    QSet<QString> builtin_names;
+    for (const auto& f : builtin_fields)
+    {
+        builtin_names.insert(QString::fromLatin1(f.name));
+        html += QString("<tr><td><b>%1</b></td><td>%2</td><td><i>%3</i></td></tr>")
+                    .arg(f.name, f.description, f.example);
+    }
+    html += "</table>";
+
+    QStringList metadata_fields;
+    for (const auto& name : m_field_names)
+    {
+        if (!builtin_names.contains(name))
+            metadata_fields.append(name);
+    }
+    if (!metadata_fields.isEmpty())
+    {
+        metadata_fields.sort();
+        html += QString("<br/>Metadata fields: %1").arg(metadata_fields.join(", "));
+    }
+
+    html += "<br/><br/><i>Tip: press Ctrl+Space to autocomplete.</i>";
+    return html;
+}
+
+QString QueryLineEdit::help_text() const
+{
+    if (!m_help_override.trimmed().isEmpty())
+        return m_help_override;
+    return build_help_html();
+}
+
+void QueryLineEdit::set_help_text(const QString& html)
+{
+    m_help_override = html;
+    refresh_help();
+}
+
+void QueryLineEdit::refresh_help()
+{
+    setToolTip(help_text());
+    emit helpTextChanged();
+}
+```
+
+- [ ] **Step 3: Refresh help whenever completions change**
+
+In `QueryLineEdit::set_completions(...)`, append a call to `refresh_help()` at
+the end of the body:
+
+```cpp
+void QueryLineEdit::set_completions(const QStringList& field_names,
+                                     const QMap<QString, QStringList>& field_values,
+                                     const QStringList& product_names)
+{
+    m_field_names = field_names;
+    m_field_values = field_values;
+    m_product_names = product_names;
+    refresh_help();
+}
+```
+
+- [ ] **Step 4: Add the missing include**
+
+At the top of `src/QueryLineEdit.cpp`, add `#include <QSet>` with the other
+includes (the builder uses `QSet<QString>`).
+
+---
+
+## Task 3: `?` button, popup, and public override API in `ProductsView`
+
+**Files:**
+- Modify: `include/SciQLopPlots/Products/ProductsView.hpp`
+- Modify: `src/ProductsView.cpp`
+
+- [ ] **Step 1: Declare new members and public API in the header**
+
+In `ProductsView.hpp`, add forward declarations near the top (after the existing
+ones):
+
+```cpp
+class QTextBrowser;
+```
+
+Add private members alongside the existing ones:
+
+```cpp
+    QToolButton* m_help_button;
+    QTextBrowser* m_help_popup;
+```
+
+Add a private slot with the other slots:
+
+```cpp
+    Q_SLOT void show_help_popup();
+```
+
+In the `public:` section, after the constructor/destructor:
+
+```cpp
+    void set_search_help(const QString& html);
+    QString search_help() const;
+```
+
+- [ ] **Step 2: Add the `?` button to the toolbar**
+
+In `src/ProductsView.cpp`, add `#include <QTextBrowser>` with the other includes.
+
+In the constructor, after the `m_view_toggle` block and before
+`m_result_count` is added to the toolbar, create the help button:
+
+```cpp
+    m_help_button = new QToolButton(this);
+    m_help_button->setText("?");
+    m_help_button->setToolTip("Show search syntax help");
+    toolbar->addWidget(m_help_button);
+```
+
+Initialise the popup pointer to null in the same constructor (before the
+`connect` calls):
+
+```cpp
+    m_help_popup = nullptr;
+```
+
+- [ ] **Step 3: Wire the button and help-changed signal**
+
+In the constructor, after the existing `connect(...)` calls for
+`m_view_toggle`, add:
+
+```cpp
+    connect(m_help_button, &QToolButton::clicked, this,
+            &ProductsView::show_help_popup);
+    connect(m_query_line_edit, &QueryLineEdit::helpTextChanged, this, [this]() {
+        if (m_help_popup && m_help_popup->isVisible())
+            m_help_popup->setHtml(search_help());
+    });
+```
+
+- [ ] **Step 4: Implement the public API and popup slot**
+
+Add these definitions at the end of `src/ProductsView.cpp`:
+
+```cpp
+void ProductsView::set_search_help(const QString& html)
+{
+    m_query_line_edit->set_help_text(html);
+}
+
+QString ProductsView::search_help() const
+{
+    return m_query_line_edit->help_text();
+}
+
+void ProductsView::show_help_popup()
+{
+    if (!m_help_popup)
+    {
+        m_help_popup = new QTextBrowser(this);
+        m_help_popup->setWindowFlags(Qt::Popup);
+        m_help_popup->setOpenExternalLinks(true);
+        m_help_popup->setFixedSize(380, 240);
+    }
+    m_help_popup->setHtml(search_help());
+    QPoint pos = m_query_line_edit->mapToGlobal(
+        QPoint(0, m_query_line_edit->height()));
+    m_help_popup->move(pos);
+    m_help_popup->show();
+}
+```
+
+---
+
+## Task 4: Regenerate bindings, build, install, verify
+
+**Files:**
+- Modify: `SciQLopPlots/bindings/bindings.xml` (touch only)
+
+- [ ] **Step 1: Force Shiboken regen**
+
+The new methods are public on the already-exposed `ProductsView`, so no XML
+entry is needed — but the meson custom_target does not track header changes, so
+touch the typesystem to force regeneration:
+
+Run: `touch SciQLopPlots/bindings/bindings.xml`
+
+- [ ] **Step 2: Compile**
+
+Run: `meson compile -C build`
+Expected: builds cleanly; `SciQLopPlotsBindings` relinks.
+
+- [ ] **Step 3: Run the new test**
+
+Run: `PYTHONPATH=build pytest tests/integration/test_search_bar_help.py -v`
+Expected: all 5 tests PASS.
+
+(Local alternative matching the user's workflow: copy the freshly built
+`build/SciQLopPlots/SciQLopPlotsBindings*.so` into SciQLop's venv site-packages
+and run pytest from outside the project dir via that venv — never with
+`QT_QPA_PLATFORM=offscreen` locally.)
+
+- [ ] **Step 4: Run the surrounding suites for regressions**
+
+Run: `PYTHONPATH=build pytest tests/integration/test_products_filter.py tests/integration/test_query_parser.py -v`
+Expected: PASS (no regressions in the products area).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add include/SciQLopPlots/Products/QueryLineEdit.hpp src/QueryLineEdit.cpp \
+        include/SciQLopPlots/Products/ProductsView.hpp src/ProductsView.cpp \
+        SciQLopPlots/bindings/bindings.xml \
+        tests/integration/test_search_bar_help.py
+git commit -m "feat(products): documented & settable search-bar help
+
+Auto-generate keyword help from known fields, shown as the search-bar
+tooltip and in a ?-button popup; expose ProductsView.set_search_help /
+search_help so SciQLop can override the whole help text.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Self-review notes
+
+- Spec coverage: hover tooltip (Task 2 `refresh_help`→`setToolTip`), `?` popup
+  (Task 3), auto-generated from fields (Task 2 `build_help_html`), SciQLop
+  whole-text override (Task 3 `set_search_help`), bindings (Task 4), tests
+  (Task 1 + Task 4). All spec sections map to a task.
+- Type consistency: `set_help_text`/`help_text`/`helpTextChanged`/`build_help_html`/
+  `refresh_help` on `QueryLineEdit`; `set_search_help`/`search_help`/
+  `show_help_popup`/`m_help_button`/`m_help_popup` on `ProductsView` — names used
+  consistently across tasks.
+- No placeholders; every code step shows full code.
+```

--- a/docs/superpowers/specs/2026-06-07-search-bar-help-design.md
+++ b/docs/superpowers/specs/2026-06-07-search-bar-help-design.md
@@ -1,0 +1,125 @@
+# Search-bar help: documented & settable keywords
+
+Date: 2026-06-07
+Status: Approved (design)
+
+## Problem
+
+The product-tree search bar (`QueryLineEdit` inside `ProductsView`) supports a
+query mini-language — free text plus `field:value` filters over `provider`,
+`type`, `after`, `before`, and metadata keys auto-discovered from products.
+Today this syntax is essentially undocumented in the UI: discoverability is
+limited to the placeholder text and a `Ctrl+Space` completion shortcut most
+users never find. We want the keywords documented in-place and a way for the
+embedding app (SciQLop) to override the help text.
+
+## Goals
+
+- Show the available fields and syntax as a **hover tooltip** on the search bar.
+- Show the same content in a **`?`-button popup** that the user can read and dismiss.
+- **Auto-generate** the keyword list from the known fields so it stays in sync.
+- Let **SciQLop override the entire help text** from Python with its own string.
+
+Non-goals: per-field descriptions supplied from Python (override is whole-text
+only for v1); markdown rendering beyond Qt's rich-text HTML subset; restyling
+the existing completion popup.
+
+## Approach (chosen: A)
+
+Help content is owned by `QueryLineEdit` — it already holds the field data
+(`m_field_names`, `m_field_values`). `ProductsView` surfaces that content two
+ways (tooltip + `?` popup) and exposes the public override API, since
+`ProductsView` is the Python-exposed widget (`bindings.xml`).
+
+Rejected alternatives:
+- **B** (all help logic in `ProductsView`): splits field data from the object
+  that owns it; more plumbing for no benefit.
+- **C** (tooltip only): under-delivers — the `?` popup was explicitly requested.
+
+## Components
+
+### `QueryLineEdit` (src/QueryLineEdit.cpp, include/.../QueryLineEdit.hpp)
+
+New members:
+- `QString m_help_override;` — empty ⇒ use auto-generated help.
+- `void set_help_text(const QString& html);` — set override; `""` (or
+  all-whitespace) reverts to auto. Updates the tooltip and emits the signal.
+- `QString help_text() const;` — effective help (override if non-blank, else
+  auto). Always returns non-empty.
+- `Q_SIGNAL void helpTextChanged();`
+- `QString build_help_html() const;` (private) — pure builder from a
+  file-local static table of builtin fields + discovered `m_field_names` /
+  `m_field_values`.
+
+Wiring:
+- `set_completions(...)` rebuilds the auto help (only when no override is set),
+  calls `setToolTip(help_text())`, and emits `helpTextChanged()`.
+- `set_help_text(...)` stores the override, calls `setToolTip(help_text())`,
+  emits `helpTextChanged()`.
+
+### `ProductsView` (src/ProductsView.cpp, include/.../ProductsView.hpp)
+
+New members:
+- `QToolButton* m_help_button;` — a `?` button added to the existing `toolbar`
+  row (always visible, next to the view toggle).
+- `QTextBrowser* m_help_popup;` — lazily created, frameless (`Qt::Popup`),
+  `setOpenExternalLinks(true)`, parented to `ProductsView`; reused across clicks.
+- `void set_search_help(const QString& html);` (public) — delegates to
+  `m_query_line_edit->set_help_text(html)`. **Python override entry point.**
+- `QString search_help() const;` (public) — `m_query_line_edit->help_text()`.
+- `void show_help_popup();` (slot) — builds/positions the popup under the search
+  bar, sets its HTML to `search_help()`, shows it.
+
+Wiring:
+- `m_help_button` clicked → `show_help_popup()`.
+- `m_query_line_edit::helpTextChanged` → refresh popup HTML if currently visible.
+
+## Data flow
+
+1. `refresh_completions()` → `set_completions(...)` → `QueryLineEdit` rebuilds
+   auto help (if no override), updates tooltip, emits `helpTextChanged`.
+2. SciQLop calls `view.set_search_help(html)` → override stored → tooltip
+   updated → `helpTextChanged` emitted.
+3. Clicking `?` → `show_help_popup()` renders `search_help()`.
+
+## Auto-generated help content
+
+Built from a file-local static table (data over code):
+
+```
+{provider, "data source",      "provider:amda"}
+{type,     "parameter kind",   "type:vector"}
+{after,    "start date (ISO)", "after:2015-01-01"}
+{before,   "end date (ISO)",   "before:2016"}
+```
+
+Rendered HTML:
+- One-line intro: type words to match product names; combine with `field:value`.
+- A `<table>` of builtin field → description → example.
+- A line listing discovered metadata field names (those in `m_field_names` not
+  in the static table), names only.
+- Footer tip: "Press Ctrl+Space to autocomplete."
+
+## Error handling / edge cases
+
+- Override `""` or all-whitespace ⇒ falls back to auto; `help_text()` never empty.
+- Popup created lazily, reused; parented for correct lifetime.
+- SciQLop-supplied HTML is trusted (same trust level as the rest of the host app).
+  Qt renders only its rich-text subset.
+
+## Bindings
+
+`set_search_help` / `search_help` are public methods on the already-exposed
+`ProductsView`, so Shiboken auto-exposes them. Per the regen quirk, touch
+`bindings.xml` to force regeneration after editing the header.
+
+## Testing (integration, written first)
+
+`tests/integration/test_search_bar_help.py`:
+- `set_search_help("custom")` ⇒ `search_help() == "custom"`.
+- Empty override reverts to auto; auto text contains every builtin field name
+  (`provider`, `type`, `after`, `before`) and "Ctrl+Space".
+- After products are loaded, a discovered metadata key appears in `search_help()`.
+
+`build_help_html` is covered transitively via `search_help()`; no separate C++
+harness needed.

--- a/include/SciQLopPlots/Products/ProductsView.hpp
+++ b/include/SciQLopPlots/Products/ProductsView.hpp
@@ -28,6 +28,7 @@ class QTreeView;
 class QListView;
 class QStackedWidget;
 class QToolButton;
+class QTextBrowser;
 class QLabel;
 class QTimer;
 class ProductsTreeFilterModel;
@@ -42,12 +43,15 @@ class ProductsView : public QWidget
     QListView* m_list_view;
     QStackedWidget* m_stack;
     QToolButton* m_view_toggle;
+    QToolButton* m_help_button;
+    QTextBrowser* m_help_popup;
     QLabel* m_result_count;
     ProductsTreeFilterModel* m_tree_filter;
     ProductsFlatFilterModel* m_flat_filter;
     QTimer* m_completion_refresh_timer;
 
     Q_SLOT void on_query_changed(const Query& query);
+    Q_SLOT void show_help_popup();
     void toggle_view();
     void update_result_count();
     void refresh_completions();
@@ -55,4 +59,7 @@ class ProductsView : public QWidget
 public:
     ProductsView(QWidget* parent = nullptr);
     virtual ~ProductsView() = default;
+
+    void set_search_help(const QString& html);
+    QString search_help() const;
 };

--- a/include/SciQLopPlots/Products/QueryLineEdit.hpp
+++ b/include/SciQLopPlots/Products/QueryLineEdit.hpp
@@ -41,6 +41,7 @@ class QueryLineEdit : public QTextEdit
     QStringList m_field_names;
     QMap<QString, QStringList> m_field_values;
     QStringList m_product_names;
+    QString m_help_override;
 
 public:
     QueryLineEdit(QWidget* parent = nullptr);
@@ -50,6 +51,11 @@ public:
                          const QStringList& product_names);
 
     void set_known_fields(const QSet<QString>& fields);
+
+    void set_help_text(const QString& html);
+    QString help_text() const;
+
+    Q_SIGNAL void helpTextChanged();
 
     Q_SIGNAL void queryChanged(const Query& query);
 
@@ -65,4 +71,6 @@ private:
     void show_popup(const QStringList& items);
     void hide_popup();
     QString current_word() const;
+    QString build_help_html() const;
+    void refresh_help();
 };

--- a/src/ProductsView.cpp
+++ b/src/ProductsView.cpp
@@ -30,6 +30,7 @@
 #include <QLabel>
 #include <QListView>
 #include <QStackedWidget>
+#include <QTextBrowser>
 #include <QTimer>
 #include <QToolButton>
 #include <QTreeView>
@@ -51,6 +52,11 @@ ProductsView::ProductsView(QWidget* parent) : QWidget(parent)
     m_view_toggle->setCheckable(true);
     m_view_toggle->hide();
     toolbar->addWidget(m_view_toggle);
+
+    m_help_button = new QToolButton(this);
+    m_help_button->setText("?");
+    m_help_button->setToolTip("Show search syntax help");
+    toolbar->addWidget(m_help_button);
 
     m_result_count = new QLabel(this);
     m_result_count->hide();
@@ -87,10 +93,18 @@ ProductsView::ProductsView(QWidget* parent) : QWidget(parent)
     m_stack->setCurrentWidget(m_tree_view);
     layout->addWidget(m_stack);
 
+    m_help_popup = nullptr;
+
     connect(m_query_line_edit, &QueryLineEdit::queryChanged, this,
             &ProductsView::on_query_changed);
     connect(m_view_toggle, &QToolButton::toggled, this,
             [this](bool) { toggle_view(); });
+    connect(m_help_button, &QToolButton::clicked, this,
+            &ProductsView::show_help_popup);
+    connect(m_query_line_edit, &QueryLineEdit::helpTextChanged, this, [this]() {
+        if (m_help_popup && m_help_popup->isVisible())
+            m_help_popup->setHtml(search_help());
+    });
 
     m_completion_refresh_timer = new QTimer(this);
     m_completion_refresh_timer->setSingleShot(true);
@@ -201,4 +215,30 @@ void ProductsView::refresh_completions()
     for (const auto& f : field_names)
         known_fields_set.insert(f.toLower());
     m_query_line_edit->set_known_fields(known_fields_set);
+}
+
+void ProductsView::set_search_help(const QString& html)
+{
+    m_query_line_edit->set_help_text(html);
+}
+
+QString ProductsView::search_help() const
+{
+    return m_query_line_edit->help_text();
+}
+
+void ProductsView::show_help_popup()
+{
+    if (!m_help_popup)
+    {
+        m_help_popup = new QTextBrowser(this);
+        m_help_popup->setWindowFlags(Qt::Popup);
+        m_help_popup->setOpenExternalLinks(true);
+        m_help_popup->setFixedSize(380, 240);
+    }
+    m_help_popup->setHtml(search_help());
+    QPoint pos = m_query_line_edit->mapToGlobal(
+        QPoint(0, m_query_line_edit->height()));
+    m_help_popup->move(pos);
+    m_help_popup->show();
 }

--- a/src/QueryLineEdit.cpp
+++ b/src/QueryLineEdit.cpp
@@ -5,6 +5,7 @@
 #include <QKeyEvent>
 #include <QListView>
 #include <QScrollBar>
+#include <QSet>
 #include <QStringListModel>
 #include <QTimer>
 #include <algorithm>
@@ -57,6 +58,7 @@ void QueryLineEdit::set_completions(const QStringList& field_names,
     m_field_names = field_names;
     m_field_values = field_values;
     m_product_names = product_names;
+    refresh_help();
 }
 
 void QueryLineEdit::set_known_fields(const QSet<QString>& fields)
@@ -259,4 +261,73 @@ QString QueryLineEdit::current_word() const
         --start;
 
     return text.mid(start, pos - start);
+}
+
+namespace
+{
+struct BuiltinField
+{
+    const char* name;
+    const char* description;
+    const char* example;
+};
+
+constexpr BuiltinField builtin_fields[] = {
+    { "provider", "data source", "provider:amda" },
+    { "type", "parameter kind", "type:vector" },
+    { "after", "start date (ISO)", "after:2015-01-01" },
+    { "before", "end date (ISO)", "before:2016" },
+};
+}
+
+QString QueryLineEdit::build_help_html() const
+{
+    QString html;
+    html += "<b>Search products</b><br/>";
+    html += "Type words to match product names, and combine with "
+            "<i>field:value</i> filters.<br/><br/>";
+    html += "<table cellspacing='4'>";
+
+    QSet<QString> builtin_names;
+    for (const auto& f : builtin_fields)
+    {
+        builtin_names.insert(QString::fromLatin1(f.name));
+        html += QString("<tr><td><b>%1</b></td><td>%2</td><td><i>%3</i></td></tr>")
+                    .arg(f.name, f.description, f.example);
+    }
+    html += "</table>";
+
+    QStringList metadata_fields;
+    for (const auto& name : m_field_names)
+    {
+        if (!builtin_names.contains(name))
+            metadata_fields.append(name.toHtmlEscaped());
+    }
+    if (!metadata_fields.isEmpty())
+    {
+        metadata_fields.sort();
+        html += QString("<br/>Metadata fields: %1").arg(metadata_fields.join(", "));
+    }
+
+    html += "<br/><br/><i>Tip: press Ctrl+Space to autocomplete.</i>";
+    return html;
+}
+
+QString QueryLineEdit::help_text() const
+{
+    if (!m_help_override.trimmed().isEmpty())
+        return m_help_override;
+    return build_help_html();
+}
+
+void QueryLineEdit::set_help_text(const QString& html)
+{
+    m_help_override = html;
+    refresh_help();
+}
+
+void QueryLineEdit::refresh_help()
+{
+    setToolTip(help_text());
+    emit helpTextChanged();
 }

--- a/tests/integration/test_search_bar_help.py
+++ b/tests/integration/test_search_bar_help.py
@@ -1,0 +1,58 @@
+"""Tests for the product search-bar help (auto-generated + override)."""
+import pytest
+from PySide6.QtWidgets import QTextEdit
+from SciQLopPlots import (
+    ProductsView, ProductsModel, ProductsModelNode,
+    ProductsModelNodeType, ParameterType,
+)
+
+
+def test_auto_help_lists_builtin_fields_and_shortcut(qtbot):
+    view = ProductsView()
+    qtbot.addWidget(view)
+    help_text = view.search_help()
+    for field in ("provider", "type", "after", "before"):
+        assert field in help_text
+    assert "Ctrl+Space" in help_text
+
+
+def test_set_search_help_overrides_auto(qtbot):
+    view = ProductsView()
+    qtbot.addWidget(view)
+    view.set_search_help("<b>Custom help</b>")
+    assert view.search_help() == "<b>Custom help</b>"
+
+
+def test_empty_override_reverts_to_auto(qtbot):
+    view = ProductsView()
+    qtbot.addWidget(view)
+    view.set_search_help("<b>Custom help</b>")
+    view.set_search_help("")
+    assert "provider" in view.search_help()
+    assert view.search_help() != "<b>Custom help</b>"
+
+
+def test_search_bar_tooltip_reflects_help(qtbot):
+    view = ProductsView()
+    qtbot.addWidget(view)
+    view.set_search_help("<b>Custom help</b>")
+    bar = view.findChild(QTextEdit)
+    assert bar is not None
+    assert bar.toolTip() == "<b>Custom help</b>"
+
+
+def test_auto_help_includes_discovered_metadata_key(qtbot):
+    model = ProductsModel.instance()
+    root = ProductsModelNode("help_test_provider")
+    node = ProductsModelNode(
+        "HelpProbe", "help_test_provider",
+        {"mission": "helptest_mission"},
+        ProductsModelNodeType.PARAMETER, ParameterType.Scalar)
+    root.add_child(node)
+    model.add_node([], root)
+
+    # ProductsView ctor runs refresh_completions() synchronously over the model,
+    # so constructing after populating gives deterministic auto-help.
+    view = ProductsView()
+    qtbot.addWidget(view)
+    assert "mission" in view.search_help()


### PR DESCRIPTION
## Summary
- The product-tree search bar's keyword help is now **auto-generated** from the known fields (`provider`, `type`, `after`, `before` + discovered metadata keys) and shown as the bar's **hover tooltip**.
- Added a **`?` toolbar button** that opens a small frameless `QTextBrowser` popup with the same help (scrollable, supports links).
- Exposed a public Python API on `ProductsView` so the embedding app (SciQLop) can **override the whole help text**: `set_search_help(html)` (empty string reverts to auto) and `search_help()`.

Help content is owned by `QueryLineEdit` (which holds the field data) and surfaced two ways via `ProductsView`, keeping a single source of truth for the tooltip and the popup. Discovered metadata field names are HTML-escaped before rendering.

## Test Plan
- [x] New `tests/integration/test_search_bar_help.py` (5 cases): auto-help lists builtin fields + Ctrl+Space tip; override replaces auto; empty override reverts; search-bar tooltip reflects help; discovered metadata key appears in auto-help.
- [x] Regression: `test_products_filter.py` + `test_query_parser.py` pass (45 passed total).
- [x] Clean `debugoptimized` build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)