### PR TITLE
feat: hide/show curves, components & colormaps (inspector + legend double-click)

### DIFF
--- a/docs/superpowers/plans/2026-06-08-hide-curve-visibility.md
+++ b/docs/superpowers/plans/2026-06-08-hide-curve-visibility.md
@@ -1,0 +1,728 @@
+# Hide / show curves & graph components — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Restore the ability to hide/show any curve, graph component, or color map from the inspector (a "Visible" checkbox) and from the legend (double-click a legend entry, component-by-component for multi-component graphs), kept in sync via the existing `visible_changed` signal.
+
+**Architecture:** The visibility *plumbing* (`set_visible`/`visible`/`visible_changed`) already exists on `SciQLopGraphComponent` and `SciQLopColorMapBase`. We only add UI affordances that drive it: (1) a `BooleanDelegate` checkbox in the two property delegates, and (2) move the legend double-click handling out of `SciQLopPlot` (which pokes QCP directly and never synced) down into the component / colormap, where each object owns its own legend entry — matching the existing `selectionChanged`/`componentClicked` pattern. Legend dimming is driven off `visible_changed`, so it stays correct no matter which entry point flips visibility.
+
+**Tech Stack:** C++20, Qt6, QCustomPlot/NeoQCP, Meson `build-venv`, pytest integration tests.
+
+---
+
+## Build & Test reference (used by every task)
+
+**Build** (Qt must be on PATH per CLAUDE.md):
+
+```bash
+export PROJ=/var/home/jeandet/Documents/prog/SciQLopPlots
+export VENV=$PROJ/.venv
+export PATH="$VENV/bin:/home/jeandet/Qt/6.11.1/gcc_64/bin:/home/jeandet/Qt/6.11.0/gcc_64/bin:$PATH"
+export PKG_CONFIG_PATH="/home/jeandet/Qt/6.11.1/gcc_64/lib/pkgconfig:$PKG_CONFIG_PATH"
+$VENV/bin/meson compile -C $PROJ/build-venv
+```
+
+**Run the new tests** (from /tmp so the source pkg doesn't shadow the build):
+
+```bash
+cd /tmp && PYTHONPATH=$PROJ/build-venv $VENV/bin/python -m pytest \
+  $PROJ/tests/integration/test_visibility.py -q
+```
+
+> These delegate/component changes are C++-only and add no new Python-exposed API
+> (`set_visible`/`visible`/`visible_changed` are already bound). No `bindings.xml`
+> change is needed. If a stale shiboken wrapper misbehaves after the build, run
+> `$VENV/bin/meson setup --reconfigure $PROJ/build-venv` and rebuild.
+
+## File structure
+
+- `tests/integration/test_visibility.py` — **new** — all tests for this feature.
+- `src/SciQLopGraphComponentDelegate.cpp` — add Visible checkbox + reverse wiring.
+- `src/SciQLopColorMapBaseDelegate.cpp` — add Visible checkbox + reverse wiring.
+- `include/SciQLopPlots/Plotables/SciQLopGraphComponent.hpp` — declare legend slot + dim helper + connect helper.
+- `src/SciQLopGraphComponent.cpp` — implement them; call connect helper from both ctors.
+- `include/SciQLopPlots/Plotables/SciQLopColorMapBase.hpp` — declare legend slot + dim helper.
+- `src/SciQLopColorMapBase.cpp` — implement them; connect in ctor.
+- `include/SciQLopPlots/SciQLopPlot.hpp` — remove `_legend_double_clicked` declaration.
+- `src/SciQLopPlot.cpp` — remove handler + its `connect`.
+
+---
+
+## Task 1: Visible checkbox on the graph-component inspector delegate
+
+**Files:**
+- Test: `tests/integration/test_visibility.py` (create)
+- Modify: `src/SciQLopGraphComponentDelegate.cpp`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/integration/test_visibility.py`:
+
+```python
+"""Hide/show visibility from the inspector delegates and component API."""
+import numpy as np
+import pytest
+from PySide6.QtWidgets import QCheckBox
+
+from SciQLopPlots import DelegateRegistry
+from conftest import process_events
+
+
+def _make_delegate(target, qtbot):
+    d = DelegateRegistry.instance().create_delegate(target, None)
+    assert d is not None
+    qtbot.addWidget(d)
+    return d
+
+
+def _visible_checkbox(delegate):
+    boxes = [c for c in delegate.findChildren(QCheckBox) if c.text() == "Visible"]
+    assert len(boxes) == 1, f"expected one 'Visible' checkbox, got {len(boxes)}"
+    return boxes[0]
+
+
+class TestComponentDelegateVisible:
+    def test_checkbox_reflects_initial_state(self, plot, sample_data, qtbot):
+        x, y = sample_data
+        g = plot.line(x, y, labels=["a"])
+        process_events()
+        comp = g.components()[0]
+        d = _make_delegate(comp, qtbot)
+        assert _visible_checkbox(d).isChecked() is True
+
+    def test_checkbox_toggles_component(self, plot, sample_data, qtbot):
+        x, y = sample_data
+        g = plot.line(x, y, labels=["a"])
+        process_events()
+        comp = g.components()[0]
+        d = _make_delegate(comp, qtbot)
+        box = _visible_checkbox(d)
+        box.setChecked(False)
+        process_events()
+        assert comp.visible() is False
+        box.setChecked(True)
+        process_events()
+        assert comp.visible() is True
+
+    def test_external_change_updates_checkbox(self, plot, sample_data, qtbot):
+        x, y = sample_data
+        g = plot.line(x, y, labels=["a"])
+        process_events()
+        comp = g.components()[0]
+        d = _make_delegate(comp, qtbot)
+        box = _visible_checkbox(d)
+        comp.set_visible(False)
+        process_events()
+        assert box.isChecked() is False
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run:
+```bash
+cd /tmp && PYTHONPATH=$PROJ/build-venv $VENV/bin/python -m pytest \
+  $PROJ/tests/integration/test_visibility.py::TestComponentDelegateVisible -q
+```
+Expected: FAIL — `_visible_checkbox` raises `AssertionError: expected one 'Visible' checkbox, got 0` (the delegate has no checkbox yet).
+
+- [ ] **Step 3: Add the Visible checkbox to the component delegate**
+
+In `src/SciQLopGraphComponentDelegate.cpp`, add the include near the other delegate includes (after line 26):
+
+```cpp
+#include "SciQLopPlots/Inspector/PropertiesDelegates/Delegates/BooleanDelegate.hpp"
+```
+
+Then, at the **start** of the constructor body (immediately after the opening brace on the line after `: PropertyDelegateBase(object, parent)`), insert:
+
+```cpp
+    auto* visibleCheck = new BooleanDelegate("Visible", object->visible(), this);
+    m_layout->addRow(visibleCheck);
+    connect(visibleCheck, &BooleanDelegate::value_changed, object,
+            &SciQLopGraphComponentInterface::set_visible);
+    connect(object, &SciQLopGraphComponentInterface::visible_changed, visibleCheck,
+            [visibleCheck](bool v)
+            {
+                QSignalBlocker blocker(visibleCheck);
+                visibleCheck->set_value(v);
+            });
+```
+
+(`QSignalBlocker` is already included in this file.)
+
+- [ ] **Step 4: Build**
+
+Run: `$VENV/bin/meson compile -C $PROJ/build-venv`
+Expected: builds with no errors.
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run:
+```bash
+cd /tmp && PYTHONPATH=$PROJ/build-venv $VENV/bin/python -m pytest \
+  $PROJ/tests/integration/test_visibility.py::TestComponentDelegateVisible -q
+```
+Expected: 3 passed.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd $PROJ
+git add tests/integration/test_visibility.py src/SciQLopGraphComponentDelegate.cpp
+git commit -m "feat(inspector): Visible checkbox on graph-component delegate
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Visible checkbox on the color-map inspector delegate
+
+**Files:**
+- Test: `tests/integration/test_visibility.py` (append)
+- Modify: `src/SciQLopColorMapBaseDelegate.cpp`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/integration/test_visibility.py`:
+
+```python
+class TestColorMapDelegateVisible:
+    def test_checkbox_toggles_colormap(self, plot, sample_colormap_data, qtbot):
+        x, y, z = sample_colormap_data
+        cmap = plot.colormap(x, y, z)
+        process_events()
+        d = _make_delegate(cmap, qtbot)
+        box = _visible_checkbox(d)
+        assert box.isChecked() is True
+        box.setChecked(False)
+        process_events()
+        assert cmap.visible() is False
+
+    def test_external_change_updates_checkbox(self, plot, sample_colormap_data, qtbot):
+        x, y, z = sample_colormap_data
+        cmap = plot.colormap(x, y, z)
+        process_events()
+        d = _make_delegate(cmap, qtbot)
+        box = _visible_checkbox(d)
+        cmap.set_visible(False)
+        process_events()
+        assert box.isChecked() is False
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run:
+```bash
+cd /tmp && PYTHONPATH=$PROJ/build-venv $VENV/bin/python -m pytest \
+  $PROJ/tests/integration/test_visibility.py::TestColorMapDelegateVisible -q
+```
+Expected: FAIL — `AssertionError: expected one 'Visible' checkbox, got 0`.
+
+- [ ] **Step 3: Add the Visible checkbox to the colormap base delegate**
+
+In `src/SciQLopColorMapBaseDelegate.cpp`, add includes after line 23 (`#include ".../SciQLopColorMapBase.hpp"`):
+
+```cpp
+#include "SciQLopPlots/Inspector/PropertiesDelegates/Delegates/BooleanDelegate.hpp"
+#include "SciQLopPlots/Plotables/SciQLopGraphInterface.hpp"
+
+#include <QSignalBlocker>
+```
+
+Replace the constructor body — delete the `Q_UNUSED(object);` line and the explanatory comment block, and insert:
+
+```cpp
+        : PropertyDelegateBase(object, parent)
+{
+    auto* visibleCheck = new BooleanDelegate("Visible", object->visible(), this);
+    m_layout->addRow(visibleCheck);
+    connect(visibleCheck, &BooleanDelegate::value_changed, object,
+            &SciQLopPlottableInterface::set_visible);
+    connect(object, &SciQLopPlottableInterface::visible_changed, visibleCheck,
+            [visibleCheck](bool v)
+            {
+                QSignalBlocker blocker(visibleCheck);
+                visibleCheck->set_value(v);
+            });
+    // Color-scale controls (gradient, autoscale percentile) live on the
+    // "Color Scale" (z) axis node. Product-specific knobs are added by derived
+    // delegates (Contours, Binning/normalization).
+}
+```
+
+(`SciQLopPlottableInterface` is the shared base of `SciQLopColorMapInterface`; it declares `set_visible`/`visible`/`visible_changed`. It is reached via the `SciQLopGraphInterface.hpp` include.)
+
+- [ ] **Step 4: Build**
+
+Run: `$VENV/bin/meson compile -C $PROJ/build-venv`
+Expected: builds with no errors.
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run:
+```bash
+cd /tmp && PYTHONPATH=$PROJ/build-venv $VENV/bin/python -m pytest \
+  $PROJ/tests/integration/test_visibility.py::TestColorMapDelegateVisible -q
+```
+Expected: 2 passed.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd $PROJ
+git add tests/integration/test_visibility.py src/SciQLopColorMapBaseDelegate.cpp
+git commit -m "feat(inspector): Visible checkbox on color-map delegate
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Safety-net tests for the visibility contract (pre-refactor guard)
+
+These lock the `set_visible`/`visible`/`visible_changed` behavior that both the
+inspector checkbox and the upcoming legend refactor depend on. They pass now and
+must keep passing after Task 4/5 (they guard against API regressions while the
+legend handler moves).
+
+**Files:**
+- Test: `tests/integration/test_visibility.py` (append)
+
+- [ ] **Step 1: Write the tests**
+
+Append to `tests/integration/test_visibility.py`:
+
+```python
+class TestVisibilityContract:
+    def test_component_round_trip(self, plot, sample_data):
+        x, y = sample_data
+        g = plot.line(x, y, labels=["a"])
+        process_events()
+        comp = g.components()[0]
+        assert comp.visible() is True
+        comp.set_visible(False)
+        assert comp.visible() is False
+        comp.set_visible(True)
+        assert comp.visible() is True
+
+    def test_component_emits_signal(self, plot, sample_data):
+        x, y = sample_data
+        g = plot.line(x, y, labels=["a"])
+        process_events()
+        comp = g.components()[0]
+        seen = []
+        comp.visible_changed.connect(lambda v: seen.append(v))
+        comp.set_visible(False)
+        assert seen == [False]
+
+    def test_multicomponent_independent(self, plot, sample_multicomponent_data):
+        x, y = sample_multicomponent_data
+        g = plot.line(x, y, labels=["a", "b", "c"])
+        process_events()
+        comps = g.components()
+        assert len(comps) == 3
+        comps[1].set_visible(False)
+        assert comps[0].visible() is True
+        assert comps[1].visible() is False
+        assert comps[2].visible() is True
+
+    def test_colormap_round_trip(self, plot, sample_colormap_data):
+        x, y, z = sample_colormap_data
+        cmap = plot.colormap(x, y, z)
+        process_events()
+        assert cmap.visible() is True
+        cmap.set_visible(False)
+        assert cmap.visible() is False
+        cmap.set_visible(True)
+        assert cmap.visible() is True
+```
+
+- [ ] **Step 2: Run to verify they pass (contract holds today)**
+
+Run:
+```bash
+cd /tmp && PYTHONPATH=$PROJ/build-venv $VENV/bin/python -m pytest \
+  $PROJ/tests/integration/test_visibility.py::TestVisibilityContract -q
+```
+Expected: 4 passed. (If `test_multicomponent_independent` fails, stop — the
+per-component model is broken and must be fixed before the legend refactor.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd $PROJ
+git add tests/integration/test_visibility.py
+git commit -m "test(visibility): lock component/colormap visibility contract
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: Move legend double-click into SciQLopGraphComponent
+
+Each component connects to the parent plot's `legendDoubleClick` and toggles its
+own visibility; legend dimming is driven off `visible_changed`. The old
+`SciQLopPlot` handler is removed in Task 6.
+
+**Files:**
+- Modify: `include/SciQLopPlots/Plotables/SciQLopGraphComponent.hpp`
+- Modify: `src/SciQLopGraphComponent.cpp`
+
+- [ ] **Step 1: Declare the slot, dim helper, and connect helper in the header**
+
+In `include/SciQLopPlots/Plotables/SciQLopGraphComponent.hpp`, find the private
+section near `bool m_selected = false;` (around line 99) and add **above** it:
+
+```cpp
+    void _connect_legend_visibility();
+    void _apply_legend_visibility_style(bool visible);
+```
+
+These are private members (the class already has `Q_OBJECT`). Then add a forward
+declaration for `QMouseEvent` near the top of the file, just after the include
+block (before `class SciQLopGraphComponent`):
+
+```cpp
+class QMouseEvent;
+```
+
+Add the private slot. Find the `private Q_SLOTS:` section if present; if there is
+none, add one just before the existing `bool m_selected = false;` line:
+
+```cpp
+private Q_SLOTS:
+    void _on_legend_double_clicked(QCPLegend* legend, QCPAbstractLegendItem* item,
+                                   QMouseEvent* event);
+
+private:
+```
+
+(The trailing `private:` keeps `m_selected` private as before.)
+
+- [ ] **Step 2: Implement in the .cpp and wire both constructors**
+
+In `src/SciQLopGraphComponent.cpp`, add includes after the existing include
+(line 22):
+
+```cpp
+#include <QCustomPlot.h>
+#include <QMouseEvent>
+#include <layoutelements/layoutelement-legend.h>
+#include <layoutelements/layoutelement-legend-group.h>
+```
+
+> If any of those headers is already transitively included via
+> `SciQLopGraphComponent.hpp`, the duplicate `#include` is harmless (header guards).
+
+Add the three new methods at the end of the file (after `QColor SciQLopGraphComponent::color()`):
+
+```cpp
+void SciQLopGraphComponent::_connect_legend_visibility()
+{
+    if (auto* plot = _plot())
+        connect(plot, &QCustomPlot::legendDoubleClick, this,
+                &SciQLopGraphComponent::_on_legend_double_clicked);
+    connect(this, &SciQLopGraphComponentInterface::visible_changed, this,
+            &SciQLopGraphComponent::_apply_legend_visibility_style);
+}
+
+void SciQLopGraphComponent::_on_legend_double_clicked(QCPLegend* legend,
+                                                      QCPAbstractLegendItem* item,
+                                                      QMouseEvent* event)
+{
+    Q_UNUSED(legend);
+    Q_UNUSED(event);
+    bool mine = false;
+    if (m_componentIndex >= 0)
+    {
+        if (auto* gi = dynamic_cast<QCPGroupLegendItem*>(item);
+            gi != nullptr && gi->multiGraph() == qobject_cast<QCPMultiGraph*>(m_plottable.data())
+            && gi->selectedComponent() == m_componentIndex)
+            mine = true;
+    }
+    else if (auto* li = dynamic_cast<QCPPlottableLegendItem*>(item);
+             li != nullptr && li == _legend_item())
+    {
+        mine = true;
+    }
+    if (mine)
+        set_visible(!visible());
+}
+
+void SciQLopGraphComponent::_apply_legend_visibility_style(bool visible)
+{
+    // Only single-plottable components have a per-entry legend item to dim;
+    // multi-component group items have no per-row text colour (matches prior
+    // behaviour — the curve simply disappears).
+    if (auto* li = _legend_item(); li != nullptr)
+    {
+        const QColor c = visible ? Qt::black : Qt::gray;
+        li->setTextColor(c);
+        li->setSelectedTextColor(c);
+    }
+}
+```
+
+Then call `_connect_legend_visibility();` at the **end** of *both* constructors:
+
+In the `SciQLopGraphComponent(QCPAbstractPlottable* plottable, ...)` ctor, add it
+just before the closing brace (after the `connect(plottable, ...selectionChanged...)`
+block, inside the `if (m_plottable)` guard is fine but place it after the guard so
+it always runs):
+
+```cpp
+    }
+    _connect_legend_visibility();
+}
+```
+
+In the `SciQLopGraphComponent(QCPMultiGraph* multiGraph, int componentIndex, ...)`
+ctor, add it just before the closing brace (after the
+`if (auto* gi = _group_legend_item(); gi) { ... }` block):
+
+```cpp
+    _connect_legend_visibility();
+}
+```
+
+- [ ] **Step 3: Build**
+
+Run: `$VENV/bin/meson compile -C $PROJ/build-venv`
+Expected: builds with no errors.
+
+- [ ] **Step 4: Run the safety-net + delegate tests (no API regression)**
+
+Run:
+```bash
+cd /tmp && PYTHONPATH=$PROJ/build-venv $VENV/bin/python -m pytest \
+  $PROJ/tests/integration/test_visibility.py -q
+```
+Expected: all passed (9 from Tasks 1-3). The double-click path is wired but not
+yet exercised by an automated test — that is verified manually in Task 7.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd $PROJ
+git add include/SciQLopPlots/Plotables/SciQLopGraphComponent.hpp src/SciQLopGraphComponent.cpp
+git commit -m "feat(legend): component owns its legend double-click hide/show
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: Same legend wiring for SciQLopColorMapBase
+
+So color maps keep legend-double-click hide/show after the plot handler is removed.
+
+**Files:**
+- Modify: `include/SciQLopPlots/Plotables/SciQLopColorMapBase.hpp`
+- Modify: `src/SciQLopColorMapBase.cpp`
+
+- [ ] **Step 1: Declare slot + dim helper in the header**
+
+In `include/SciQLopPlots/Plotables/SciQLopColorMapBase.hpp`, add a forward
+declaration for `QMouseEvent` near the top (after the existing include block,
+before `class SciQLopColorMapBase`):
+
+```cpp
+class QMouseEvent;
+```
+
+In the `protected:` section (near `_legend_item()`), add:
+
+```cpp
+    void _connect_legend_visibility();
+    void _apply_legend_visibility_style(bool visible);
+```
+
+Add a private slot section before the closing `};` of the class (after the public
+API, alongside the other members):
+
+```cpp
+private Q_SLOTS:
+    void _on_legend_double_clicked(QCPLegend* legend, QCPAbstractLegendItem* item,
+                                   QMouseEvent* event);
+```
+
+- [ ] **Step 2: Implement and connect in the constructor**
+
+In `src/SciQLopColorMapBase.cpp`, add includes after the existing includes at the
+top of the file:
+
+```cpp
+#include <QCustomPlot.h>
+#include <QMouseEvent>
+#include <layoutelements/layoutelement-legend.h>
+```
+
+Call the connect helper at the end of the constructor body:
+
+```cpp
+    , _colorScaleAxis{colorScaleAxis}
+{
+    _connect_legend_visibility();
+}
+```
+
+Add the method implementations after the constructor:
+
+```cpp
+void SciQLopColorMapBase::_connect_legend_visibility()
+{
+    if (auto* plot = _plot())
+        connect(plot, &QCustomPlot::legendDoubleClick, this,
+                &SciQLopColorMapBase::_on_legend_double_clicked);
+    connect(this, &SciQLopPlottableInterface::visible_changed, this,
+            &SciQLopColorMapBase::_apply_legend_visibility_style);
+}
+
+void SciQLopColorMapBase::_on_legend_double_clicked(QCPLegend* legend,
+                                                    QCPAbstractLegendItem* item,
+                                                    QMouseEvent* event)
+{
+    Q_UNUSED(legend);
+    Q_UNUSED(event);
+    if (auto* li = dynamic_cast<QCPPlottableLegendItem*>(item);
+        li != nullptr && li == _legend_item())
+        set_visible(!visible());
+}
+
+void SciQLopColorMapBase::_apply_legend_visibility_style(bool visible)
+{
+    if (auto* li = _legend_item(); li != nullptr)
+    {
+        const QColor c = visible ? Qt::black : Qt::gray;
+        li->setTextColor(c);
+        li->setSelectedTextColor(c);
+    }
+}
+```
+
+- [ ] **Step 3: Build**
+
+Run: `$VENV/bin/meson compile -C $PROJ/build-venv`
+Expected: builds with no errors.
+
+- [ ] **Step 4: Run tests (no regression)**
+
+Run:
+```bash
+cd /tmp && PYTHONPATH=$PROJ/build-venv $VENV/bin/python -m pytest \
+  $PROJ/tests/integration/test_visibility.py -q
+```
+Expected: all passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd $PROJ
+git add include/SciQLopPlots/Plotables/SciQLopColorMapBase.hpp src/SciQLopColorMapBase.cpp
+git commit -m "feat(legend): color map owns its legend double-click hide/show
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6: Remove the old SciQLopPlot legend handler
+
+**Files:**
+- Modify: `src/SciQLopPlot.cpp` (remove handler body + connect at line ~64)
+- Modify: `include/SciQLopPlots/SciQLopPlot.hpp` (remove declaration at line ~211)
+
+- [ ] **Step 1: Remove the connect**
+
+In `src/SciQLopPlot.cpp`, delete the line (around line 64):
+
+```cpp
+    connect(this, &QCustomPlot::legendDoubleClick, this, &SciQLopPlot::_legend_double_clicked);
+```
+
+- [ ] **Step 2: Remove the handler body**
+
+In `src/SciQLopPlot.cpp`, delete the entire `void SciQLopPlot::_legend_double_clicked(...)
+{ ... }` function (lines ~545-584, the whole body shown in the design doc).
+
+- [ ] **Step 3: Remove the declaration**
+
+In `include/SciQLopPlots/SciQLopPlot.hpp`, delete the line (around line 211):
+
+```cpp
+    void _legend_double_clicked(QCPLegend* legend, QCPAbstractLegendItem* item, QMouseEvent* event);
+```
+
+- [ ] **Step 4: Verify no other references**
+
+Run:
+```bash
+grep -rn "_legend_double_clicked" $PROJ/src $PROJ/include
+```
+Expected: no output.
+
+- [ ] **Step 5: Build**
+
+Run: `$VENV/bin/meson compile -C $PROJ/build-venv`
+Expected: builds with no errors.
+
+- [ ] **Step 6: Run full visibility tests**
+
+Run:
+```bash
+cd /tmp && PYTHONPATH=$PROJ/build-venv $VENV/bin/python -m pytest \
+  $PROJ/tests/integration/test_visibility.py -q
+```
+Expected: all passed.
+
+- [ ] **Step 7: Commit**
+
+```bash
+cd $PROJ
+git add src/SciQLopPlot.cpp include/SciQLopPlots/SciQLopPlot.hpp
+git commit -m "refactor(legend): drop SciQLopPlot double-click handler (moved to components)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 7: Full regression run + manual legend verification
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Run the whole integration suite**
+
+Run:
+```bash
+cd /tmp && PYTHONPATH=$PROJ/build-venv $VENV/bin/python -m pytest \
+  $PROJ/tests/integration -q
+```
+Expected: the full suite passes (no regressions). Read the final `N passed`
+line and the exit code — do not infer success from a partial scroll.
+
+- [ ] **Step 2: Manual legend double-click check**
+
+Deploy the built `.so`/`.py` into SciQLop's venv (per CLAUDE.md: `cp build-venv/SciQLopPlots/*.so ... build-venv/SciQLopPlots/*.py ...` into SciQLop's `.venv`), launch SciQLop, then verify:
+  - Double-click a single-curve legend entry → curve hides, legend text greys; double-click again → shows, text black.
+  - Open the inspector for that component → the "Visible" checkbox tracks the legend state and vice-versa.
+  - For a multi-component graph, expand the group legend, double-click one
+    component row → only that component hides; others unchanged.
+  - Color map: inspector "Visible" checkbox hides/shows the map.
+
+- [ ] **Step 3: Final confirmation**
+
+Report the integration suite result (`N passed`) and the manual-check outcome.
+This branch is then ready for the finishing-a-development-branch flow (PR).
+
+---
+
+## Notes / out of scope
+
+- **Group-header double-click is now a no-op** (the old "toggle all components" on
+  the group header is intentionally dropped; each legend row toggles exactly one
+  thing). Out of scope: a dedicated "toggle all" affordance.
+- Out of scope: persisting visibility across save/load; changing how hidden curves
+  participate in autoscale (unchanged).

--- a/docs/superpowers/specs/2026-06-08-hide-curve-visibility-design.md
+++ b/docs/superpowers/specs/2026-06-08-hide-curve-visibility-design.md
@@ -1,0 +1,120 @@
+# Hide / show curves & graph components — design
+
+Date: 2026-06-08
+Branch: `feat/hide-curve-visibility`
+
+## Goal
+
+Restore the ability to hide (and re-show) any curve / graph from two entry points:
+
+1. **The inspector** — a "Visible" checkbox on each plotable component (line graphs,
+   curves, ND-projection curves) and on color maps.
+2. **The legend** — double-clicking a legend entry toggles that entry's visibility,
+   **component by component** for multi-component graphs.
+
+Both entry points must stay in sync: toggling from the legend updates the inspector
+checkbox and vice-versa, and the legend entry dims when hidden regardless of which
+path triggered it.
+
+## Existing infrastructure (already present, reused as-is)
+
+- `SciQLopGraphComponentInterface::set_visible(bool)` / `visible()` / `visible_changed(bool)`.
+- `SciQLopGraphComponent::set_visible()` already handles both cases correctly:
+  - single plottable → `m_plottable->setVisible(...)`,
+  - multi-component → `mg->component(i).visible = ...`,
+  - and emits `visible_changed` + `replot`.
+- `SciQLopColorMapBase` has `set_visible` / `visible` / `visible_changed`.
+- `SciQLopGraphComponent::_legend_item()` / `_group_legend_item()` already resolve a
+  component to its QCP legend entry.
+- `BooleanDelegate` (a `QCheckBox` with a `value`/`set_value`/`value_changed` API).
+
+The plumbing exists; only the **UI affordances** that drive it are missing/broken.
+
+## Approach (B — chosen)
+
+Per-component legend behavior already lives inside `SciQLopGraphComponent` (it owns
+`selectionChanged` and group `componentClicked` wiring). Visibility-on-double-click is
+the only legend behavior that currently lives up in `SciQLopPlot`, poking QCP directly —
+which is exactly why it never synced. We move it down into the component to match the
+existing pattern.
+
+### 1. Inspector checkboxes
+
+`SciQLopGraphComponentDelegate` (covers line graphs, curves, ND-projection curves — they
+share `SciQLopGraphComponentInterface`):
+
+- Add `BooleanDelegate("Visible", component->visible())` as the first row.
+- Forward: `value_changed` → `component->set_visible`.
+- Reverse: `component->visible_changed` → `checkbox->set_value` wrapped in `QSignalBlocker`
+  to avoid feedback loops.
+
+`SciQLopColorMapBaseDelegate`: same checkbox, wired to the color map's existing
+`set_visible` / `visible_changed`.
+
+### 2. Legend double-click → component
+
+In `SciQLopGraphComponent`'s constructors:
+
+- Connect the parent plot's `QCustomPlot::legendDoubleClick(QCPLegend*, QCPAbstractLegendItem*, QMouseEvent*)`
+  signal to a member slot.
+- The slot decides "is this double-click mine?":
+  - single-plottable component: the clicked item is this component's `_legend_item()`;
+  - multi-component: the clicked item is the group item and its `selectedComponent()`
+    equals this component's index.
+- When it's a match, call `set_visible(!visible())`. All sync flows from the resulting
+  `visible_changed`.
+
+Legend dimming is driven off the signal, not the click:
+
+- Connect `visible_changed` → a small helper that sets the legend item text color
+  (normal when visible, gray when hidden). This dims correctly whether the toggle came
+  from the legend or the inspector.
+
+### 3. Remove the old path
+
+- Delete `SciQLopPlot::_legend_double_clicked` and the
+  `connect(this, &QCustomPlot::legendDoubleClick, this, &SciQLopPlot::_legend_double_clicked)`
+  in the `SciQLopPlot` constructor. Its responsibilities now live in the component.
+
+### Group "header" (no component selected) behavior
+
+The old handler had a branch: double-clicking the group header (no specific component
+selected) toggled all-on / all-off. With Approach B each component only owns its own
+index, so a header double-click (where `selectedComponent() < 0`) is a no-op. This keeps
+the model simple and unambiguous — each legend row toggles exactly one thing. (If a
+"toggle all" affordance is wanted later it can be added at the graph level, but it is out
+of scope here per YAGNI.)
+
+## Files touched
+
+- `src/SciQLopGraphComponentDelegate.cpp` — add Visible checkbox + reverse wiring.
+- `src/SciQLopColorMapBaseDelegate.cpp` — add Visible checkbox + reverse wiring.
+- `include/SciQLopPlots/Plotables/SciQLopGraphComponent.hpp` — declare the double-click
+  slot + legend-dimming helper.
+- `src/SciQLopGraphComponent.cpp` — connect `legendDoubleClick` + `visible_changed`,
+  implement the slot/helper.
+- `src/SciQLopPlot.cpp` + `include/SciQLopPlots/SciQLopPlot.hpp` — remove
+  `_legend_double_clicked` and its connection.
+
+## Testing (TDD — tests written first, must fail before, pass after)
+
+Integration tests (pytest, `tests/integration`):
+
+1. **Single-component line graph**: `component.set_visible(False)` flips `component.visible()`
+   to `False` and the underlying plottable is hidden; `set_visible(True)` restores it.
+2. **Multi-component graph**: toggling one component's visibility leaves the others
+   untouched (per-component independence).
+3. **Color map**: `set_visible(False)`/`True` round-trips via `visible()`.
+4. **Signal sync**: connecting to `visible_changed` and calling `set_visible` emits the
+   new value exactly once (this is the contract the inspector checkbox and legend dimming
+   both rely on).
+
+Legend double-click is a GUI mouse interaction; we test the contract it depends on
+(`visible_changed` emission + `set_visible` semantics) rather than synthesizing legend
+mouse events. The double-click → `set_visible` wiring is verified manually in the app.
+
+## Out of scope
+
+- A "toggle all components" affordance.
+- Persisting visibility across save/load.
+- Any change to how hidden curves participate in autoscale (unchanged from today).

--- a/include/SciQLopPlots/Plotables/SciQLopColorMapBase.hpp
+++ b/include/SciQLopPlots/Plotables/SciQLopColorMapBase.hpp
@@ -26,6 +26,8 @@
 #include <optional>
 #include <qcustomplot.h>
 
+class QMouseEvent;
+
 class SciQLopColorMapBase : public SciQLopColorMapInterface
 {
     Q_OBJECT
@@ -53,6 +55,9 @@ protected:
     }
 
     virtual QCPAbstractPlottable* plottable() const = 0;
+
+    void _connect_legend_visibility();
+    void _apply_legend_visibility_style(bool visible);
 
 public:
     SciQLopColorMapBase(SciQLopPlotAxis* keyAxis, SciQLopPlotAxis* valueAxis,
@@ -175,4 +180,8 @@ protected:
     // Installs z_rescale_range as the color-scale axis rescale provider.
     void install_rescale_provider() noexcept;
 #endif
+
+private Q_SLOTS:
+    void _on_legend_double_clicked(QCPLegend* legend, QCPAbstractLegendItem* item,
+                                   QMouseEvent* event);
 };

--- a/include/SciQLopPlots/Plotables/SciQLopColorMapBase.hpp
+++ b/include/SciQLopPlots/Plotables/SciQLopColorMapBase.hpp
@@ -49,6 +49,8 @@ protected:
         if (auto* p = plottable(); p)
         {
             auto plot = _plot();
+            if (!plot)
+                return nullptr;
             return plot->legend->itemWithPlottable(p);
         }
         return nullptr;

--- a/include/SciQLopPlots/Plotables/SciQLopGraphComponent.hpp
+++ b/include/SciQLopPlots/Plotables/SciQLopGraphComponent.hpp
@@ -28,6 +28,7 @@
 #include <layoutelements/layoutelement-legend-group.h>
 #include "SciQLopPlots/qcp_enums.hpp"
 
+class QMouseEvent;
 
 struct MultiGraphRef {
     QCPMultiGraph* graph = nullptr;
@@ -96,6 +97,14 @@ class SciQLopGraphComponent : public SciQLopGraphComponentInterface
         return nullptr;
     }
 
+    void _connect_legend_visibility();
+    void _apply_legend_visibility_style(bool visible);
+
+private Q_SLOTS:
+    void _on_legend_double_clicked(QCPLegend* legend, QCPAbstractLegendItem* item,
+                                   QMouseEvent* event);
+
+private:
     bool m_selected = false;
 
 public:

--- a/include/SciQLopPlots/Plotables/SciQLopGraphComponent.hpp
+++ b/include/SciQLopPlots/Plotables/SciQLopGraphComponent.hpp
@@ -77,6 +77,8 @@ class SciQLopGraphComponent : public SciQLopGraphComponentInterface
         if (m_plottable)
         {
             auto plot = _plot();
+            if (!plot)
+                return nullptr;
             return plot->legend->itemWithPlottable(m_plottable.data());
         }
         return nullptr;

--- a/include/SciQLopPlots/Products/ProductsView.hpp
+++ b/include/SciQLopPlots/Products/ProductsView.hpp
@@ -43,15 +43,12 @@ class ProductsView : public QWidget
     QListView* m_list_view;
     QStackedWidget* m_stack;
     QToolButton* m_view_toggle;
-    QToolButton* m_help_button;
-    QTextBrowser* m_help_popup;
     QLabel* m_result_count;
     ProductsTreeFilterModel* m_tree_filter;
     ProductsFlatFilterModel* m_flat_filter;
     QTimer* m_completion_refresh_timer;
 
     Q_SLOT void on_query_changed(const Query& query);
-    Q_SLOT void show_help_popup();
     void toggle_view();
     void update_result_count();
     void refresh_completions();

--- a/include/SciQLopPlots/SciQLopPlot.hpp
+++ b/include/SciQLopPlots/SciQLopPlot.hpp
@@ -208,8 +208,6 @@ protected:
 
     QCPAbstractPlottable* plottable(const QString& name) const;
 
-    void _legend_double_clicked(QCPLegend* legend, QCPAbstractLegendItem* item, QMouseEvent* event);
-
     void _wheel_pan(QCPAxis* axis, const double wheelSteps);
     void _wheel_zoom(QCPAxis* axis, const double wheelSteps, const QPointF& pos);
     void _pinch_zoom(QPinchGesture* gesture);

--- a/src/ProductsView.cpp
+++ b/src/ProductsView.cpp
@@ -30,7 +30,6 @@
 #include <QLabel>
 #include <QListView>
 #include <QStackedWidget>
-#include <QTextBrowser>
 #include <QTimer>
 #include <QToolButton>
 #include <QTreeView>
@@ -52,11 +51,6 @@ ProductsView::ProductsView(QWidget* parent) : QWidget(parent)
     m_view_toggle->setCheckable(true);
     m_view_toggle->hide();
     toolbar->addWidget(m_view_toggle);
-
-    m_help_button = new QToolButton(this);
-    m_help_button->setText("?");
-    m_help_button->setToolTip("Show search syntax help");
-    toolbar->addWidget(m_help_button);
 
     m_result_count = new QLabel(this);
     m_result_count->hide();
@@ -93,18 +87,12 @@ ProductsView::ProductsView(QWidget* parent) : QWidget(parent)
     m_stack->setCurrentWidget(m_tree_view);
     layout->addWidget(m_stack);
 
-    m_help_popup = nullptr;
-
+    // Search syntax help is shown as the search-bar hover tooltip (set by
+    // QueryLineEdit::refresh_help). No popup/panel — nothing to get stuck.
     connect(m_query_line_edit, &QueryLineEdit::queryChanged, this,
             &ProductsView::on_query_changed);
     connect(m_view_toggle, &QToolButton::toggled, this,
             [this](bool) { toggle_view(); });
-    connect(m_help_button, &QToolButton::clicked, this,
-            &ProductsView::show_help_popup);
-    connect(m_query_line_edit, &QueryLineEdit::helpTextChanged, this, [this]() {
-        if (m_help_popup && m_help_popup->isVisible())
-            m_help_popup->setHtml(search_help());
-    });
 
     m_completion_refresh_timer = new QTimer(this);
     m_completion_refresh_timer->setSingleShot(true);
@@ -225,20 +213,4 @@ void ProductsView::set_search_help(const QString& html)
 QString ProductsView::search_help() const
 {
     return m_query_line_edit->help_text();
-}
-
-void ProductsView::show_help_popup()
-{
-    if (!m_help_popup)
-    {
-        m_help_popup = new QTextBrowser(this);
-        m_help_popup->setWindowFlags(Qt::Popup);
-        m_help_popup->setOpenExternalLinks(true);
-        m_help_popup->setFixedSize(380, 240);
-    }
-    m_help_popup->setHtml(search_help());
-    QPoint pos = m_query_line_edit->mapToGlobal(
-        QPoint(0, m_query_line_edit->height()));
-    m_help_popup->move(pos);
-    m_help_popup->show();
 }

--- a/src/SciQLopColorMapBase.cpp
+++ b/src/SciQLopColorMapBase.cpp
@@ -21,6 +21,8 @@
 ----------------------------------------------------------------------------*/
 #include "SciQLopPlots/Plotables/SciQLopColorMapBase.hpp"
 #include "SciQLopPlots/Plotables/AxisHelpers.hpp"
+#include <QMouseEvent>
+#include <layoutelements/layoutelement-legend.h>
 #include <algorithm>
 #include <cmath>
 
@@ -32,6 +34,7 @@ SciQLopColorMapBase::SciQLopColorMapBase(SciQLopPlotAxis* keyAxis, SciQLopPlotAx
     , _valueAxis{valueAxis}
     , _colorScaleAxis{colorScaleAxis}
 {
+    _connect_legend_visibility();
 }
 
 SciQLopColorMapBase::~SciQLopColorMapBase()
@@ -41,6 +44,36 @@ SciQLopColorMapBase::~SciQLopColorMapBase()
     // destroyed thanks to QPointer.
     if (_colorScaleAxis)
         _colorScaleAxis->set_rescale_range_provider(nullptr);
+}
+
+void SciQLopColorMapBase::_connect_legend_visibility()
+{
+    if (auto* plot = _plot())
+        connect(plot, &QCustomPlot::legendDoubleClick, this,
+                &SciQLopColorMapBase::_on_legend_double_clicked);
+    connect(this, &SciQLopPlottableInterface::visible_changed, this,
+            &SciQLopColorMapBase::_apply_legend_visibility_style);
+}
+
+void SciQLopColorMapBase::_on_legend_double_clicked(QCPLegend* legend,
+                                                    QCPAbstractLegendItem* item,
+                                                    QMouseEvent* event)
+{
+    Q_UNUSED(legend);
+    Q_UNUSED(event);
+    if (auto* li = dynamic_cast<QCPPlottableLegendItem*>(item);
+        li != nullptr && li == _legend_item())
+        set_visible(!visible());
+}
+
+void SciQLopColorMapBase::_apply_legend_visibility_style(bool visible)
+{
+    if (auto* li = _legend_item(); li != nullptr)
+    {
+        const QColor c = visible ? Qt::black : Qt::gray;
+        li->setTextColor(c);
+        li->setSelectedTextColor(c);
+    }
 }
 
 void SciQLopColorMapBase::set_selected(bool selected) noexcept

--- a/src/SciQLopColorMapBase.cpp
+++ b/src/SciQLopColorMapBase.cpp
@@ -70,7 +70,12 @@ void SciQLopColorMapBase::_apply_legend_visibility_style(bool visible)
 {
     if (auto* li = _legend_item(); li != nullptr)
     {
-        const QColor c = visible ? Qt::black : Qt::gray;
+        // Restore the legend's themed text colour when visible; dim via alpha
+        // when hidden so it reads correctly on both light and dark themes
+        // (never hard-code black/gray — black is invisible on a dark legend).
+        QColor c = li->parentLegend() ? li->parentLegend()->textColor() : li->textColor();
+        if (!visible)
+            c.setAlpha(90);
         li->setTextColor(c);
         li->setSelectedTextColor(c);
     }

--- a/src/SciQLopColorMapBaseDelegate.cpp
+++ b/src/SciQLopColorMapBaseDelegate.cpp
@@ -21,10 +21,12 @@
 ----------------------------------------------------------------------------*/
 #include "SciQLopPlots/Inspector/PropertiesDelegates/SciQLopColorMapBaseDelegate.hpp"
 #include "SciQLopPlots/Plotables/SciQLopColorMapBase.hpp"
+#include "SciQLopPlots/Inspector/PropertiesDelegates/Delegates/BooleanDelegate.hpp"
 
 #include <QDoubleSpinBox>
 #include <QFormLayout>
 #include <QGroupBox>
+#include <QSignalBlocker>
 
 SciQLopColorMapBase* SciQLopColorMapBaseDelegate::color_map_base() const
 {
@@ -35,11 +37,17 @@ SciQLopColorMapBaseDelegate::SciQLopColorMapBaseDelegate(SciQLopColorMapBase* ob
                                                          QWidget* parent)
         : PropertyDelegateBase(object, parent)
 {
-    Q_UNUSED(object);
-    // Color-scale controls live on the "Color Scale" (z) axis node:
-    //   - Gradient (moved in PR #67)
-    //   - Autoscale percentile (moved in PR #69)
-    // The colormap node only carries product-specific knobs added by
-    // derived delegates (Contours on SciQLopColorMap, Binning/normalization
-    // on SciQLopHistogram2DDelegate).
+    auto* visibleCheck = new BooleanDelegate("Visible", object->visible(), this);
+    m_layout->addRow(visibleCheck);
+    connect(visibleCheck, &BooleanDelegate::value_changed, object,
+            &SciQLopPlottableInterface::set_visible);
+    connect(object, &SciQLopPlottableInterface::visible_changed, visibleCheck,
+            [visibleCheck](bool v)
+            {
+                QSignalBlocker blocker(visibleCheck);
+                visibleCheck->set_value(v);
+            });
+    // Color-scale controls (gradient, autoscale percentile) live on the
+    // "Color Scale" (z) axis node. Product-specific knobs are added by derived
+    // delegates (Contours, Binning/normalization).
 }

--- a/src/SciQLopCrosshair.cpp
+++ b/src/SciQLopCrosshair.cpp
@@ -50,18 +50,23 @@ SciQLopCrosshair::SciQLopCrosshair(QCustomPlot* plot)
     m_vline = new QCPItemStraightLine(plot);
     m_vline->setLayer("overlay");
     m_vline->setSelectable(false);
+    // Decorative overlay following the cursor: keep it from stealing clicks
+    // (e.g. a legend double-click) from the elements beneath it.
+    m_vline->setMouseTransparent(true);
     m_vline->setPen(QPen(QColor(128, 128, 128, 180), 1, Qt::DashLine));
     m_vline->setVisible(false);
 
     m_hline = new QCPItemStraightLine(plot);
     m_hline->setLayer("overlay");
     m_hline->setSelectable(false);
+    m_hline->setMouseTransparent(true);
     m_hline->setPen(QPen(QColor(128, 128, 128, 180), 1, Qt::DashLine));
     m_hline->setVisible(false);
 
     m_tooltip = new QCPItemRichText(plot);
     m_tooltip->setLayer("overlay");
     m_tooltip->setSelectable(false);
+    m_tooltip->setMouseTransparent(true);
     m_tooltip->setClipToAxisRect(false);
     m_tooltip->setPadding(QMargins(6, 4, 6, 4));
     m_tooltip->setBrush(QBrush(QColor(0xee, 0xf2, 0xf7, 220)));

--- a/src/SciQLopGraphComponent.cpp
+++ b/src/SciQLopGraphComponent.cpp
@@ -312,7 +312,12 @@ void SciQLopGraphComponent::_apply_legend_visibility_style(bool visible)
     // behaviour — the curve simply disappears).
     if (auto* li = _legend_item(); li != nullptr)
     {
-        const QColor c = visible ? Qt::black : Qt::gray;
+        // Restore the legend's themed text colour when visible; dim via alpha
+        // when hidden so it reads correctly on both light and dark themes
+        // (never hard-code black/gray — black is invisible on a dark legend).
+        QColor c = li->parentLegend() ? li->parentLegend()->textColor() : li->textColor();
+        if (!visible)
+            c.setAlpha(90);
         li->setTextColor(c);
         li->setSelectedTextColor(c);
     }

--- a/src/SciQLopGraphComponent.cpp
+++ b/src/SciQLopGraphComponent.cpp
@@ -20,6 +20,9 @@
 -- Mail : alexis.jeandet@member.fsf.org
 ----------------------------------------------------------------------------*/
 #include "SciQLopPlots/Plotables/SciQLopGraphComponent.hpp"
+#include <QMouseEvent>
+#include <layoutelements/layoutelement-legend.h>
+#include <layoutelements/layoutelement-legend-group.h>
 
 SciQLopGraphComponent::SciQLopGraphComponent(QCPAbstractPlottable* plottable, QObject* parent)
         : SciQLopGraphComponentInterface(parent), m_plottable(plottable)
@@ -40,6 +43,7 @@ SciQLopGraphComponent::SciQLopGraphComponent(QCPAbstractPlottable* plottable, QO
         connect(plottable, QOverload<bool>::of(&QCPAbstractPlottable::selectionChanged), this,
                 &SciQLopGraphComponent::set_selected);
     }
+    _connect_legend_visibility();
 }
 
 SciQLopGraphComponent::SciQLopGraphComponent(QCPMultiGraph* multiGraph, int componentIndex,
@@ -62,6 +66,7 @@ SciQLopGraphComponent::SciQLopGraphComponent(QCPMultiGraph* multiGraph, int comp
                     set_selected(clickedComponent == m_componentIndex);
                 });
     }
+    _connect_legend_visibility();
 }
 
 SciQLopGraphComponent::~SciQLopGraphComponent()
@@ -264,4 +269,51 @@ QColor SciQLopGraphComponent::color() const noexcept
         return m_plottable->pen().color();
     }
     return QColor();
+}
+
+void SciQLopGraphComponent::_connect_legend_visibility()
+{
+    if (auto* plot = _plot())
+        connect(plot, &QCustomPlot::legendDoubleClick, this,
+                &SciQLopGraphComponent::_on_legend_double_clicked);
+    connect(this, &SciQLopGraphComponentInterface::visible_changed, this,
+            &SciQLopGraphComponent::_apply_legend_visibility_style);
+}
+
+void SciQLopGraphComponent::_on_legend_double_clicked(QCPLegend* legend,
+                                                      QCPAbstractLegendItem* item,
+                                                      QMouseEvent* event)
+{
+    Q_UNUSED(legend);
+    Q_UNUSED(event);
+    bool mine = false;
+    if (m_componentIndex >= 0)
+    {
+        // selectedComponent() is already set by the time legendDoubleClick fires:
+        // Qt delivers the press/release selection event before the double-click event.
+        if (auto* gi = dynamic_cast<QCPGroupLegendItem*>(item);
+            gi != nullptr && gi->multiGraph() == qobject_cast<QCPMultiGraph*>(m_plottable.data())
+            && gi->selectedComponent() == m_componentIndex)
+            mine = true;
+    }
+    else if (auto* li = dynamic_cast<QCPPlottableLegendItem*>(item);
+             li != nullptr && li == _legend_item())
+    {
+        mine = true;
+    }
+    if (mine)
+        set_visible(!visible());
+}
+
+void SciQLopGraphComponent::_apply_legend_visibility_style(bool visible)
+{
+    // Only single-plottable components have a per-entry legend item to dim;
+    // multi-component group items have no per-row text colour (matches prior
+    // behaviour — the curve simply disappears).
+    if (auto* li = _legend_item(); li != nullptr)
+    {
+        const QColor c = visible ? Qt::black : Qt::gray;
+        li->setTextColor(c);
+        li->setSelectedTextColor(c);
+    }
 }

--- a/src/SciQLopGraphComponentDelegate.cpp
+++ b/src/SciQLopGraphComponentDelegate.cpp
@@ -22,6 +22,7 @@
 #include "SciQLopPlots/Inspector/PropertiesDelegates/SciQLopGraphComponentDelegate.hpp"
 
 #include "SciQLopPlots/Inspector/PropertiesDelegates/Delegates/ColorDelegate.hpp"
+#include "SciQLopPlots/Inspector/PropertiesDelegates/Delegates/BooleanDelegate.hpp"
 #include "SciQLopPlots/Inspector/PropertiesDelegates/Delegates/LineDelegate.hpp"
 #include "SciQLopPlots/Plotables/SciQLopGraphComponentInterface.hpp"
 
@@ -39,6 +40,17 @@ SciQLopGraphComponentDelegate::SciQLopGraphComponentDelegate(SciQLopGraphCompone
                                                              QWidget* parent)
         : PropertyDelegateBase(object, parent)
 {
+    auto* visibleCheck = new BooleanDelegate("Visible", object->visible(), this);
+    m_layout->addRow(visibleCheck);
+    connect(visibleCheck, &BooleanDelegate::value_changed, object,
+            &SciQLopGraphComponentInterface::set_visible);
+    connect(object, &SciQLopGraphComponentInterface::visible_changed, visibleCheck,
+            [visibleCheck](bool v)
+            {
+                QSignalBlocker blocker(visibleCheck);
+                visibleCheck->set_value(v);
+            });
+
     m_lineDelegate = new LineDelegate(object->pen(), object->line_style(),
                                       object->marker_shape(), this);
     m_layout->addWidget(m_lineDelegate);

--- a/src/SciQLopPlot.cpp
+++ b/src/SciQLopPlot.cpp
@@ -61,7 +61,6 @@ SciQLopPlot::SciQLopPlot(QWidget* parent) : QCustomPlot { parent }
                           | QCP::iMultiSelect);
 
 
-    connect(this, &QCustomPlot::legendDoubleClick, this, &SciQLopPlot::_legend_double_clicked);
     connect(this->xAxis, QOverload<const QCPRange&>::of(&QCPAxis::rangeChanged), this,
             [this](const QCPRange& range)
             { if (!m_suppress_range_signals) Q_EMIT x_axis_range_changed({ range.lower, range.upper }); });
@@ -542,46 +541,6 @@ QCPAbstractPlottable* SciQLopPlot::plottable(const QString& name) const
     return nullptr;
 }
 
-void SciQLopPlot::_legend_double_clicked(QCPLegend* legend, QCPAbstractLegendItem* item,
-                                         QMouseEvent* event)
-{
-    if (auto legend_item = dynamic_cast<QCPPlottableLegendItem*>(item); legend_item != nullptr)
-    {
-        auto plottable = legend_item->plottable();
-        plottable->setVisible(!plottable->visible());
-        if (plottable->visible())
-        {
-            item->setTextColor(Qt::black);
-            item->setSelectedTextColor(Qt::black);
-        }
-        else
-        {
-            item->setTextColor(Qt::gray);
-            item->setSelectedTextColor(Qt::gray);
-        }
-        this->replot(rpQueuedReplot);
-    }
-    else if (auto* gi = dynamic_cast<QCPGroupLegendItem*>(item); gi != nullptr)
-    {
-        auto* mg = gi->multiGraph();
-        if (!mg)
-            return;
-        int comp = gi->selectedComponent();
-        if (comp >= 0 && comp < mg->componentCount())
-        {
-            mg->component(comp).visible = !mg->component(comp).visible;
-        }
-        else
-        {
-            bool anyVisible = false;
-            for (int i = 0; i < mg->componentCount(); ++i)
-                anyVisible |= mg->component(i).visible;
-            for (int i = 0; i < mg->componentCount(); ++i)
-                mg->component(i).visible = !anyVisible;
-        }
-        this->replot(rpQueuedReplot);
-    }
-}
 }
 
 void SciQLopPlot::_configure_plotable(SciQLopGraphInterface* plottable, const QStringList& labels,

--- a/tests/integration/test_visibility.py
+++ b/tests/integration/test_visibility.py
@@ -76,3 +76,47 @@ class TestColorMapDelegateVisible:
         cmap.set_visible(False)
         process_events()
         assert box.isChecked() is False
+
+
+class TestVisibilityContract:
+    def test_component_round_trip(self, plot, sample_data):
+        x, y = sample_data
+        g = plot.line(x, y, labels=["a"])
+        process_events()
+        comp = g.components()[0]
+        assert comp.visible() is True
+        comp.set_visible(False)
+        assert comp.visible() is False
+        comp.set_visible(True)
+        assert comp.visible() is True
+
+    def test_component_emits_signal(self, plot, sample_data):
+        x, y = sample_data
+        g = plot.line(x, y, labels=["a"])
+        process_events()
+        comp = g.components()[0]
+        seen = []
+        comp.visible_changed.connect(lambda v: seen.append(v))
+        comp.set_visible(False)
+        assert seen == [False]
+
+    def test_multicomponent_independent(self, plot, sample_multicomponent_data):
+        x, y = sample_multicomponent_data
+        g = plot.line(x, y, labels=["a", "b", "c"])
+        process_events()
+        comps = g.components()
+        assert len(comps) == 3
+        comps[1].set_visible(False)
+        assert comps[0].visible() is True
+        assert comps[1].visible() is False
+        assert comps[2].visible() is True
+
+    def test_colormap_round_trip(self, plot, sample_colormap_data):
+        x, y, z = sample_colormap_data
+        cmap = plot.colormap(x, y, z)
+        process_events()
+        assert cmap.visible() is True
+        cmap.set_visible(False)
+        assert cmap.visible() is False
+        cmap.set_visible(True)
+        assert cmap.visible() is True

--- a/tests/integration/test_visibility.py
+++ b/tests/integration/test_visibility.py
@@ -1,0 +1,55 @@
+"""Hide/show visibility from the inspector delegates and component API."""
+import numpy as np
+import pytest
+from PySide6.QtWidgets import QCheckBox
+
+from SciQLopPlots import DelegateRegistry
+from conftest import process_events
+
+
+def _make_delegate(target, qtbot):
+    d = DelegateRegistry.instance().create_delegate(target, None)
+    assert d is not None
+    qtbot.addWidget(d)
+    return d
+
+
+def _visible_checkbox(delegate):
+    boxes = [c for c in delegate.findChildren(QCheckBox) if c.text() == "Visible"]
+    assert len(boxes) == 1, f"expected one 'Visible' checkbox, got {len(boxes)}"
+    return boxes[0]
+
+
+class TestComponentDelegateVisible:
+    def test_checkbox_reflects_initial_state(self, plot, sample_data, qtbot):
+        x, y = sample_data
+        g = plot.line(x, y, labels=["a"])
+        process_events()
+        comp = g.components()[0]
+        d = _make_delegate(comp, qtbot)
+        assert _visible_checkbox(d).isChecked() is True
+
+    def test_checkbox_toggles_component(self, plot, sample_data, qtbot):
+        x, y = sample_data
+        g = plot.line(x, y, labels=["a"])
+        process_events()
+        comp = g.components()[0]
+        d = _make_delegate(comp, qtbot)
+        box = _visible_checkbox(d)
+        box.setChecked(False)
+        process_events()
+        assert comp.visible() is False
+        box.setChecked(True)
+        process_events()
+        assert comp.visible() is True
+
+    def test_external_change_updates_checkbox(self, plot, sample_data, qtbot):
+        x, y = sample_data
+        g = plot.line(x, y, labels=["a"])
+        process_events()
+        comp = g.components()[0]
+        d = _make_delegate(comp, qtbot)
+        box = _visible_checkbox(d)
+        comp.set_visible(False)
+        process_events()
+        assert box.isChecked() is False

--- a/tests/integration/test_visibility.py
+++ b/tests/integration/test_visibility.py
@@ -53,3 +53,26 @@ class TestComponentDelegateVisible:
         comp.set_visible(False)
         process_events()
         assert box.isChecked() is False
+
+
+class TestColorMapDelegateVisible:
+    def test_checkbox_toggles_colormap(self, plot, sample_colormap_data, qtbot):
+        x, y, z = sample_colormap_data
+        cmap = plot.colormap(x, y, z)
+        process_events()
+        d = _make_delegate(cmap, qtbot)
+        box = _visible_checkbox(d)
+        assert box.isChecked() is True
+        box.setChecked(False)
+        process_events()
+        assert cmap.visible() is False
+
+    def test_external_change_updates_checkbox(self, plot, sample_colormap_data, qtbot):
+        x, y, z = sample_colormap_data
+        cmap = plot.colormap(x, y, z)
+        process_events()
+        d = _make_delegate(cmap, qtbot)
+        box = _visible_checkbox(d)
+        cmap.set_visible(False)
+        process_events()
+        assert box.isChecked() is False


### PR DESCRIPTION
## Summary

Restore the ability to hide/show any curve, graph component, or colormap from two entry points, kept in sync via the existing `visible_changed` signal:

1. **Inspector** — a "Visible" checkbox on the graph-component delegate (line graphs, curves, ND-projection curves) and on the colormap delegate.
2. **Legend** — double-click a legend entry to toggle it, **component-by-component** for multi-component graphs.

Each component / colormap now owns its own legend double-click handling (matching the existing `selectionChanged`/`componentClicked` pattern); the old `SciQLopPlot::_legend_double_clicked` (which poked QCP directly and never synced state) is removed.

## What's included

- **Inspector checkboxes** wired bidirectionally (`set_visible` ⇄ `visible_changed`, `QSignalBlocker` guards the loop).
- **Per-component legend double-click** in `SciQLopGraphComponent` and `SciQLopColorMapBase`; legend dimming driven off `visible_changed`.
- **fix(legend): theme-aware dim** — hidden entries dim via alpha, visible entries restore the legend's themed text colour (no more hard-coded `Qt::black`, which was invisible on a dark legend).
- **fix(crosshair): mouse-transparent overlays** — the crosshair vline/hline/tooltip sit on the topmost overlay layer under the cursor and were stealing legend double-clicks (QCP routed them to `itemDoubleClick`). They now opt out of hit-testing via `QCPLayerable::setMouseTransparent` (NeoQCP).
- **fix(products): search help via search-bar tooltip only** — drops the `?`-button + floating `QTextBrowser` popup that couldn't be dismissed reliably on Wayland; help stays as the search-bar hover tooltip.

## Dependencies

Requires NeoQCP changes merged in **SciQLop/NeoQCP#30** (colormap RHI compositing honors plottable visibility; `QCPLayerable::setMouseTransparent`). The wrap tracks `main`, which now contains them.

## Behavior notes

- Group-header double-click is a no-op by design — each legend row toggles exactly one thing. ("Toggle all" is out of scope.)
- Multi-component group legend rows are not text-dimmed (group items have no per-row text colour); the curve simply disappears — consistent with prior behavior.

## Test plan

- [x] Full integration suite: **704 passed** (built against merged NeoQCP main).
- [x] New `tests/integration/test_visibility.py` covers inspector checkboxes (component + colormap) and the visibility contract (round-trip, per-component independence, signal emission).
- [ ] Manual (GUI): hide a curve/colormap via checkbox and via legend double-click; confirm colormap disappears and pans correctly; confirm legend double-click works with crosshair enabled; confirm legend dim reads correctly on a dark theme.

Design + implementation plan are included under `docs/superpowers/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)