### PR TITLE
fix(curve): float32 x/y crashed the app (double-only resampler)

### DIFF
--- a/include/SciQLopPlots/Plotables/Resamplers/AbstractResampler.hpp
+++ b/include/SciQLopPlots/Plotables/Resamplers/AbstractResampler.hpp
@@ -27,6 +27,7 @@
 #include <SciQLopPlots/Profiling.hpp>
 #include <SciQLopPlots/Plotables/SciQLopGraphInterface.hpp>
 #include <SciQLopPlots/Python/PythonInterface.hpp>
+#include <SciQLopPlots/Python/DtypeDispatch.hpp>
 #include <SciQLopPlots/Python/Views.hpp>
 #include <SciQLopPlots/SciQLopPlotAxis.hpp>
 #include <qcustomplot.h>
@@ -125,7 +126,22 @@ protected:
         const auto len = b.flat_size();
         if (len > 0)
         {
-            return { b.data()[0], b.data()[len - 1] };
+            // x may be any numeric dtype (the curve path allows non-double keys);
+            // read first/last (the buffer is sorted) converted to double.
+            try
+            {
+                return dispatch_dtype(b.format_code(),
+                                      [&](auto tag) -> QCPRange
+                                      {
+                                          using T = typename decltype(tag)::type;
+                                          const auto* p = static_cast<const T*>(b.raw_data());
+                                          return { static_cast<double>(p[0]),
+                                                   static_cast<double>(p[len - 1]) };
+                                      });
+            }
+            catch (const std::invalid_argument&)
+            {
+            }
         }
         return { std::nan(""), std::nan("") };
     }

--- a/src/SciQLopCurve.cpp
+++ b/src/SciQLopCurve.cpp
@@ -97,14 +97,25 @@ SciQLopCurve::~SciQLopCurve()
 
 void SciQLopCurve::set_data(SciQLopPyBuffer x, SciQLopPyBuffer y)
 {
-    // CurveResampler reads y via SciQLopPyBuffer::data() which only returns a valid
-    // double* for float64 buffers (see PythonInterface.hpp). Other dtypes
-    // would misrender silently — fail loudly instead, matching what
-    // SciQLopSingleLineGraph / SciQLopMultiGraphBase do for x.
-    if (x.is_valid() && x.format_code() != 'd')
-        throw std::runtime_error("Curve.set_data: x must be float64");
-    if (y.is_valid() && y.format_code() != 'd')
-        throw std::runtime_error("Curve.set_data: y must be float64");
+    // The resampler converts x/y from any numeric dtype to double. Reject
+    // unsupported dtypes here (at the Python boundary) so the worker thread only
+    // ever sees dtypes dispatch_dtype can handle.
+    const auto require_numeric = [](const SciQLopPyBuffer& buf, const char* name)
+    {
+        if (!buf.is_valid())
+            return;
+        try
+        {
+            dispatch_dtype(buf.format_code(), [](auto) {});
+        }
+        catch (const std::invalid_argument&)
+        {
+            throw std::runtime_error(std::string("Curve.set_data: ") + name
+                                     + " has an unsupported (non-numeric) dtype");
+        }
+    };
+    require_numeric(x, "x");
+    require_numeric(y, "y");
     set_busy(true);
     this->_resampler->setData(x, y);
     Q_EMIT data_changed(x, y);
@@ -127,25 +138,25 @@ void SciQLopCurve::collect_visible_values(const SciQLopPlotRange& visible_key_ra
     const auto& y = buffers[1];
     if (!x.is_valid() || !y.is_valid())
         return;
-    if (x.format_code() != 'd')
-        return;
     const std::size_t n = x.flat_size();
     if (n == 0 || y.flat_size() < n)
         return;
 
     const double x_lo = visible_key_range.first;
     const double x_hi = visible_key_range.second;
-    const double* xs = x.data();
 
     out.reserve(out.size() + n);
     try
     {
-        dispatch_dtype(y.format_code(), [&](auto tag) {
-            using V = typename decltype(tag)::type;
+        dispatch_dtype(x.format_code(), [&](auto x_tag) {
+        dispatch_dtype(y.format_code(), [&](auto y_tag) {
+            using XT = typename decltype(x_tag)::type;
+            using V = typename decltype(y_tag)::type;
+            const auto* xs = static_cast<const XT*>(x.raw_data());
             const auto* ys = static_cast<const V*>(y.raw_data());
             for (std::size_t i = 0; i < n; ++i)
             {
-                const double xv = xs[i];
+                const double xv = static_cast<double>(xs[i]);
                 if (xv < x_lo || xv > x_hi)
                     continue;
                 const double v = static_cast<double>(ys[i]);
@@ -156,6 +167,7 @@ void SciQLopCurve::collect_visible_values(const SciQLopPlotRange& visible_key_ra
                 }
                 out.push_back(v);
             }
+        });
         });
     }
     catch (const std::invalid_argument&) { /* unsupported dtype — skip */ }

--- a/src/SciQLopCurveResampler.cpp
+++ b/src/SciQLopCurveResampler.cpp
@@ -20,15 +20,17 @@
 -- Mail : alexis.jeandet@member.fsf.org
 ----------------------------------------------------------------------------*/
 #include "SciQLopPlots/Plotables/Resamplers/SciQLopCurveResampler.hpp"
+#include "SciQLopPlots/Python/DtypeDispatch.hpp"
 
-QVector<QCPCurveData> curve_copy_data(const double* x, const double* y, std::size_t x_size,
-                                      const int y_incr)
+template <typename X, typename Y>
+QVector<QCPCurveData> curve_copy_data(const X* x, const Y* y, std::size_t x_size, const int y_incr)
 {
     QVector<QCPCurveData> data(x_size);
-    const double* current_y_it = y;
+    const Y* current_y_it = y;
     for (auto i = 0UL; i < x_size; i++)
     {
-        data[i] = QCPCurveData { static_cast<double>(i), x[i], *current_y_it };
+        data[i] = QCPCurveData { static_cast<double>(i), static_cast<double>(x[i]),
+                                 static_cast<double>(*current_y_it) };
         current_y_it += y_incr;
     }
     return data;
@@ -39,12 +41,34 @@ void CurveResampler::_resample_impl(const ResamplerData1d& data, const Resampler
     if (data.x.is_valid() && data.x.flat_size() > 0 && data.new_data)
     {
         const auto y_incr = 1UL;
+        const auto count = data.x.flat_size();
         QList<QVector<QCPCurveData>> curve_data;
-        for (auto line_index = 0UL; line_index < line_count(); line_index++)
+        // x/y may be any numeric dtype (set_data validates support); dispatch on
+        // both and convert to double. Guarded so an unexpected dtype can't
+        // terminate this worker thread.
+        try
         {
-            const auto count = data.x.flat_size();
-            const auto start_y = data.y.data() + (line_index * data.x.flat_size());
-            curve_data.emplace_back(curve_copy_data(data.x.data(), start_y, count, y_incr));
+            dispatch_dtype(
+                data.x.format_code(),
+                [&](auto x_tag)
+                {
+                    dispatch_dtype(
+                        data.y.format_code(),
+                        [&](auto y_tag)
+                        {
+                            using X = typename decltype(x_tag)::type;
+                            using Y = typename decltype(y_tag)::type;
+                            const auto* xs = static_cast<const X*>(data.x.raw_data());
+                            const auto* ys = static_cast<const Y*>(data.y.raw_data());
+                            for (auto line_index = 0UL; line_index < line_count(); line_index++)
+                                curve_data.emplace_back(
+                                    curve_copy_data(xs, ys + (line_index * count), count, y_incr));
+                        });
+                });
+        }
+        catch (const std::invalid_argument&)
+        {
+            return;
         }
         Q_EMIT setGraphData(curve_data);
     }

--- a/tests/integration/test_graph_api.py
+++ b/tests/integration/test_graph_api.py
@@ -169,3 +169,40 @@ class TestPlotMethod:
         plot_obj, graph_obj = result
         assert plot_obj is not None
         assert graph_obj is not None
+
+
+class TestParametricCurveDtypes:
+    """SciQLopCurve must accept non-float64 x/y. The CurveResampler read x/y via
+    the double-only SciQLopPyBuffer::data(), and set_data hard-rejected anything
+    but float64 — a std::terminate crash on float32 (which Speasy routinely
+    produces). These pass only once the dtype-dispatched resampler is in place."""
+
+    @pytest.mark.parametrize("dtype", [np.float32, np.float64, np.int32,
+                                       np.int64, np.uint16])
+    def test_parametric_curve_accepts_dtype(self, plot, qtbot, dtype):
+        n = 200
+        t = np.linspace(0, 2 * np.pi, n)
+        x = (np.cos(t) * 100).astype(dtype)
+        y = (np.sin(t) * 100).astype(dtype)
+        g = plot.parametric_curve(x, y, labels=["c"])
+        plot.replot(True)
+        qtbot.waitUntil(lambda: len(g.data()) >= 2 and g.data()[0].size > 0
+                                and not g.busy(),
+                        timeout=5000)
+        assert len(g.data()) >= 2
+
+    def test_float32_curve_values_are_correct(self, plot, qtbot):
+        # not just "doesn't crash" — the resampled values must match the input.
+        n = 100
+        x = np.linspace(-50, 50, n).astype(np.float32)
+        y = (x * 2.0).astype(np.float32)
+        g = plot.parametric_curve(x, y, labels=["c"])
+        plot.replot(True)
+        qtbot.waitUntil(lambda: len(g.data()) >= 2 and g.data()[0].size > 0
+                                and not g.busy(),
+                        timeout=5000)
+        gx = np.array(g.data()[0])
+        gy = np.array(g.data()[1])
+        assert gx.min() == pytest.approx(-50.0, abs=1.0)
+        assert gx.max() == pytest.approx(50.0, abs=1.0)
+        assert gy.max() == pytest.approx(100.0, abs=2.0)


### PR DESCRIPTION
`SciQLopCurve` hard-rejected any x/y dtype but float64, and the `CurveResampler` read x/y through the double-only `SciQLopPyBuffer::data()` — so **float32** x/y (which Speasy routinely produces) **hard-crashed via `std::terminate`** rather than raising. Surfaced while fixing the NDProjection float32 crash (#79); this is the underlying curve-path version, affecting all `SciQLopCurve`/`parametric_curve` usage.

Reproduced: `plot.parametric_curve(x_f32, y_f32, labels=["c"])` → `terminate called ... SciQLopPyBuffer::data() called on non-double buffer`.

## Fix — make the curve path dtype-aware
- `CurveResampler::curve_copy_data` templated on x/y type, converting to double; the call site dispatches on both dtypes (guarded so the worker thread can't `terminate` on an unexpected dtype).
- `AbstractResampler::_bounds` (shared key-range computation) dispatches instead of assuming `double[]`.
- `SciQLopCurve::collect_visible_values` dispatches on x as well as y.
- `set_data` now validates only that x/y are **numeric** (a `dispatch_dtype`-supported dtype), rejecting genuinely non-numeric buffers at the Python boundary so the worker never sees them.

Line graphs still pin x to float64 in their own `set_data`, so the shared `_bounds` change is backward-compatible there.

## Tests
`test_graph_api.py::TestParametricCurveDtypes` — `parametric_curve` over float32/float64/int32/int64/uint16, plus a float32 value-correctness check (resampled values match input). Full integration suite: **693 passed**.

> Together with #79 this closes the float32 gap for projection curves end-to-end (projection x/y are curves under the hood).

🤖 Generated with [Claude Code](https://claude.com/claude-code)