### PR TITLE
fix(colorbar): adaptive tick-label precision so labels stay distinct

### DIFF
--- a/include/SciQLopPlots/SciQLopPlotAxis.hpp
+++ b/include/SciQLopPlots/SciQLopPlotAxis.hpp
@@ -357,6 +357,14 @@ public:
     QCPAxis* qcp_axis() const noexcept override;
     QCPColorScale* qcp_colorscale() const noexcept;
 
+private:
+    // Pick the tick-label precision so adjacent labels stay distinct: log keeps
+    // precision 0 (clean decade powers), linear adapts to the current range so
+    // closely-spaced values (e.g. a small range around a huge value) don't all
+    // render to the same significant figure.
+    void update_number_precision() noexcept;
+
+public:
 
 #ifdef BINDINGS_H
 #define Q_SIGNAL

--- a/src/SciQLopPlot.cpp
+++ b/src/SciQLopPlot.cpp
@@ -76,9 +76,8 @@ SciQLopPlot::SciQLopPlot(QWidget* parent) : QCustomPlot { parent }
 
     m_color_scale = new QCPColorScale(this);
     m_color_scale->setVisible(false);
-    m_color_scale->axis()->setNumberFormat("gb");
-
-    m_color_scale->axis()->setNumberPrecision(0);
+    // Number format + precision are managed adaptively by SciQLopPlotColorScaleAxis
+    // (precision 0 here would render closely-spaced linear ticks all identical).
 
     connect(m_color_scale->axis(), QOverload<const QCPRange&>::of(&QCPAxis::rangeChanged), this,
             [this](const QCPRange& range)

--- a/src/SciQLopPlotAxis.cpp
+++ b/src/SciQLopPlotAxis.cpp
@@ -470,9 +470,45 @@ SciQLopPlotColorScaleAxis::SciQLopPlotColorScaleAxis(QCPColorScale* axis, QObjec
                                                      const QString& name)
         : SciQLopPlotAxis(axis->axis(), parent, false, name), m_axis(axis)
 {
+    if (axis->axis())
+        axis->axis()->setNumberFormat("gb");
     connect(axis, QOverload<const QCPRange&>::of(&QCPColorScale::dataRangeChanged), this,
             [this](const QCPRange& range)
-            { Q_EMIT range_changed(SciQLopPlotRange { range.lower, range.upper }); });
+            {
+                update_number_precision();
+                Q_EMIT range_changed(SciQLopPlotRange { range.lower, range.upper });
+            });
+    update_number_precision();
+}
+
+void SciQLopPlotColorScaleAxis::update_number_precision() noexcept
+{
+    if (m_axis.isNull() || !m_axis->axis())
+        return;
+    auto* ax = m_axis->axis();
+    int precision = 0; // log: clean decade powers (1e3, 1e4, ...)
+    // Use the color scale's dataScaleType (the source of truth this wrapper
+    // drives), not the axis scaleType, so the two can't disagree.
+    if (m_axis->dataScaleType() != QCPAxis::stLogarithmic)
+    {
+        const QCPRange r = ax->range();
+        const double span = r.size();
+        const double maxabs = std::max(std::abs(r.lower), std::abs(r.upper));
+        precision = 4;
+        if (span > 0.0 && maxabs > 0.0)
+        {
+            // Enough significant figures that adjacent ticks (≈ span/5 apart)
+            // stay distinct. Clamp in floating point BEFORE the int cast: an
+            // extreme tiny span makes 5*maxabs/span overflow to inf, and
+            // static_cast<int> of a non-finite/out-of-range double is UB.
+            const double sig = std::log10(5.0 * maxabs / span) + 1.0;
+            precision = std::isfinite(sig)
+                ? static_cast<int>(std::clamp(std::ceil(sig), 3.0, 15.0))
+                : 15; // values nearly identical relative to magnitude: max sig figs
+        }
+    }
+    if (ax->numberPrecision() != precision)
+        ax->setNumberPrecision(precision);
 }
 
 void SciQLopPlotColorScaleAxis::set_range(const SciQLopPlotRange& range) noexcept
@@ -517,6 +553,7 @@ void SciQLopPlotColorScaleAxis::set_log(bool log) noexcept
                     QSharedPointer<QCPAxisTicker>(new QCPAxisTicker));
             }
         }
+        update_number_precision();  // log -> clean powers, linear -> adaptive
         m_axis->parentPlot()->replot(QCustomPlot::rpQueuedReplot);
         Q_EMIT log_changed(log);
     }


### PR DESCRIPTION
## Problem
The color scale (colorbar) tick labels sometimes all render **identical**, making the scale unreadable:
- a **linear** color scale around `1000` showed `1e+03` on every tick;
- a small range around a huge value, e.g. `[1e9, 1.001e9]`, showed `1e+09` on every tick.

Root cause: the colorbar axis hardcoded `setNumberPrecision(0)` (1 significant figure). That's correct for **log decade** ticks (clean powers `1e3`, `1e4`), but on a **linear** scale every closely-spaced tick collapses to the same single significant figure. `set_log` never adjusted precision either.

## Fix
Number-format management moves into `SciQLopPlotColorScaleAxis`, choosing precision adaptively:
- **log** → precision `0` (clean decade powers, unchanged);
- **linear** → `clamp(⌈log10(5·max|v| / span)⌉ + 1, 3, 15)` derived from the current range, so adjacent ticks always differ — recomputed on every data-range change (zoom/pan) and on log↔linear toggle, and in the constructor.

The hardcoded format/precision is removed from `SciQLopPlot.cpp`. 3 files, ~39 lines.

## Verification (rendered colorbars)
- linear `[1000, 1000.5]` → `1000.1 / 1000.2 / 1000.3 / 1000.4`
- linear `[1e9, 1.001e9]` → `1.0002e+09 / 1.0004e+09 / …`
- log decades → `1e+02 / 1e+01 / 1 / 0.1 / 0.01` (unchanged)
- 59 colormap/axis integration tests pass.

(Rendered tick labels aren't introspectable from the Python test layer, so verification was visual via `save_png`; no unit test added.)

> Note: building this against the current NeoQCP `main` also picks up the merged colormap pan-translation fix (SciQLop/NeoQCP#36) via the `revision=main` wrap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)