### PR TITLE
feat(api): auto-deref the QPointer wrappers plots() returns (fuzzing finding #3)

### DIFF
--- a/SciQLopPlots/__init__.py
+++ b/SciQLopPlots/__init__.py
@@ -285,21 +285,21 @@ for _cls in (
 #     (raw pointer or auto-deref'd Ptr) is unaffected.
 import functools
 
-_PLOT_PTR_TYPES = (
+_PTR_HANDLE_TYPES = (
     SciQLopPlotsBindings.SciQLopPlotInterfacePtr,
     SciQLopPlotsBindings.MultiPlotsVerticalSpanPtr,
 )
 
 
-def _deref_plot_ptr(value):
-    return value.data() if isinstance(value, _PLOT_PTR_TYPES) else value
+def _deref_ptr_handle(value):
+    return value.data() if isinstance(value, _PTR_HANDLE_TYPES) else value
 
 
-def _accept_plot_ptr(func):
+def _accept_ptr_handle(func):
     @functools.wraps(func)
     def wrapper(*args, **kwargs):
-        return func(*(_deref_plot_ptr(a) for a in args),
-                    **{k: _deref_plot_ptr(v) for k, v in kwargs.items()})
+        return func(*(_deref_ptr_handle(a) for a in args),
+                    **{k: _deref_ptr_handle(v) for k, v in kwargs.items()})
     return wrapper
 
 
@@ -315,9 +315,9 @@ for _item_cls in (
     SciQLopPlotsBindings.SciQLopHorizontalSpan,
     SciQLopPlotsBindings.SciQLopRectangularSpan,
 ):
-    _item_cls.__init__ = _accept_plot_ptr(_item_cls.__init__)
+    _item_cls.__init__ = _accept_ptr_handle(_item_cls.__init__)
 
 for _method in ("add_plot", "remove_plot", "insert_plot", "move_plot", "index", "contains"):
     setattr(SciQLopMultiPlotPanel, _method,
-            _accept_plot_ptr(getattr(SciQLopMultiPlotPanel, _method)))
+            _accept_ptr_handle(getattr(SciQLopMultiPlotPanel, _method)))
 

--- a/SciQLopPlots/__init__.py
+++ b/SciQLopPlots/__init__.py
@@ -267,3 +267,57 @@ for _cls in (
 ):
     _cls.on = OnDescriptor()
 
+
+# --- Accept the QPointer wrappers panel.plots() returns wherever a raw plot
+#     pointer is expected (item/span constructors, panel plot-management
+#     methods). shiboken cannot implicitly convert an object-type smart pointer,
+#     so we dereference it here instead of forcing callers to write .data().
+#
+#     A Ptr is matched by isinstance against the registered smart-pointer types —
+#     NEVER by probing for a .data() member: QByteArray, QModelIndex, ndarray and
+#     many others expose .data() and would be silently corrupted by a duck-typed
+#     check.
+#
+#     Tradeoff: routing a ctor through a Python wrapper bypasses shiboken's
+#     tp_init, so a *wrong-args* call to a wrapped entry point yields a terser
+#     "(missing signature)" TypeError instead of the "Supported signatures"
+#     listing. Still a TypeError, never the old NameError; the happy path
+#     (raw pointer or auto-deref'd Ptr) is unaffected.
+import functools
+
+_PLOT_PTR_TYPES = (
+    SciQLopPlotsBindings.SciQLopPlotInterfacePtr,
+    SciQLopPlotsBindings.MultiPlotsVerticalSpanPtr,
+)
+
+
+def _deref_plot_ptr(value):
+    return value.data() if isinstance(value, _PLOT_PTR_TYPES) else value
+
+
+def _accept_plot_ptr(func):
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        return func(*(_deref_plot_ptr(a) for a in args),
+                    **{k: _deref_plot_ptr(v) for k, v in kwargs.items()})
+    return wrapper
+
+
+for _item_cls in (
+    SciQLopPlotsBindings.SciQLopTextItem,
+    SciQLopPlotsBindings.SciQLopPixmapItem,
+    SciQLopPlotsBindings.SciQLopEllipseItem,
+    SciQLopPlotsBindings.SciQLopCurvedLineItem,
+    SciQLopPlotsBindings.SciQLopStraightLine,
+    SciQLopPlotsBindings.SciQLopVerticalLine,
+    SciQLopPlotsBindings.SciQLopHorizontalLine,
+    SciQLopPlotsBindings.SciQLopVerticalSpan,
+    SciQLopPlotsBindings.SciQLopHorizontalSpan,
+    SciQLopPlotsBindings.SciQLopRectangularSpan,
+):
+    _item_cls.__init__ = _accept_plot_ptr(_item_cls.__init__)
+
+for _method in ("add_plot", "remove_plot", "insert_plot", "move_plot", "index", "contains"):
+    setattr(SciQLopMultiPlotPanel, _method,
+            _accept_plot_ptr(getattr(SciQLopMultiPlotPanel, _method)))
+

--- a/tests/integration/test_fuzzing_findings.py
+++ b/tests/integration/test_fuzzing_findings.py
@@ -106,7 +106,8 @@ class TestInterfacePtrAutoDeref:
     """``panel.plots()`` returns ``SciQLopPlotInterfacePtr`` (QPointer) wrappers.
     Passing one where a plot pointer is expected used to require a manual
     ``ptr.data()`` — shiboken doesn't implicitly deref the smart pointer
-    (finding #3). The typesystem now accepts the Ptr directly."""
+    (finding #3). A Python-level wrapper in ``SciQLopPlots/__init__.py`` now
+    auto-dereferences the Ptr before calling the bound API."""
 
     def _panel_with_plot(self, qtbot):
         panel = SciQLopMultiPlotPanel()

--- a/tests/integration/test_fuzzing_findings.py
+++ b/tests/integration/test_fuzzing_findings.py
@@ -8,7 +8,13 @@ import numpy as np
 import pytest
 from PySide6.QtCore import qInstallMessageHandler
 
-from SciQLopPlots import GraphType, SciQLopHorizontalLine, SciQLopPlotRange
+from SciQLopPlots import (
+    GraphType,
+    SciQLopHorizontalLine,
+    SciQLopMultiPlotPanel,
+    SciQLopPlotRange,
+    SciQLopVerticalLine,
+)
 
 
 @pytest.fixture
@@ -71,21 +77,63 @@ class TestGarbageDataRaises:
 
 class TestOverloadErrorMessage:
     """A wrong-argument call on a SciQLopPlotsBindings class must produce a
-    real TypeError listing the accepted overloads — not the NameError that
-    shiboken's signature formatter throws when it can't resolve the binding
-    module name in its eval namespace (report #2 / finding #1)."""
+    real TypeError — not the NameError that shiboken's signature formatter
+    throws when it can't resolve the binding module name in its eval namespace
+    (report #2 / finding #1)."""
 
     def test_wrong_args_raise_typeerror_not_nameerror(self):
+        # Item ctors are Python-wrapped for Ptr auto-deref (finding #3), which
+        # routes around shiboken's tp_init: still a TypeError, never NameError.
         with pytest.raises(TypeError):
             SciQLopHorizontalLine("not a plot", 5.0)
 
     def test_error_message_lists_supported_signatures(self):
+        # An unwrapped overloaded method keeps shiboken's rich error listing.
+        from PySide6.QtWidgets import QApplication
+        from SciQLopPlots import SciQLopPlot
+        QApplication.instance() or QApplication([])
+        plot = SciQLopPlot()
+        x = _x()
         try:
-            SciQLopHorizontalLine("not a plot", 5.0)
+            plot.colormap(x, np.sin(x))  # 2-arg colormap needs (x, y, z)
         except TypeError as e:
             assert "Supported signatures" in str(e), str(e)
         except NameError as e:
             pytest.fail(f"shiboken signature formatter raised NameError: {e}")
+
+
+class TestInterfacePtrAutoDeref:
+    """``panel.plots()`` returns ``SciQLopPlotInterfacePtr`` (QPointer) wrappers.
+    Passing one where a plot pointer is expected used to require a manual
+    ``ptr.data()`` — shiboken doesn't implicitly deref the smart pointer
+    (finding #3). The typesystem now accepts the Ptr directly."""
+
+    def _panel_with_plot(self, qtbot):
+        panel = SciQLopMultiPlotPanel()
+        qtbot.addWidget(panel)
+        x = _x()
+        panel.plot(x, np.sin(x))
+        return panel
+
+    def test_ptr_accepted_by_item_ctor(self, qtbot):
+        panel = self._panel_with_plot(qtbot)
+        ptr = panel.plots()[0]
+        # SciQLopVerticalLine(SciQLopPlot*, ...) — derived-pointer param
+        line = SciQLopVerticalLine(ptr, 5.0)
+        assert line is not None
+
+    def test_ptr_accepted_by_base_interface_param(self, qtbot):
+        panel = self._panel_with_plot(qtbot)
+        ptr = panel.plots()[0]
+        # remove_plot(SciQLopPlotInterface*) — base-pointer param
+        panel.remove_plot(ptr)
+        assert len(panel.plots()) == 0
+
+    def test_raw_plot_still_accepted(self, qtbot):
+        panel = self._panel_with_plot(qtbot)
+        raw = panel.plots()[0].data()
+        line = SciQLopVerticalLine(raw, 5.0)
+        assert line is not None
 
 
 class TestRangeStringParsing:


### PR DESCRIPTION
Last of the 2026-06-12 fuzzing-campaign findings. `panel.plots()` returns `SciQLopPlotInterfacePtr` (QPointer) wrappers, but the item/span constructors and the panel plot-management methods take a raw plot pointer — so callers had to remember `.data()`:

```python
ptr = panel.plots()[0]
SciQLopVerticalLine(ptr, 5.0)       # before: TypeError
SciQLopVerticalLine(ptr.data(), 5.0)  # had to write this
```

## Why it's done in Python, not the typesystem
The backlog assumed "a typesystem conversion rule would fix it." It can't: shiboken **rejects `<conversion-rule>` on an `object-type`** (`Conversion rules can only be specified for argument modification, value-type, primitive-type, container-type or smartpointer-type`) — object types are identity-based pointers with no notion of an implicit conversion *to* them. The per-argument route would mean repeating a conversion on ~16 signatures plus every future one. So the deref is done once at import in `__init__.py` (where the bindings are already patched).

## What it does
The item/span ctors (`SciQLopTextItem`, `SciQLopPixmapItem`, `SciQLopEllipseItem`, `SciQLopCurvedLineItem`, `SciQLopStraightLine`/`Vertical`/`Horizontal`Line, `SciQLopVerticalSpan`/`Horizontal`/`Rectangular`Span) and the panel methods (`add_plot`/`remove_plot`/`insert_plot`/`move_plot`/`index`/`contains`) dereference any `Ptr` argument before calling through.

A `Ptr` is matched by **`isinstance` against the registered smart-pointer types, never by probing for a `.data()` member** — `QByteArray`, `QModelIndex`, `ndarray` and many others expose `.data()` and a duck-typed check would silently corrupt them. (Verified: those pass through untouched.)

## Tradeoff (please weigh in)
Routing a ctor through a Python wrapper bypasses shiboken's `tp_init`, so a **wrong-args** call to a wrapped entry point now yields a terser `"... is wrong (missing signature)"` `TypeError` instead of the `"Supported signatures: ..."` listing that PR #84 (finding #1) added. It's still a `TypeError` (never the old `NameError`), and the happy path — raw pointer or auto-deref'd `Ptr` — is unaffected. The #1 rich-error guarantee is still verified on an unwrapped method. If you'd rather keep the richer ctor errors than the auto-deref convenience, this is easy to scope down to the panel methods only (or revert).

Reproducers in `tests/integration/test_fuzzing_findings.py::TestInterfacePtrAutoDeref`. 743 integration + 114 unit green. Pure-Python change — no extension rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)