### PR TITLE
fix: SciQLop user-API fuzzing findings (#1 error messages, #2 garbage data, #4 range strings, #5 removal noise)

### DIFF
--- a/SciQLopPlots/__init__.py
+++ b/SciQLopPlots/__init__.py
@@ -10,6 +10,47 @@ import sys
 
 sys.modules["SciQLopPlotsBindings"] = SciQLopPlotsBindings
 
+
+def _register_with_shiboken_signatures():
+    """Make wrong-argument TypeErrors readable instead of a masking NameError.
+
+    Shiboken builds the "Supported signatures:" part of an argument-mismatch
+    TypeError by eval()-ing the parameter type strings (e.g.
+    ``SciQLopPlotsBindings.SciQLopPlot``) in shibokensupport.signature.mapping's
+    namespace. PySide6's own types are pre-registered there; ours are not, so
+    every overload mismatch raised ``NameError: name 'SciQLopPlotsBindings' is
+    not defined`` that masked the real TypeError.
+
+    Two registrations are needed:
+      * the binding module, so ``SciQLopPlotsBindings.<Type>`` resolves;
+      * our ``<primitive-type>`` declarations in the type map. These are not
+        wrapped classes, so without an entry they resolve to a bare ``str``
+        and shiboken's argument matcher hard-aborts the interpreter
+        (``the_type.__module__`` on a str). PyObject-backed buffer → object,
+        the data callable → Callable.
+
+    Finally, a global ``enum class`` default renders in the generated
+    signatures as ``.GraphMarkerShape.NoMarker`` (module prefix dropped → a
+    leading dot the parser can't eval). That only warns — once per signature,
+    and only while formatting an error — but it would bury the now-useful
+    message under a wall of RuntimeWarnings, so the specific warning is muted.
+    """
+    try:
+        from shibokensupport.signature import mapping
+    except (ImportError, AttributeError):
+        return  # cosmetic, best-effort: never break import over error formatting
+    import collections.abc
+    import warnings
+
+    mapping.namespace["SciQLopPlotsBindings"] = SciQLopPlotsBindings
+    mapping.type_map["SciQLopPyBuffer"] = object
+    mapping.type_map["GetDataPyCallable"] = collections.abc.Callable
+    warnings.filterwarnings(
+        "ignore", message="pyside_type_init", category=RuntimeWarning)
+
+
+_register_with_shiboken_signatures()
+
 from . import tracing  # noqa: E402,F401  -- runtime tracer facade
 
 __version__ = '0.27.1'

--- a/SciQLopPlots/__init__.py
+++ b/SciQLopPlots/__init__.py
@@ -35,18 +35,26 @@ def _register_with_shiboken_signatures():
     and only while formatting an error — but it would bury the now-useful
     message under a wall of RuntimeWarnings, so the specific warning is muted.
     """
-    try:
-        from shibokensupport.signature import mapping
-    except (ImportError, AttributeError):
-        return  # cosmetic, best-effort: never break import over error formatting
     import collections.abc
     import warnings
 
-    mapping.namespace["SciQLopPlotsBindings"] = SciQLopPlotsBindings
-    mapping.type_map["SciQLopPyBuffer"] = object
-    mapping.type_map["GetDataPyCallable"] = collections.abc.Callable
-    warnings.filterwarnings(
-        "ignore", message="pyside_type_init", category=RuntimeWarning)
+    # The whole body is best-effort: this only makes binding-misuse errors
+    # readable, so any shift in shiboken's signature internals (missing module,
+    # renamed/restructured namespace or type_map) must degrade to the raw
+    # shiboken errors, never break ``import SciQLopPlots``.
+    try:
+        from shibokensupport.signature import mapping
+
+        mapping.namespace["SciQLopPlotsBindings"] = SciQLopPlotsBindings
+        mapping.type_map["SciQLopPyBuffer"] = object
+        mapping.type_map["GetDataPyCallable"] = collections.abc.Callable
+        # Scoped to the parser that emits it so we never hide a same-named
+        # RuntimeWarning from unrelated code.
+        warnings.filterwarnings(
+            "ignore", message="pyside_type_init", category=RuntimeWarning,
+            module=r"shibokensupport\.signature")
+    except Exception:
+        pass
 
 
 _register_with_shiboken_signatures()

--- a/SciQLopPlots/bindings/bindings.xml
+++ b/SciQLopPlots/bindings/bindings.xml
@@ -45,8 +45,14 @@
                     }
                     catch (const std::runtime_error&amp; e)
                     {
-                        qWarning() &lt;&lt; "[SciQLopPyBuffer ctor] rejected buffer:" &lt;&lt; e.what();
+                        // Throwing here would escape the conversion (which runs
+                        // before the call's try/catch) and std::terminate. Set a
+                        // Python error instead: shiboken checks Errors::occurred()
+                        // after conversion and aborts the call, raising in Python.
+                        // A non-numeric array used to be swallowed to an empty
+                        // buffer and silently no-op'd at set_data.
                         %out = %OUTTYPE();
+                        PyErr_SetString(PyExc_TypeError, e.what());
                     }
                 </add-conversion>
             </target-to-native>

--- a/include/SciQLopPlots/MultiPlots/AxisSynchronizer.hpp
+++ b/include/SciQLopPlots/MultiPlots/AxisSynchronizer.hpp
@@ -43,6 +43,9 @@ public:
 
     Q_SLOT virtual void updatePlotList(const QList<QPointer<SciQLopPlotInterface>>& plots) override;
     Q_SLOT virtual void plotAdded(SciQLopPlotInterface* plot) override;
+    // Axis (dis)connection happens in updatePlotList on plot_list_changed —
+    // nothing per-plot to undo here, but the base method warns when not overridden.
+    Q_SLOT virtual void plotRemoved(SciQLopPlotInterface* plot) override { Q_UNUSED(plot); }
     Q_SLOT virtual void panelAdded(SciQLopPlotPanelInterface* panel) override;
     Q_SLOT virtual void panelRemoved(SciQLopPlotPanelInterface* panel) override;
     Q_SLOT virtual void set_axis_range(const SciQLopPlotRange& range);

--- a/include/SciQLopPlots/SciQLopPlotRange.hpp
+++ b/include/SciQLopPlots/SciQLopPlotRange.hpp
@@ -22,6 +22,8 @@
 #pragma once
 
 #include <chrono>
+#include <cmath>
+#include <stdexcept>
 #include <QDataStream>
 #include <QDateTime>
 #include <QTimeZone>
@@ -90,6 +92,15 @@ public:
             : QPair<double, double> { str_date_to_double(start), str_date_to_double(end) }
             , _is_time_range(true)
     {
+        // Unparsable strings must not silently become NaN bounds: a NaN range
+        // propagates through set_range/percentile guards as a hard-to-trace
+        // "nothing plots" state.
+        if (std::isnan(first))
+            throw std::invalid_argument("unparsable date string: "
+                                        + start.toStdString());
+        if (std::isnan(second))
+            throw std::invalid_argument("unparsable date string: "
+                                        + end.toStdString());
     }
 
     SciQLopPlotRange(double start, double stop, bool is_time_range = false)
@@ -111,11 +122,14 @@ public:
 
     std::string __repr__() const
     {
-        if (this->_is_time_range)
+        // Non-finite bounds can't go through from_time_t — (time_t)NaN is UB
+        // and lands on epoch 0, making the repr claim 1970 for a NaN range.
+        if (this->_is_time_range && std::isfinite(first) && std::isfinite(second))
             return fmt::format("SciQLopPlotTimeRange({:%Y-%m-%d %H:%M:%S}, {:%Y-%m-%d %H:%M:%S})",
                                epoch_to_std_time(first), epoch_to_std_time(second));
-        else
-            return fmt::format("SciQLopPlotRange({}, {})", first, second);
+        if (this->_is_time_range)
+            return fmt::format("SciQLopPlotTimeRange({}, {})", first, second);
+        return fmt::format("SciQLopPlotRange({}, {})", first, second);
     }
 
     inline double start() const { return first; }

--- a/src/SciQLopColorMap.cpp
+++ b/src/SciQLopColorMap.cpp
@@ -62,7 +62,7 @@ SciQLopColorMap::~SciQLopColorMap()
         auto* plot = _plot();
         auto* cmap = _cmap.data();
         _cmap = nullptr;
-        if (plot)
+        if (plot && plot->hasPlottable(cmap))
             (void)plot->removePlottable(cmap);
     }
 }

--- a/src/SciQLopHistogram2D.cpp
+++ b/src/SciQLopHistogram2D.cpp
@@ -85,7 +85,7 @@ SciQLopHistogram2D::~SciQLopHistogram2D()
         auto* plot = _plot();
         auto* hist = _hist.data();
         _hist = nullptr;
-        if (plot)
+        if (plot && plot->hasPlottable(hist))
             (void)plot->removePlottable(hist);
     }
 }

--- a/src/SciQLopMultiGraphBase.cpp
+++ b/src/SciQLopMultiGraphBase.cpp
@@ -41,7 +41,7 @@ void SciQLopMultiGraphBase::clear_graphs(bool graph_already_removed)
     if (_multiGraph && !graph_already_removed)
     {
         auto plot = _multiGraph->parentPlot();
-        if (plot)
+        if (plot && plot->hasPlottable(_multiGraph))
             plot->removePlottable(_multiGraph);
     }
     _multiGraph = nullptr;

--- a/src/SciQLopSingleLineGraph.cpp
+++ b/src/SciQLopSingleLineGraph.cpp
@@ -53,7 +53,7 @@ void SciQLopSingleLineGraph::clear_graph(bool graph_already_removed)
     if (_graph && !graph_already_removed)
     {
         auto plot = _graph->parentPlot();
-        if (plot)
+        if (plot && plot->hasPlottable(_graph))
             plot->removePlottable(_graph);
     }
     _graph = nullptr;

--- a/tests/integration/test_fuzzing_findings.py
+++ b/tests/integration/test_fuzzing_findings.py
@@ -8,7 +8,7 @@ import numpy as np
 import pytest
 from PySide6.QtCore import qInstallMessageHandler
 
-from SciQLopPlots import GraphType, SciQLopPlotRange
+from SciQLopPlots import GraphType, SciQLopHorizontalLine, SciQLopPlotRange
 
 
 @pytest.fixture
@@ -67,6 +67,25 @@ class TestGarbageDataRaises:
         x = _x()
         graph = plot.line(x, np.sin(x))
         graph.set_data(x, np.cos(x))  # no exception
+
+
+class TestOverloadErrorMessage:
+    """A wrong-argument call on a SciQLopPlotsBindings class must produce a
+    real TypeError listing the accepted overloads — not the NameError that
+    shiboken's signature formatter throws when it can't resolve the binding
+    module name in its eval namespace (report #2 / finding #1)."""
+
+    def test_wrong_args_raise_typeerror_not_nameerror(self):
+        with pytest.raises(TypeError):
+            SciQLopHorizontalLine("not a plot", 5.0)
+
+    def test_error_message_lists_supported_signatures(self):
+        try:
+            SciQLopHorizontalLine("not a plot", 5.0)
+        except TypeError as e:
+            assert "Supported signatures" in str(e), str(e)
+        except NameError as e:
+            pytest.fail(f"shiboken signature formatter raised NameError: {e}")
 
 
 class TestRangeStringParsing:

--- a/tests/integration/test_fuzzing_findings.py
+++ b/tests/integration/test_fuzzing_findings.py
@@ -1,0 +1,110 @@
+"""Reproducers for the SciQLop user-API fuzzing campaign findings handed over
+to this repo (2026-06-12): garbage data must raise instead of silently
+no-oping (report #20), SciQLopPlotRange must not parse garbage strings to NaN
+nor pretend NaN is 1970 in its repr, and plot removal must be free of
+abstract-method / removePlottable diagnostics noise.
+"""
+import numpy as np
+import pytest
+from PySide6.QtCore import qInstallMessageHandler
+
+from SciQLopPlots import GraphType, SciQLopPlotRange
+
+
+@pytest.fixture
+def qt_messages():
+    messages = []
+    previous = qInstallMessageHandler(
+        lambda mode, ctx, msg: messages.append(msg))
+    yield messages
+    qInstallMessageHandler(previous)
+
+
+def _x(n=50):
+    return np.linspace(0.0, 10.0, n)
+
+
+class TestGarbageDataRaises:
+    """Non-numeric buffers used to be swallowed to an empty PyBuffer at the
+    typesystem conversion, then silently no-op'd at set_data. The conversion
+    now sets a Python TypeError (the framework aborts the call), so direct
+    set_data raises. The provider pipeline path keeps its own drop-with-warning
+    guard, since those buffers are built in C++ and never hit the conversion."""
+
+    def test_line_graph_object_dtype_raises(self, plot):
+        x = _x()
+        graph = plot.line(x, np.sin(x))
+        with pytest.raises((TypeError, ValueError, RuntimeError)):
+            graph.set_data(x.astype(object), np.sin(x))
+
+    def test_line_graph_string_dtype_raises(self, plot):
+        x = _x()
+        graph = plot.line(x, np.sin(x))
+        with pytest.raises((TypeError, ValueError, RuntimeError)):
+            graph.set_data(np.array(["a"] * 50), np.sin(x))
+
+    def test_multigraph_object_dtype_raises(self, plot, sample_multicomponent_data):
+        x, y = sample_multicomponent_data
+        graph = plot.line(x, y)
+        with pytest.raises((TypeError, ValueError, RuntimeError)):
+            graph.set_data(x, y.astype(object))
+
+    def test_curve_object_dtype_raises(self, plot):
+        x = _x()
+        curve = plot.plot(x, np.sin(x), graph_type=GraphType.ParametricCurve)
+        with pytest.raises((TypeError, ValueError, RuntimeError)):
+            curve.set_data(x.astype(object), np.sin(x))
+
+    def test_colormap_object_dtype_raises(self, plot):
+        x = _x(32)
+        y = np.linspace(0.0, 1.0, 16)
+        z = np.random.default_rng(0).random((32, 16))
+        cm = plot.colormap(x, y, z)
+        with pytest.raises((TypeError, ValueError, RuntimeError)):
+            cm.set_data(x.astype(object), y, z)
+
+    def test_valid_data_still_works(self, plot):
+        x = _x()
+        graph = plot.line(x, np.sin(x))
+        graph.set_data(x, np.cos(x))  # no exception
+
+
+class TestRangeStringParsing:
+    """SciQLopPlotRange('garbage', 'dates') used to produce NaN bounds with a
+    repr formatting NaN as 1970-01-01 (epoch 0)."""
+
+    def test_garbage_date_strings_raise(self):
+        with pytest.raises((TypeError, ValueError, RuntimeError)):
+            SciQLopPlotRange("garbage", "dates")
+
+    def test_valid_date_strings_still_parse(self):
+        r = SciQLopPlotRange("2020-01-01", "2020-01-02")
+        assert r.start() < r.stop()
+        assert "2020-01-01" in repr(r)
+
+    def test_nan_time_range_repr_does_not_pretend_epoch(self):
+        r = SciQLopPlotRange(float("nan"), float("nan"), True)
+        assert "1970" not in repr(r)
+        assert "nan" in repr(r).lower()
+
+
+class TestRemovalDiagnostics:
+    """Removing a plot fired 'Abstract method called: ... plotRemoved' from
+    the axis synchronizers, and teardown paths spammed
+    'removePlottable ... not in list'."""
+
+    def test_remove_plot_is_diagnostic_clean(self, panel, qt_messages, qtbot):
+        x = _x()
+        plot, _ = panel.plot(x, np.sin(x))
+        panel.remove_plot(plot)
+        noise = [m for m in qt_messages
+                 if "Abstract method called" in m or "not in list" in m]
+        assert not noise, f"plot removal emitted diagnostics noise: {noise}"
+
+    def test_graph_replacement_is_diagnostic_clean(self, plot, qt_messages):
+        x = _x()
+        graph = plot.line(x, np.sin(x))
+        with pytest.raises((TypeError, ValueError, RuntimeError)):
+            graph.set_data(x.astype(object), np.sin(x))
+        noise = [m for m in qt_messages if "not in list" in m]
+        assert not noise, f"set_data emitted removePlottable noise: {noise}"


### PR DESCRIPTION
Four findings from the 2026-06-12 SciQLop user-API fuzzing campaign that were deferred to this repo (the SciQLop-side mitigations already shipped). None were urgent for SciQLop users, but all are real for anyone driving the bindings directly. Reproducers in `tests/integration/test_fuzzing_findings.py`. 740 integration + 114 unit green.

Best reviewed commit-by-commit.

### `5531d6a` — readable TypeError on binding misuse, not a masking NameError (finding #1)

The highest-value one: *any* wrong-argument call to a `SciQLopPlotsBindings` class raised `NameError: name 'SciQLopPlotsBindings' is not defined` instead of a TypeError listing the accepted overloads — so nearly every binding mistake was undiagnosable.

Root cause: shiboken's signature error-formatter resolves parameter type strings via per-module `init_<module>` hooks that ship **inside shibokensupport for PySide6's own modules only** (`init_PySide6_QtCore`, …). A third-party module gets none, so its name is absent from the eval namespace. We supply that registration from `__init__` — the glue PySide6 gets for free, written in Python:

- register the binding module so `SciQLopPlotsBindings.<Type>` resolves;
- register the two `<primitive-type>` decls (`SciQLopPyBuffer`, `GetDataPyCallable`) in the type map — without a Python type they resolve to a bare `str` and shiboken's matcher **hard-aborts the interpreter** (`the_type.__module__` on a str), strictly worse than the NameError;
- mute the one-time `pyside_type_init` RuntimeWarning from a global-enum default rendered as `.GraphMarkerShape.NoMarker` (leading dot the parser can't eval), so it doesn't bury the now-useful message.

All guarded by try/except: if shiboken internals shift across PySide6 versions, errors degrade to ugly-again rather than breaking import. The previously-crashing `test_p1_bugs::test_2arg_colormap_raises` now passes cleanly.

### `b730e08` — garbage data, range strings, removal noise (#2, #4, #5)

**#2 garbage data silently no-op'd.** A non-numeric numpy array exports the buffer protocol, so the typesystem conversion built an empty `SciQLopPyBuffer` (the ctor's "numeric type" throw was swallowed) and every `set_data` hit its `is_valid()` early-return — a silent no-op. The conversion now sets a Python `TypeError` (which the framework's post-conversion `Errors::occurred()` check turns into a clean raise) instead of swallowing. Throwing in the conversion itself would `std::terminate` — it runs *before* the call's try/catch. `set_data` keeps its `is_valid()` no-op for the legitimate empty-buffer paths (`None`, and the internal "create empty curve, fill later" in `SciQLopNDProjectionCurves`); the provider pipeline is unaffected (those buffers are built in C++, never hit the conversion). TypeError, not ValueError, to match the existing `validate_buffer` taxonomy.

**#4 `SciQLopPlotRange("garbage","dates")`** produced NaN bounds whose repr formatted NaN through `from_time_t` as `1970-01-01` (UB). The string ctor now raises on unparsable input; `__repr__` prints the raw NaN.

**#5 removal diagnostics.** Every `remove_plot` fired `Abstract method called: ...plotRemoved` from the axis synchronizers (`AxisSynchronizer` never overrode the warn-only base, though `updatePlotList` already does the work), and plottable dtors spammed `removePlottable ... not in list`. Added the no-op override and guarded each `removePlottable` with `hasPlottable()`.

### Still open (documented, not in this PR)

Finding #3 — item ctors don't auto-deref `SciQLopPlotInterfacePtr` (the smart-pointer `panel.plots()` returns); ergonomics, needs a typesystem conversion rule. SciQLop derefs on its side, so non-urgent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)