### PR TITLE
Fix colorbar range in inspector + 'm' rescale revert on limited axes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,27 +12,42 @@ Uses **Meson** with `meson-python` as the Python build backend.
 
 ### Development Build
 
+> **STOP — do not run a bare `meson setup build` / `meson compile -C build`.**
+> Qt is not on the default PATH and the stale top-level `build/` dir will trigger
+> a doomed reconfigure. Use the dedicated in-tree venv + `build-venv` recipe below.
+> Never build against (or `cp .so` into) the SciQLop runtime venv during dev.
+
 ```bash
-# Configure (debug build)
-meson setup build --buildtype=debug
+# One-time: dedicated in-tree venv (Qt/PySide6 6.11.1, meson pinned to 1.10.2)
+cd /var/home/jeandet/Documents/prog/SciQLopPlots
+uv venv .venv --python 3.13
+VIRTUAL_ENV=$(pwd)/.venv uv pip install \
+  pyside6==6.11.1 shiboken6==6.11.1 shiboken6-generator==6.11.1 \
+  numpy meson==1.10.2 ninja meson-python pytest pytest-qt scipy
 
-# Configure (debug with optimizations, recommended for profiling)
-meson setup build --buildtype=debugoptimized
+# Every build: Qt MUST be on PATH (6.11.1 first, 6.11.0 after it for `qsb`)
+VENV=$(pwd)/.venv
+export PATH="$VENV/bin:/home/jeandet/Qt/6.11.1/gcc_64/bin:/home/jeandet/Qt/6.11.0/gcc_64/bin:$PATH"
+export PKG_CONFIG_PATH="/home/jeandet/Qt/6.11.1/gcc_64/lib/pkgconfig:$PKG_CONFIG_PATH"
+$VENV/bin/meson setup build-venv --buildtype=debugoptimized   # first time only
+$VENV/bin/meson compile -C build-venv
 
-# Build
-meson compile -C build
-
-# Run tests (manual test examples)
-meson test -C build
+# Run tests from /tmp so the source pkg doesn't shadow the build (no LD_LIBRARY_PATH!)
+cd /tmp && PYTHONPATH=<PROJ>/build-venv $VENV/bin/python -m pytest <PROJ>/tests/integration -q
 ```
+
+Always `--buildtype=debugoptimized` (never plain `debug`: -O0 makes CPU code unusably slow).
+After switching branches, a stale shiboken wrapper can fail to regenerate — `rm` the
+offending `build-venv/SciQLopPlots/bindings/.../**_wrapper.cpp` and `meson setup
+--reconfigure build-venv` to force a clean regen.
 
 ### Python Wheel Build
 
 ```bash
-pip install .
-# or for development:
-pip install -e . --no-build-isolation
+pip install .   # produces a wheel; NOT for iterative dev
 ```
+
+For iterative development use the `build-venv` recipe above and `cp build-venv/SciQLopPlots/*.so build-venv/SciQLopPlots/*.py` into the target venv — never `pip install -e .` (it disturbs the venv).
 
 ### Meson Options
 

--- a/src/SciQLopPlotAxis.cpp
+++ b/src/SciQLopPlotAxis.cpp
@@ -438,7 +438,13 @@ void SciQLopPlotAxis::rescale() noexcept
             newRange.lower = center - m_axis->range().size() / 2.0;
             newRange.upper = center + m_axis->range().size() / 2.0;
         }
-        m_axis->setRange(newRange);
+        // Route through set_range (not m_axis->setRange directly) so clamp_range
+        // and m_last_valid_range stay consistent: with a max/min range-size limit
+        // configured, a direct setRange makes the rangeChanged handler see
+        // clamped != requested and revert to the old range, so 'm' silently does
+        // nothing. Mirrors the percentile path above.
+        set_range(SciQLopPlotRange(newRange.lower, newRange.upper, _is_time_axis));
+        return;
     }
     m_axis->parentPlot()->replot(QCustomPlot::rpQueuedReplot);
 }

--- a/src/SciQLopPlotAxisDelegate.cpp
+++ b/src/SciQLopPlotAxisDelegate.cpp
@@ -171,8 +171,9 @@ SciQLopPlotAxisDelegate::SciQLopPlotAxisDelegate(SciQLopPlotAxisInterface* objec
 
     m_layout->addRow(labelBox);
 
-    // Range group (numeric, non-color-scale axes only).
-    const bool show_range = !ax->is_time_axis() && (this->color_scale() == nullptr);
+    // Range group (every numeric axis, including the color-scale / colorbar:
+    // its range() / set_range() drive the QCPColorScale data range).
+    const bool show_range = !ax->is_time_axis();
     if (show_range)
     {
         auto* rangeBox = new QGroupBox("Range", this);
@@ -209,13 +210,14 @@ SciQLopPlotAxisDelegate::SciQLopPlotAxisDelegate(SciQLopPlotAxisInterface* objec
         m_layout->addRow(rangeBox);
     }
 
-    // Plot-wide "Auto scale" toggle: surfaced on every vertical value axis
-    // delegate (the natural place users look for axis-rescale controls), not
-    // on the Plot node. Backing state lives on the parent SciQLopPlot — all
-    // value-axis delegates share it.
+    // Plot-wide "Auto scale" toggle: surfaced on every vertical value axis and
+    // on the color-scale (colorbar) node — the natural places users look for
+    // axis-rescale controls, not the Plot node. Backing state lives on the
+    // parent SciQLopPlot and is shared: it gates both value-axis rescale and
+    // the colormap's data-driven z rescale (see SciQLopPlot data_changed wiring).
     if (auto* concrete = as_type<SciQLopPlotAxis>(m_object);
-        concrete && !ax->is_time_axis() && this->color_scale() == nullptr
-        && ax->orientation() == Qt::Vertical)
+        concrete && !ax->is_time_axis()
+        && (this->color_scale() != nullptr || ax->orientation() == Qt::Vertical))
     {
         if (auto* plot = _owning_plot(m_object))
         {

--- a/tests/integration/test_colormap_autoscale_percentile.py
+++ b/tests/integration/test_colormap_autoscale_percentile.py
@@ -11,7 +11,7 @@ import time
 import pytest
 import numpy as np
 from PySide6.QtCore import QCoreApplication
-from PySide6.QtWidgets import QGroupBox
+from PySide6.QtWidgets import QGroupBox, QWidget
 
 from SciQLopPlots import SciQLopPlotRange, DelegateRegistry
 
@@ -200,10 +200,14 @@ class TestInspectorUI:
     delegate (PR #69), where users find them next to gradient/log/label.
     They are NOT exposed on the colormap or histogram product nodes."""
 
-    def _group_titles(self, target, qtbot):
+    def _delegate(self, target, qtbot):
         delegate = DelegateRegistry.instance().create_delegate(target, None)
         assert delegate is not None
         qtbot.addWidget(delegate)
+        return delegate
+
+    def _group_titles(self, target, qtbot):
+        delegate = self._delegate(target, qtbot)  # keep alive across findChildren
         return [g.title() for g in delegate.findChildren(QGroupBox)]
 
     def test_z_axis_delegate_has_percentile_group_with_colormap(
@@ -212,6 +216,24 @@ class TestInspectorUI:
         x, y, z = sample_colormap_data
         plot.colormap(x, y, z)
         assert "Autoscale percentile" in self._group_titles(plot.z_axis(), qtbot)
+
+    def test_z_axis_delegate_exposes_range(self, plot, qtbot, sample_colormap_data):
+        # The colorbar (z) range must be settable from the inspector, like every
+        # other numeric axis. It was silently dropped when the Range group was
+        # first added (commit 3a9d1ad gated it behind color_scale() == nullptr).
+        x, y, z = sample_colormap_data
+        plot.colormap(x, y, z)
+        assert "Range" in self._group_titles(plot.z_axis(), qtbot)
+
+    def test_z_axis_delegate_exposes_auto_scale_toggle(
+        self, plot, qtbot, sample_colormap_data
+    ):
+        # Pairs with the Range group, mirroring value axes: turning auto-scale
+        # off lets a manually-typed colorbar range stick.
+        x, y, z = sample_colormap_data
+        plot.colormap(x, y, z)
+        delegate = self._delegate(plot.z_axis(), qtbot)
+        assert delegate.findChild(QWidget, "plot_auto_scale") is not None
 
     def test_z_axis_delegate_has_percentile_group_with_histogram(self, plot, qtbot):
         plot.add_histogram2d("h", 20, 20)

--- a/tests/integration/test_histogram2d.py
+++ b/tests/integration/test_histogram2d.py
@@ -238,3 +238,88 @@ class TestHistogram2DDispatcher:
         y = rng.normal(0, 1, 100)
         with pytest.raises(TypeError, match="Waterfall"):
             plot.plot(x, y, graph_type=GraphType.Histogram2D, gain=2.0)
+
+
+class TestRescaleRespectsRangeLimit:
+    """The 'm'-key rescale (axis.rescale()) must land on the clamped target when a
+    max/min range-size limit is configured, not revert to the previous range.
+
+    Regression for: the min/max rescale path called QCPAxis::setRange() directly,
+    so the rangeChanged clamp-handler saw clamped != requested and reverted to the
+    old range -- making 'm' silently do nothing on axes with a zoom limit (as
+    SciQLop sets). The percentile path already routed through set_range(); the
+    plain path did not.
+    """
+
+    @staticmethod
+    def _pump(n=80):
+        from PySide6.QtCore import QCoreApplication
+        for _ in range(n):
+            QCoreApplication.processEvents()
+
+    def test_x_rescale_lands_on_clamped_range_not_revert(self, plot):
+        from SciQLopPlots import SciQLopPlotRange
+        hist = plot.add_histogram2d("h", 50, 50)
+        rng = np.random.default_rng(0)
+        hist.set_data(rng.uniform(10.0, 90.0, 5000), rng.uniform(-30.0, 40.0, 5000))
+        self._pump()
+        plot.replot(True)
+        self._pump()
+
+        plot.x_axis().set_max_range_size(50.0)              # SciQLop-style zoom cap
+        plot.x_axis().set_range(SciQLopPlotRange(45.0, 55.0))  # zoom in
+        self._pump()
+
+        plot.x_axis().rescale()                              # the 'm' action
+        self._pump()
+
+        xr = plot.x_axis().range()
+        # Must NOT revert to the [45,55] zoom.
+        assert not (abs(xr.start() - 45.0) < 0.5 and abs(xr.stop() - 55.0) < 0.5), \
+            "x rescale reverted to the pre-rescale zoom instead of landing on the clamped target"
+        # Should land on the clamped target (~width 50, centred on the data ~50).
+        assert (xr.stop() - xr.start()) == pytest.approx(50.0, abs=1.0)
+        assert 24.0 <= xr.start() <= 27.0 and 73.0 <= xr.stop() <= 77.0
+
+    def test_y_value_axis_rescale_lands_on_clamped_range_not_revert(self, plot):
+        # The value-axis branch (getValueRange) is a different code path than the
+        # key-axis branch, but shares the final set_range; verify it too so the
+        # fix is proven for value axes, not just key axes.
+        from SciQLopPlots import SciQLopPlotRange
+        hist = plot.add_histogram2d("h", 50, 50)
+        rng = np.random.default_rng(2)
+        hist.set_data(rng.uniform(10.0, 90.0, 5000), rng.uniform(-30.0, 40.0, 5000))
+        self._pump()
+        plot.replot(True)
+        self._pump()
+
+        # full x first so the value-range restriction sees all points
+        plot.x_axis().rescale()
+        plot.y_axis().set_max_range_size(40.0)               # y extent is 70 > 40
+        plot.y_axis().set_range(SciQLopPlotRange(0.0, 5.0))   # zoom in
+        self._pump()
+
+        plot.y_axis().rescale()
+        self._pump()
+
+        yr = plot.y_axis().range()
+        assert not (abs(yr.start() - 0.0) < 0.5 and abs(yr.stop() - 5.0) < 0.5), \
+            "y rescale reverted to the pre-rescale zoom instead of landing on the clamped target"
+        assert (yr.stop() - yr.start()) == pytest.approx(40.0, abs=1.5)
+
+    def test_rescale_without_limit_still_fits_full_extent(self, plot):
+        from SciQLopPlots import SciQLopPlotRange
+        hist = plot.add_histogram2d("h", 50, 50)
+        rng = np.random.default_rng(1)
+        hist.set_data(rng.uniform(10.0, 90.0, 5000), rng.uniform(-30.0, 40.0, 5000))
+        self._pump()
+        plot.replot(True)
+        self._pump()
+
+        plot.x_axis().set_range(SciQLopPlotRange(45.0, 55.0))
+        self._pump()
+        plot.x_axis().rescale()
+        self._pump()
+
+        xr = plot.x_axis().range()  # no limit -> full data extent
+        assert xr.start() <= 12.0 and xr.stop() >= 88.0


### PR DESCRIPTION
Two independent, evidence-backed fixes to axis range UX, both verified with new regression tests.

## 1. Colorbar (z) Range missing from the inspector
The **Color Scale** node lost its numeric Min/Max when the Range group was first added (`3a9d1ad` gated it behind `color_scale() == nullptr`); only the autoscale-percentile group remained. The backend (`SciQLopPlotColorScaleAxis::set_range/range/range_changed`) was always able to drive the `QCPColorScale` data range.

- Restore the **Range** group on the color-scale node.
- Surface the shared plot-wide **Auto scale** toggle there too (the same flag that gates the colormap's data-driven z rescale), so a manually-typed colorbar range can stick — mirroring the value-axis delegate.

## 2. 'm'-key rescale silently reverted on axes with a range-size limit
`SciQLopPlotAxis::rescale()`'s min/max path called `m_axis->setRange(newRange)` **directly**. When an axis has a `max/min` range-size limit (as SciQLop sets to constrain zoom), the requested range is clamped, the `rangeChanged` handler sees `clamped != requested` and **reverts to the previous range** — so 'm' does nothing. The colorbar has no size limit and its own rescale path, which is why only X/Y were affected and the behaviour looked intermittent (it only reverts when the target exceeds the limit).

Fix: route the min/max path through `set_range()` (sets `m_last_valid_range` before `setRange`, so it lands on the clamped target), mirroring the percentile path already fixed for this trap. The single change covers **X, Y, X2, Y2** — they share the method; Z was already correct.

## Tests
- `test_colormap_autoscale_percentile.py`: Color Scale node exposes Range + Auto scale.
- `test_histogram2d.py::TestRescaleRespectsRangeLimit`: key-axis and value-axis rescale land on the clamped target (not revert) with a limit set; full extent without a limit.
- Full integration suite green (683 passed).

## Also
- `docs`: corrected the CLAUDE.md build recipe (in-tree venv + `build-venv`, Qt on PATH) — the documented bare `meson setup build` doesn't work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)