### PR TITLE
fix(ndprojection): float32 time/scalar data crashed the app (double-only copy)

### DIFF
--- a/src/SciQLopNDProjectionCurves.cpp
+++ b/src/SciQLopNDProjectionCurves.cpp
@@ -20,6 +20,29 @@
 -- Mail : alexis.jeandet@member.fsf.org
 ----------------------------------------------------------------------------*/
 #include "SciQLopPlots/Plotables/SciQLopNDProjectionCurves.hpp"
+#include "SciQLopPlots/Python/DtypeDispatch.hpp"
+
+#include <algorithm>
+
+namespace
+{
+// Copy any numeric PyBuffer to QVector<double>, converting per its dtype.
+// SciQLopPyBuffer::data() is double-only and throws (→ std::terminate) on
+// float32/int buffers, which Speasy routinely produces.
+QVector<double> to_double_vector(const SciQLopPyBuffer& buffer)
+{
+    QVector<double> out(static_cast<int>(buffer.flat_size()));
+    dispatch_dtype(buffer.format_code(),
+                   [&](auto tag)
+                   {
+                       using V = typename decltype(tag)::type;
+                       const auto* src = static_cast<const V*>(buffer.raw_data());
+                       std::transform(src, src + buffer.flat_size(), out.data(),
+                                      [](V v) { return static_cast<double>(v); });
+                   });
+    return out;
+}
+} // namespace
 
 SciQLopNDProjectionCurves::SciQLopNDProjectionCurves(SciQLopPlotInterface* parent,
                                                      QList<SciQLopPlot*>& plots,
@@ -90,8 +113,7 @@ void SciQLopNDProjectionCurves::set_data(const QList<SciQLopPyBuffer>& data)
                                   data_without_time[(i + 1) % curves_count]);
         }
         const auto& time_buf = data[0];
-        QVector<double> times(time_buf.flat_size());
-        std::copy(time_buf.data(), time_buf.data() + time_buf.flat_size(), times.data());
+        QVector<double> times = to_double_vector(time_buf);
         for (auto* curve : std::as_const(m_curves))
             curve->set_time_values(times);
     }
@@ -101,8 +123,7 @@ void SciQLopNDProjectionCurves::set_data(const QList<SciQLopPyBuffer>& data)
         {
             m_curves[i]->set_data(data[3 * i], data[3 * i + 1]);
             const auto& scalar_buf = data[3 * i + 2];
-            QVector<double> scalars(scalar_buf.flat_size());
-            std::copy(scalar_buf.data(), scalar_buf.data() + scalar_buf.flat_size(), scalars.data());
+            QVector<double> scalars = to_double_vector(scalar_buf);
             m_curves[i]->set_color_values(scalars);
         }
     }

--- a/tests/integration/test_projection_improvements.py
+++ b/tests/integration/test_projection_improvements.py
@@ -241,3 +241,24 @@ class TestLinkedCrosshairs:
         proj.parametric_curve([t, x, y, z], labels=["a", "b", "c"])
         proj.set_linked_crosshairs(True)
         process_events()
+
+
+class TestProjectionFloat32Data:
+    """NDProjectionCurves::set_data copied time/scalar buffers via the double-only
+    SciQLopPyBuffer::data(), which throws -> std::terminate on float32 (or int)
+    buffers. Speasy routinely returns float32, so this crashed the app. Fixed by
+    dtype-dispatched copies. These pass only when the crash is gone."""
+
+    @pytest.mark.parametrize("time_dtype", [np.float32, np.int64, np.uint32])
+    def test_non_double_time_does_not_crash(self, qtbot, time_dtype):
+        proj = SciQLopNDProjectionPlot(3)
+        qtbot.addWidget(proj)
+        n = 50
+        t = np.linspace(0, 49, n).astype(time_dtype)   # non-double time -> N+1 path
+        # x/y kept float64: the curve resampler is separately double-only.
+        x = np.cos(np.linspace(0, 10, n)).astype(np.float64)
+        y = np.sin(np.linspace(0, 10, n)).astype(np.float64)
+        z = (np.arange(n) * 0.1).astype(np.float64)
+        graph = proj.parametric_curve([t, x, y, z], labels=["a", "b", "c"])
+        process_events()
+        assert graph is not None


### PR DESCRIPTION
`SciQLopNDProjectionCurves::set_data` copied the time buffer (N+1 layout) and the per-curve scalar/colour buffer (3×N layout) using `SciQLopPyBuffer::data()`, which is **double-only** and throws `"called on non-double buffer"`. Thrown from this non-Python-entry path, the exception escaped to **`std::terminate`** — so a **float32** (or integer) time array, which Speasy routinely produces, **hard-crashed the application** instead of raising.

Reproduced: `proj.parametric_curve([t_float32, x, y, z], ...)` → `terminate called after throwing 'std::runtime_error'`.

## Fix
Copy both buffers via a dtype-dispatched `to_double_vector()` helper (`dispatch_dtype` + `static_cast<double>`), matching the `SciQLopCurve` pattern.

## Tests
`test_projection_improvements.py::TestProjectionFloat32Data::test_non_double_time_does_not_crash`, parametrized over `float32 / int64 / uint32` time. Full integration suite: **689 passed**.

> Out of scope: feeding **float32 x/y** still hits the separate double-only `CurveResampler` limitation (the underlying SciQLopCurve path). The test keeps x/y float64 and varies only the time dtype. Tracked separately (`backlog_ndprojection_scalar_dtype` / the curve-resampler dtype gap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)