### PR TITLE
fix(items): Pixels-mode StraightLine/PixmapItem land off-screen (ctor order)

### DIFF
--- a/include/SciQLopPlots/Items/SciQLopPixmapItem.hpp
+++ b/include/SciQLopPlots/Items/SciQLopPixmapItem.hpp
@@ -42,9 +42,10 @@ public:
             : impl::SciQLopPlotItem<QCPItemPixmap> { plot }
     {
         this->setPixmap(pixmap);
-        this->topLeft->setCoords(rect.topLeft());
-        this->bottomRight->setCoords(rect.bottomRight());
-        this->setMovable(movable);
+        // setType before setCoords: setType retains the pixel position computed
+        // under the current type, so coords set first (default plot-coords) then
+        // switched to ptAbsolute would be converted off-screen. Matches
+        // EllipseItem/TextItem ordering.
         if (coordinates == Coordinates::Data)
         {
             this->topLeft->setType(QCPItemPosition::ptPlotCoords);
@@ -55,6 +56,9 @@ public:
             this->topLeft->setType(QCPItemPosition::ptAbsolute);
             this->bottomRight->setType(QCPItemPosition::ptAbsolute);
         }
+        this->topLeft->setCoords(rect.topLeft());
+        this->bottomRight->setCoords(rect.bottomRight());
+        this->setMovable(movable);
     }
 
     virtual ~PixmapItem() { }

--- a/include/SciQLopPlots/Items/SciQLopStraightLines.hpp
+++ b/include/SciQLopPlots/Items/SciQLopStraightLines.hpp
@@ -72,6 +72,20 @@ public:
             , m_orientation { orientation }
             , m_coordinates { coordinates }
     {
+        // setType before setCoords: setType retains the pixel position computed
+        // under the *current* type, so setting coords first (default plot-coords)
+        // then switching to ptAbsolute converts the intended pixels off-screen.
+        // Matches EllipseItem/TextItem ordering.
+        if (coordinates == Coordinates::Data)
+        {
+            this->point1->setType(QCPItemPosition::ptPlotCoords);
+            this->point2->setType(QCPItemPosition::ptPlotCoords);
+        }
+        else
+        {
+            this->point1->setType(QCPItemPosition::ptAbsolute);
+            this->point2->setType(QCPItemPosition::ptAbsolute);
+        }
         if (orientation == Qt::Orientation::Vertical)
         {
             this->point1->setCoords(position, 0);
@@ -83,16 +97,6 @@ public:
             this->point2->setCoords(1, position);
         }
         this->setMovable(movable);
-        if (coordinates == Coordinates::Data)
-        {
-            this->point1->setType(QCPItemPosition::ptPlotCoords);
-            this->point2->setType(QCPItemPosition::ptPlotCoords);
-        }
-        else
-        {
-            this->point1->setType(QCPItemPosition::ptAbsolute);
-            this->point2->setType(QCPItemPosition::ptAbsolute);
-        }
     }
 
     virtual ~StraightLine() { }

--- a/tests/integration/test_item_signals_and_pixel.py
+++ b/tests/integration/test_item_signals_and_pixel.py
@@ -53,6 +53,45 @@ class TestStraightLineSignal:
         assert line.position == pytest.approx(12.0)
 
 
+class TestStraightLinePixelCoordinates:
+    """A Pixels-mode StraightLine must land at the requested pixel position.
+
+    Regression: the ctor set coords before setType(ptAbsolute); setType retains
+    the pixel position computed under the old (default plot-coords)
+    interpretation, so the intended absolute-pixel value was converted off-screen
+    (e.g. 200 -> ~1550 with an x range of [0,100]). Fixed by setting the type
+    before the coords, matching EllipseItem/TextItem.
+    """
+
+    def _vline_pixels(self, plot, px):
+        from SciQLopPlots import SciQLopStraightLine
+        from PySide6.QtCore import Qt
+        return SciQLopStraightLine(plot, px, False, Coordinates.Pixels, Qt.Orientation.Vertical)
+
+    def test_pixel_position_is_not_reinterpreted_as_data(self, plot):
+        plot.resize(800, 600)
+        plot.show()
+        process_events()
+        plot.x_axis().set_range(SciQLopPlotRange(0.0, 100.0))  # data range != pixels
+        process_events()
+        line = self._vline_pixels(plot, 200.0)
+        process_events()
+        assert line.position == pytest.approx(200.0, abs=1.0)
+
+    def test_pixel_line_stays_fixed_on_zoom(self, plot):
+        plot.resize(800, 600)
+        plot.show()
+        process_events()
+        plot.x_axis().set_range(SciQLopPlotRange(0.0, 100.0))
+        process_events()
+        line = self._vline_pixels(plot, 200.0)
+        process_events()
+        before = line.position
+        plot.x_axis().set_range(SciQLopPlotRange(0.0, 1000.0))  # zoom out 10x
+        process_events()
+        assert line.position == pytest.approx(before, abs=1.0)  # pixel anchor unmoved
+
+
 class TestStraightLineMinMax:
 
     def test_min_clamps_set_position(self, plot):


### PR DESCRIPTION
`StraightLine` and `PixmapItem` constructors set position **coords before** switching the position **type** to `ptAbsolute`. `QCPItemPosition::setType` retains the *pixel* position computed under the current type — so coords stored as the default `ptPlotCoords` and then switched to `ptAbsolute` get run through the plot-coord→pixel mapping and land off-screen.

Reproduced: a Pixels-mode vertical line requested at **200 px** (x range `[0,100]`, 800 px wide) ended up at **~1550 px**.

## Fix
Set the position type **before** the coords, matching the already-correct `EllipseItem`/`TextItem` constructors.

## Tests
`test_item_signals_and_pixel.py::TestStraightLinePixelCoordinates` — a Pixels-mode line lands at the requested pixel and stays fixed when the axis zooms. (`PixmapItem` shares the fix but exposes no Python position getter, so it isn't separately asserted.)

Full integration suite: **686 passed**.

Backlog: `backlog_pixmap_item_pixel_ctor_order` (also caught the identical bug in `StraightLine`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)