### PR TITLE
feat: remote data channels for out-of-process plugins

### DIFF
--- a/SciQLopPlots/bindings/bindings.xml
+++ b/SciQLopPlots/bindings/bindings.xml
@@ -510,8 +510,12 @@
     </object-type>
 
     <object-type name="SciQLopFunctionGraph" parent-management="no"/>
+    <object-type name="SciQLopRemoteGraph" parent-management="no"/>
 
     <object-type name="SciQLopLineGraphFunction" parent-management="yes">
+        <property name="name" type="QString" get="objectName" set="setObjectName" generate-getsetdef="yes"/>
+    </object-type>
+    <object-type name="SciQLopLineGraphRemote" parent-management="yes">
         <property name="name" type="QString" get="objectName" set="setObjectName" generate-getsetdef="yes"/>
     </object-type>
     <object-type name="SciQLopSingleLineGraphFunction" parent-management="yes">
@@ -952,6 +956,8 @@
     <object-type name="VPlotsAlign" parent-management="yes">
     </object-type>
     <object-type name="DataProviderInterface" parent-management="yes">
+    </object-type>
+    <object-type name="RemoteDataPipeline" parent-management="yes">
     </object-type>
     <object-type name="DataProviderWorker" parent-management="yes">
         <modify-function signature="set_data_provider(DataProviderInterface*)">

--- a/SciQLopPlots/bindings/bindings.xml
+++ b/SciQLopPlots/bindings/bindings.xml
@@ -524,13 +524,25 @@
     <object-type name="SciQLopCurveFunction" parent-management="yes">
         <property name="name" type="QString" get="objectName" set="setObjectName" generate-getsetdef="yes"/>
     </object-type>
+    <object-type name="SciQLopCurveRemote" parent-management="yes">
+        <property name="name" type="QString" get="objectName" set="setObjectName" generate-getsetdef="yes"/>
+    </object-type>
     <object-type name="SciQLopColorMapFunction" parent-management="yes">
+        <property name="name" type="QString" get="objectName" set="setObjectName" generate-getsetdef="yes"/>
+    </object-type>
+    <object-type name="SciQLopColorMapRemote" parent-management="yes">
         <property name="name" type="QString" get="objectName" set="setObjectName" generate-getsetdef="yes"/>
     </object-type>
     <object-type name="SciQLopHistogram2DFunction" parent-management="yes">
         <property name="name" type="QString" get="objectName" set="setObjectName" generate-getsetdef="yes"/>
     </object-type>
+    <object-type name="SciQLopHistogram2DRemote" parent-management="yes">
+        <property name="name" type="QString" get="objectName" set="setObjectName" generate-getsetdef="yes"/>
+    </object-type>
     <object-type name="SciQLopWaterfallGraphFunction" parent-management="yes">
+        <property name="name" type="QString" get="objectName" set="setObjectName" generate-getsetdef="yes"/>
+    </object-type>
+    <object-type name="SciQLopWaterfallGraphRemote" parent-management="yes">
         <property name="name" type="QString" get="objectName" set="setObjectName" generate-getsetdef="yes"/>
     </object-type>
 

--- a/docs/superpowers/plans/2026-06-20-remote-data-provider.md
+++ b/docs/superpowers/plans/2026-06-20-remote-data-provider.md
@@ -668,11 +668,13 @@ The line-graph slice proves the pattern end-to-end. The remaining graph types ea
 
 | Function class | Remote twin | N |
 |---|---|---|
-| `SciQLopSingleLineGraphFunction` | `SciQLopSingleLineGraphRemote` | 2 |
+| `SciQLopSingleLineGraphFunction` | _(folded into `SciQLopLineGraphRemote` — the multi-line remote handles single-component data; a separate variant would be redundant)_ | — |
 | `SciQLopCurveFunction` | `SciQLopCurveRemote` | 2 |
 | `SciQLopColorMapFunction` | `SciQLopColorMapRemote` | 3 |
-| `SciQLopHistogram2DFunction` | `SciQLopHistogram2DRemote` | 3 |
-| `SciQLopWaterfallGraphFunction` | `SciQLopWaterfallGraphRemote` | 3 (verify) |
+| `SciQLopHistogram2DFunction` | `SciQLopHistogram2DRemote` | 2 |
+| `SciQLopWaterfallGraphFunction` | `SciQLopWaterfallGraphRemote` | 2 |
+
+(N = output arity, taken from each `*Function` ctor's `SciQLopFunctionGraph(callable, this, N)`: only the colormap returns 3 buffers; histogram2d and waterfall return 2.)
 
 - [ ] For each: add the concrete class (header+cpp) mirroring Task 4, add an `add_remote_*` factory mirroring Task 7, bind it (Task 5 pattern), and add a `set_data`-delivers test mirroring Task 6.
 - [ ] Verify the correct `N` (output arity) per type by checking the `N` its `*Function` ctor passes to `SciQLopFunctionGraph`.

--- a/docs/superpowers/plans/2026-06-20-remote-data-provider.md
+++ b/docs/superpowers/plans/2026-06-20-remote-data-provider.md
@@ -1,0 +1,689 @@
+# RemoteDataProvider Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a transport-agnostic `RemoteDataProvider` that inverts the `plot(callback)` data direction — emit a range request *outward* and receive final buffers *inward* — so slow, pure-Python plugins can run out-of-process without holding SciQLop's GIL.
+
+**Architecture:** A new `DataProviderInterface` subclass reuses the existing worker thread + rate-limit/pending machinery. Its range `get_data` **emits a signal** instead of running a callable and returns no synchronous data; its buffer `get_data` overrides **pass the incoming buffers straight through** as final output. A `RemoteDataPipeline` (the bound "channel" object) re-exposes `data_requested` out and `set_data(...)` in. A `SciQLopRemoteGraph` mixin wires it to a graph, marking busy on request and clearing it on data arrival. The first vertical slice targets the line graph; other graph types replicate the same pattern.
+
+**Tech Stack:** C++20, Qt6 (QObject/signals/threads), Shiboken6 bindings, Meson `build-venv`, pytest integration tests.
+
+---
+
+## Background the implementer must know
+
+**Build & test (from `CLAUDE.md`):** never run a bare `meson setup build`. Use the in-tree `.venv` + `build-venv`:
+
+```bash
+cd /var/home/jeandet/Documents/prog/SciQLopPlots
+VENV=$(pwd)/.venv
+export PATH="$VENV/bin:/home/jeandet/Qt/6.11.1/gcc_64/bin:/home/jeandet/Qt/6.11.0/gcc_64/bin:$PATH"
+export PKG_CONFIG_PATH="/home/jeandet/Qt/6.11.1/gcc_64/lib/pkgconfig:$PKG_CONFIG_PATH"
+$VENV/bin/meson compile -C build-venv
+# run tests from /tmp so the source pkg doesn't shadow the build:
+cd /tmp && PYTHONPATH=/var/home/jeandet/Documents/prog/SciQLopPlots/build-venv \
+  $VENV/bin/python -m pytest /var/home/jeandet/Documents/prog/SciQLopPlots/tests/integration -q
+```
+
+**Shiboken quirks (from project memory):**
+- After editing any Python-exposed header, **`touch SciQLopPlots/bindings/bindings.xml`** — the meson custom_target does not track headers.
+- Each `<add-function>` needs its **own try/catch** in its `<inject-code>`, or a thrown `std::exception` escapes to `std::terminate`.
+- A stale shiboken wrapper after structural changes: `rm` the offending `build-venv/SciQLopPlots/bindings/.../*_wrapper.cpp` and `meson setup --reconfigure build-venv`.
+
+**Key existing code to mirror (read these first):**
+- `include/SciQLopPlots/DataProducer/DataProducer.hpp` — `DataProviderInterface`, `DataProviderWorker`, `SimplePyCallablePWrapper`, `SimplePyCallablePipeline`.
+- `src/DataProducer.cpp` — `_range_based_update` (calls `get_data(start,stop)` then `_notify_new_data`), `_data_based_update(_2D_data)` (calls `get_data(x,y)` — this is why the remote buffer override must pass through), `SimplePyCallablePipeline` ctor wiring.
+- `include/SciQLopPlots/Plotables/SciQLopGraphInterface.hpp` — `SciQLopFunctionGraph` mixin (note: **not** a QObject; `call(range)` sets `as_graph->set_busy(true)`).
+- `src/SciQLopGraphInterface.cpp` — `SciQLopFunctionGraph` ctor: the `drop_bad_batch` guard + switch on N wiring `new_data_* → graph.set_data`, `pipeline_idle → set_busy(false)`, `range_changed → pipeline.call(range)`.
+- `include/SciQLopPlots/Plotables/SciQLopLineGraph.hpp` + `src/SciQLopLineGraph.cpp` — `SciQLopLineGraphFunction` (multiple-inherits `SciQLopLineGraph` + `SciQLopFunctionGraph`).
+
+**The two semantic differences from the callable path (the whole point):**
+1. Range request: `get_data(lower, upper)` **emits `data_requested(range)` and returns `{}`** (no synchronous data; the answer arrives later via `set_data`).
+2. Buffer delivery: `get_data(x,y)` / `(x,y,z)` / `(nd)` **return their inputs unchanged** (the incoming buffers *are* the final output), so `_data_based_update → _notify_new_data` emits `new_data_*`.
+3. Busy spans request→response: set busy on `call(range)`, clear on `new_data_*` (do **not** wire `pipeline_idle → set_busy(false)` for remote — `pipeline_idle` fires right after the request is emitted).
+
+---
+
+## File structure
+
+- **Modify** `include/SciQLopPlots/DataProducer/DataProducer.hpp` — add `RemoteDataProvider` (provider subclass) and `RemoteDataPipeline` (channel wrapper). Both belong here next to `SimplePyCallablePipeline`; they share the worker/rate-limit machinery declared in this file.
+- **Modify** `src/DataProducer.cpp` — `RemoteDataProvider` method bodies + `RemoteDataPipeline` ctor wiring.
+- **Modify** `include/SciQLopPlots/Plotables/SciQLopGraphInterface.hpp` — add `SciQLopRemoteGraph` mixin (sibling of `SciQLopFunctionGraph`) + a small shared templated free function `connect_pipeline_data_to_graph` (extracted from the existing ctor; DRY because the `drop_bad_batch` switch is identical and tricky).
+- **Modify** `src/SciQLopGraphInterface.cpp` — define `connect_pipeline_data_to_graph`, refactor `SciQLopFunctionGraph` ctor to use it, define `SciQLopRemoteGraph` ctor.
+- **Modify** `include/SciQLopPlots/Plotables/SciQLopLineGraph.hpp` + `src/SciQLopLineGraph.cpp` — add `SciQLopLineGraphRemote` (mirror of `SciQLopLineGraphFunction`).
+- **Modify** `SciQLopPlots/bindings/bindings.xml` — expose `RemoteDataPipeline` (signal `data_requested`, slots `set_data`), `SciQLopRemoteGraph` accessor, `SciQLopLineGraphRemote`.
+- **Create** `tests/integration/test_remote_data_provider.py` — the integration tests (in-process, no real IPC).
+
+---
+
+## Task 1: Core primitive — `RemoteDataProvider` + `RemoteDataPipeline`
+
+**Files:**
+- Modify: `include/SciQLopPlots/DataProducer/DataProducer.hpp`
+- Modify: `src/DataProducer.cpp`
+
+- [ ] **Step 1: Declare `RemoteDataProvider` in the header**
+
+In `DataProducer.hpp`, after the `SimplePyCallablePWrapper` class, add:
+
+```cpp
+// A provider that does not compute: it emits a request for a range and waits.
+// Range get_data emits data_requested and returns nothing (the answer arrives
+// later via set_data). Buffer get_data overrides pass their inputs straight
+// through, so the existing _data_based_update push path turns an incoming
+// set_data(x,y) into new_data_2d(x,y) with no transformation.
+class RemoteDataProvider : public DataProviderInterface
+{
+    Q_OBJECT
+public:
+    RemoteDataProvider(QObject* parent = nullptr) : DataProviderInterface(parent) { }
+    virtual ~RemoteDataProvider() = default;
+
+    inline QList<SciQLopPyBuffer> get_data(double lower, double upper) override
+    {
+        Q_EMIT data_requested(SciQLopPlotRange { lower, upper });
+        return {}; // no synchronous data; response arrives via set_data
+    }
+
+    inline QList<SciQLopPyBuffer> get_data(SciQLopPyBuffer x, SciQLopPyBuffer y) override
+    {
+        return { x, y };
+    }
+
+    inline QList<SciQLopPyBuffer> get_data(SciQLopPyBuffer x, SciQLopPyBuffer y,
+                                           SciQLopPyBuffer z) override
+    {
+        return { x, y, z };
+    }
+
+    inline QList<SciQLopPyBuffer> get_data(QList<SciQLopPyBuffer> values) override
+    {
+        return values;
+    }
+
+#ifdef BINDINGS_H
+#define Q_SIGNAL
+signals:
+#endif
+    Q_SIGNAL void data_requested(const SciQLopPlotRange& range);
+};
+```
+
+- [ ] **Step 2: Declare `RemoteDataPipeline` in the header**
+
+After `SimplePyCallablePipeline`, add the channel wrapper:
+
+```cpp
+// The bound "channel" object. One per remote product. data_requested goes out
+// (SciQLop forwards it to the worker process); set_data(...) brings the final
+// buffers back in.
+class RemoteDataPipeline : public QObject
+{
+    Q_OBJECT
+    RemoteDataProvider* m_provider;
+    DataProviderWorker* m_worker;
+
+public:
+    RemoteDataPipeline(QObject* parent = nullptr);
+    virtual ~RemoteDataPipeline() = default;
+
+    inline Q_SLOT void call(const SciQLopPlotRange& range) { m_worker->set_range(range); }
+
+    inline Q_SLOT void set_data(SciQLopPyBuffer x, SciQLopPyBuffer y)
+    {
+        m_worker->set_data(x, y);
+    }
+    inline Q_SLOT void set_data(SciQLopPyBuffer x, SciQLopPyBuffer y, SciQLopPyBuffer z)
+    {
+        m_worker->set_data(x, y, z);
+    }
+    inline Q_SLOT void set_data(QList<SciQLopPyBuffer> values) { m_worker->set_data(values); }
+
+    inline void invalidate_cache() { m_provider->invalidate_cache(); }
+
+#ifdef BINDINGS_H
+#define Q_SIGNAL
+signals:
+#endif
+    Q_SIGNAL void data_requested(const SciQLopPlotRange& range);
+    Q_SIGNAL void new_data_3d(SciQLopPyBuffer x, SciQLopPyBuffer y, SciQLopPyBuffer z);
+    Q_SIGNAL void new_data_2d(SciQLopPyBuffer x, SciQLopPyBuffer y);
+    Q_SIGNAL void new_data_nd(QList<SciQLopPyBuffer> values);
+    Q_SIGNAL void pipeline_idle();
+};
+```
+
+- [ ] **Step 3: Define `RemoteDataPipeline` ctor in `src/DataProducer.cpp`**
+
+At the end of the file, mirroring `SimplePyCallablePipeline`'s ctor but also forwarding `data_requested`:
+
+```cpp
+RemoteDataPipeline::RemoteDataPipeline(QObject* parent) : QObject(parent)
+{
+    m_provider = new RemoteDataProvider(this);
+    m_worker = new DataProviderWorker(this);
+    m_worker->set_data_provider(m_provider);
+    connect(m_provider, &RemoteDataProvider::data_requested, this,
+            &RemoteDataPipeline::data_requested);
+    connect(m_provider, &RemoteDataProvider::new_data_2d, this,
+            &RemoteDataPipeline::new_data_2d);
+    connect(m_provider, &RemoteDataProvider::new_data_3d, this,
+            &RemoteDataPipeline::new_data_3d);
+    connect(m_provider, &RemoteDataProvider::new_data_nd, this,
+            &RemoteDataPipeline::new_data_nd);
+    connect(m_provider, &RemoteDataProvider::pipeline_idle, this,
+            &RemoteDataPipeline::pipeline_idle);
+}
+```
+
+Note: `set_data_provider` reparents the provider to nullptr then moves it to the worker thread (see existing impl), so `new RemoteDataProvider(this)` parentage is intentionally dropped — identical to how `SimplePyCallablePWrapper` is handled.
+
+- [ ] **Step 4: Build**
+
+Run:
+```bash
+cd /var/home/jeandet/Documents/prog/SciQLopPlots && VENV=$(pwd)/.venv && \
+export PATH="$VENV/bin:/home/jeandet/Qt/6.11.1/gcc_64/bin:/home/jeandet/Qt/6.11.0/gcc_64/bin:$PATH" && \
+export PKG_CONFIG_PATH="/home/jeandet/Qt/6.11.1/gcc_64/lib/pkgconfig:$PKG_CONFIG_PATH" && \
+$VENV/bin/meson compile -C build-venv
+```
+Expected: compiles clean (no Python surface yet — pure C++).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add include/SciQLopPlots/DataProducer/DataProducer.hpp src/DataProducer.cpp
+git commit -m "feat(remote): add RemoteDataProvider + RemoteDataPipeline core primitive
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Shared `connect_pipeline_data_to_graph` helper + refactor `SciQLopFunctionGraph`
+
+This extracts the identical `drop_bad_batch`+switch wiring so the remote adapter reuses it. Templated on the pipeline type because `SimplePyCallablePipeline` and `RemoteDataPipeline` expose the same `new_data_*` signals.
+
+**Files:**
+- Modify: `include/SciQLopPlots/Plotables/SciQLopGraphInterface.hpp`
+- Modify: `src/SciQLopGraphInterface.cpp`
+
+- [ ] **Step 1: Declare the helper in the header**
+
+In `SciQLopGraphInterface.hpp`, above `class SciQLopFunctionGraph`, add a templated free function declaration + definition (header-defined because it is templated):
+
+```cpp
+// Wire a pipeline's new_data_* signals to graph->set_data, guarding against
+// exceptions escaping a queued connection (which would std::terminate). N picks
+// the arity: 2 -> new_data_2d, 3 -> new_data_3d, else new_data_nd.
+template <typename Pipeline>
+inline QList<QMetaObject::Connection>
+connect_pipeline_data_to_graph(Pipeline* pipeline, SciQLopPlottableInterface* graph, int N)
+{
+    const auto drop_bad_batch = [](SciQLopPlottableInterface* g, auto&&... buffers)
+    {
+        try
+        {
+            g->set_data(std::forward<decltype(buffers)>(buffers)...);
+        }
+        catch (const std::exception& e)
+        {
+            qWarning() << "SciQLopPlots: dropping data batch from provider for"
+                       << g->objectName() << ":" << e.what();
+        }
+    };
+    QList<QMetaObject::Connection> conns;
+    switch (N)
+    {
+        case 2:
+            conns << QObject::connect(pipeline, &Pipeline::new_data_2d, graph,
+                [g = graph, drop_bad_batch](SciQLopPyBuffer x, SciQLopPyBuffer y)
+                { drop_bad_batch(g, std::move(x), std::move(y)); });
+            break;
+        case 3:
+            conns << QObject::connect(pipeline, &Pipeline::new_data_3d, graph,
+                [g = graph, drop_bad_batch](SciQLopPyBuffer x, SciQLopPyBuffer y, SciQLopPyBuffer z)
+                { drop_bad_batch(g, std::move(x), std::move(y), std::move(z)); });
+            break;
+        default:
+            conns << QObject::connect(pipeline, &Pipeline::new_data_nd, graph,
+                [g = graph, drop_bad_batch](const QList<SciQLopPyBuffer>& values)
+                { drop_bad_batch(g, values); });
+            break;
+    }
+    return conns;
+}
+```
+
+Ensure `<QDebug>` (for `qWarning`) and `<QMetaObject>` are available via existing includes; add `#include <QDebug>` to the header if not already transitively included.
+
+- [ ] **Step 2: Refactor `SciQLopFunctionGraph` ctor to use the helper**
+
+In `src/SciQLopGraphInterface.cpp`, replace the inline `drop_bad_batch` lambda + `switch (N)` block (lines ~109-139) with:
+
+```cpp
+    for (const auto& c : connect_pipeline_data_to_graph(m_pipeline, this->as_graph, N))
+        Q_UNUSED(c);
+```
+
+Leave the `pipeline_idle → set_busy(false)` and `range_changed → pipeline.call` connections (lines ~140-143) unchanged.
+
+- [ ] **Step 3: Build**
+
+Run the `meson compile -C build-venv` command from Task 1 Step 4.
+Expected: compiles clean; the callable path is behavior-identical (pure refactor).
+
+- [ ] **Step 4: Run the existing callable-path tests to prove no regression**
+
+```bash
+cd /tmp && PYTHONPATH=/var/home/jeandet/Documents/prog/SciQLopPlots/build-venv \
+  $(cd /var/home/jeandet/Documents/prog/SciQLopPlots && pwd)/.venv/bin/python \
+  -m pytest /var/home/jeandet/Documents/prog/SciQLopPlots/tests/integration -q -k "graph or plot"
+```
+Expected: PASS (same counts as before this task).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add include/SciQLopPlots/Plotables/SciQLopGraphInterface.hpp src/SciQLopGraphInterface.cpp
+git commit -m "refactor(graph): extract connect_pipeline_data_to_graph helper
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: `SciQLopRemoteGraph` mixin
+
+**Files:**
+- Modify: `include/SciQLopPlots/Plotables/SciQLopGraphInterface.hpp`
+- Modify: `src/SciQLopGraphInterface.cpp`
+
+- [ ] **Step 1: Declare `SciQLopRemoteGraph` in the header**
+
+After `class SciQLopFunctionGraph { ... };`, add the sibling mixin. It holds the channel and exposes it so SciQLop can connect `data_requested` and call `set_data`:
+
+```cpp
+class SciQLopRemoteGraph
+{
+protected:
+    RemoteDataPipeline* m_pipeline;
+    SciQLopPlottableInterface* as_graph = nullptr;
+    QList<QMetaObject::Connection> m_connections;
+
+public:
+    SciQLopRemoteGraph() { }
+    SciQLopRemoteGraph(SciQLopPlottableInterface* as_graph, int N = 2);
+    virtual ~SciQLopRemoteGraph() = default;
+
+    // The bound channel endpoint: SciQLop connects channel.data_requested to its
+    // IPC send and calls channel.set_data(...) with shared-memory-backed numpy.
+    inline RemoteDataPipeline* remote_channel() const noexcept { return m_pipeline; }
+
+    inline void invalidate_pipeline_cache() noexcept { m_pipeline->invalidate_cache(); }
+};
+```
+
+- [ ] **Step 2: Define the ctor in `src/SciQLopGraphInterface.cpp`**
+
+Busy spans request→response: set busy when a range request is initiated, clear it when data arrives. Do **not** connect `pipeline_idle → set_busy(false)`.
+
+```cpp
+SciQLopRemoteGraph::SciQLopRemoteGraph(SciQLopPlottableInterface* as_graph, int N)
+        : m_pipeline { new RemoteDataPipeline(as_graph) }, as_graph { as_graph }
+{
+    m_connections = connect_pipeline_data_to_graph(m_pipeline, this->as_graph, N);
+
+    // Busy: on request out, clear on data in (NOT on pipeline_idle, which fires
+    // as soon as the request is emitted, before the response arrives).
+    m_connections << QObject::connect(this->as_graph,
+        &SciQLopGraphInterface::range_changed, m_pipeline,
+        [pipeline = m_pipeline, g = this->as_graph](const SciQLopPlotRange& range)
+        { g->set_busy(true); pipeline->call(range); });
+
+    const auto clear_busy = [g = this->as_graph]() { g->set_busy(false); };
+    m_connections << QObject::connect(m_pipeline, &RemoteDataPipeline::new_data_2d, this->as_graph, clear_busy);
+    m_connections << QObject::connect(m_pipeline, &RemoteDataPipeline::new_data_3d, this->as_graph, clear_busy);
+    m_connections << QObject::connect(m_pipeline, &RemoteDataPipeline::new_data_nd, this->as_graph, clear_busy);
+}
+```
+
+Note: `range_changed` carries `SciQLopPlotRange`. Confirm the signal signature in `SciQLopGraphInterface.hpp` (it is `Q_SIGNAL void range_changed(const SciQLopPlotRange&)`); if the project routes range via the axis instead (as `SciQLopFunctionGraph::observe` does for axes), connect through the same axis `range_changed` the function graph uses. Match whichever the line graph actually emits — verify by reading how `SciQLopLineGraphFunction` receives ranges before finalizing this connection.
+
+- [ ] **Step 3: Build**
+
+Run `meson compile -C build-venv`. Expected: clean compile.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add include/SciQLopPlots/Plotables/SciQLopGraphInterface.hpp src/SciQLopGraphInterface.cpp
+git commit -m "feat(remote): add SciQLopRemoteGraph mixin (busy spans request->response)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: `SciQLopLineGraphRemote` concrete graph
+
+**Files:**
+- Modify: `include/SciQLopPlots/Plotables/SciQLopLineGraph.hpp`
+- Modify: `src/SciQLopLineGraph.cpp`
+
+- [ ] **Step 1: Declare `SciQLopLineGraphRemote` in the header**
+
+Mirror `SciQLopLineGraphFunction` (which multiple-inherits `SciQLopLineGraph` + `SciQLopFunctionGraph`):
+
+```cpp
+class SciQLopLineGraphRemote : public SciQLopLineGraph, public SciQLopRemoteGraph
+{
+    Q_OBJECT
+public:
+    explicit SciQLopLineGraphRemote(QCustomPlot* parent, SciQLopPlotAxis* key_axis,
+                                    SciQLopPlotAxis* value_axis,
+                                    const QStringList& labels = QStringList());
+    ~SciQLopLineGraphRemote() override = default;
+};
+```
+
+(Match the exact ctor parameter list of `SciQLopLineGraphFunction` in the same header, minus the `GetDataPyCallable&&` argument.)
+
+- [ ] **Step 2: Define the ctor in `src/SciQLopLineGraph.cpp`**
+
+Mirror `SciQLopLineGraphFunction` (line ~32), passing `N = 2`:
+
+```cpp
+SciQLopLineGraphRemote::SciQLopLineGraphRemote(QCustomPlot* parent, SciQLopPlotAxis* key_axis,
+                                               SciQLopPlotAxis* value_axis,
+                                               const QStringList& labels)
+        : SciQLopLineGraph(parent, key_axis, value_axis, labels)
+        , SciQLopRemoteGraph(this, 2)
+{
+}
+```
+
+(Copy the exact base-ctor argument list from `SciQLopLineGraphFunction`'s definition — read it first; it may pass more than shown here.)
+
+- [ ] **Step 3: Build**
+
+Run `meson compile -C build-venv`. Expected: clean compile.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add include/SciQLopPlots/Plotables/SciQLopLineGraph.hpp src/SciQLopLineGraph.cpp
+git commit -m "feat(remote): add SciQLopLineGraphRemote concrete graph
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: Bindings — expose the channel + remote line graph to Python
+
+**Files:**
+- Modify: `SciQLopPlots/bindings/bindings.xml`
+
+- [ ] **Step 1: Add typesystem entries**
+
+Find the `<object-type name="SimplePyCallablePipeline"/>` entry (or the section that registers the DataProducer types) and add alongside it:
+
+```xml
+<object-type name="RemoteDataPipeline">
+    <!-- data_requested(range) out; set_data(...) in; new_data_* / pipeline_idle as on SimplePyCallablePipeline -->
+</object-type>
+<object-type name="RemoteDataProvider"/>
+```
+
+Find the `<object-type name="SciQLopLineGraphFunction"/>` entry and add:
+
+```xml
+<object-type name="SciQLopRemoteGraph"/>
+<object-type name="SciQLopLineGraphRemote"/>
+```
+
+If any `<add-function>` / `<inject-code>` is needed for `set_data` overload disambiguation, give **each** its own `try { ... } catch (const std::exception& e) { ... }` block (see `shiboken_addfunction_exception_pattern` memory).
+
+- [ ] **Step 2: Force binding regen and build**
+
+```bash
+cd /var/home/jeandet/Documents/prog/SciQLopPlots && touch SciQLopPlots/bindings/bindings.xml && \
+VENV=$(pwd)/.venv && \
+export PATH="$VENV/bin:/home/jeandet/Qt/6.11.1/gcc_64/bin:/home/jeandet/Qt/6.11.0/gcc_64/bin:$PATH" && \
+export PKG_CONFIG_PATH="/home/jeandet/Qt/6.11.1/gcc_64/lib/pkgconfig:$PKG_CONFIG_PATH" && \
+$VENV/bin/meson compile -C build-venv
+```
+Expected: regenerates wrappers and compiles. If a stale `*_wrapper.cpp` errors, `rm` it and `meson setup --reconfigure build-venv`, then recompile.
+
+- [ ] **Step 3: Smoke-check the symbols import**
+
+```bash
+cd /tmp && PYTHONPATH=/var/home/jeandet/Documents/prog/SciQLopPlots/build-venv \
+  $(cd /var/home/jeandet/Documents/prog/SciQLopPlots && pwd)/.venv/bin/python -c \
+  "import SciQLopPlots as s; print(s.RemoteDataPipeline, s.SciQLopLineGraphRemote)"
+```
+Expected: prints both type objects, no `AttributeError`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add SciQLopPlots/bindings/bindings.xml
+git commit -m "feat(remote): expose RemoteDataPipeline + SciQLopLineGraphRemote bindings
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6: Integration tests — in-process, no real IPC
+
+**Files:**
+- Create: `tests/integration/test_remote_data_provider.py`
+
+This is the behavioral specification. A pure-Python responder stands in for the remote process: it receives `data_requested`, computes, and calls `set_data`. (Read an existing test in `tests/integration/` first to copy the app/qtbot fixture conventions.)
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+import numpy as np
+import pytest
+from multiprocessing import shared_memory
+import SciQLopPlots as s
+
+
+def _make_remote_line_graph(plot):
+    # Adjust to the project's actual add/plot factory for SciQLopLineGraphRemote.
+    # The graph exposes remote_channel() -> RemoteDataPipeline.
+    return plot.add_remote_line_graph(["B"])  # see Task 7 for the factory
+
+
+def test_request_emitted_on_range_change(qtbot, plot_with_time_axis):
+    plot = plot_with_time_axis
+    g = _make_remote_line_graph(plot)
+    ch = g.remote_channel()
+
+    requests = []
+    ch.data_requested.connect(lambda r: requests.append((r.start(), r.stop())))
+
+    with qtbot.waitSignal(ch.data_requested, timeout=2000):
+        plot.x_axis().set_range(s.SciQLopPlotRange(10.0, 20.0))
+
+    assert requests and requests[-1] == (10.0, 20.0)
+
+
+def test_set_data_delivers_to_graph(qtbot, plot_with_time_axis):
+    plot = plot_with_time_axis
+    g = _make_remote_line_graph(plot)
+    ch = g.remote_channel()
+
+    x = np.linspace(10.0, 20.0, 100, dtype=np.float64)
+    y = np.sin(x).astype(np.float64)
+
+    def respond(_range):
+        ch.set_data(x, y)
+
+    ch.data_requested.connect(respond)
+    with qtbot.waitSignal(ch.new_data_2d, timeout=2000):
+        plot.x_axis().set_range(s.SciQLopPlotRange(10.0, 20.0))
+
+    # graph received the data (assert via the graph's data accessor used elsewhere
+    # in the suite, e.g. g.data() or a plotted-points count).
+
+
+def test_busy_clears_only_after_data_arrives(qtbot, plot_with_time_axis):
+    plot = plot_with_time_axis
+    g = _make_remote_line_graph(plot)
+    ch = g.remote_channel()
+
+    # Defer the response so we can observe busy==True in between.
+    pending = {}
+    ch.data_requested.connect(lambda r: pending.setdefault("r", r))
+
+    plot.x_axis().set_range(s.SciQLopPlotRange(10.0, 20.0))
+    qtbot.waitUntil(lambda: "r" in pending, timeout=2000)
+    assert g.busy() is True  # request out, no data yet
+
+    x = np.linspace(10.0, 20.0, 10, dtype=np.float64)
+    ch.set_data(x, x)
+    qtbot.waitUntil(lambda: g.busy() is False, timeout=2000)
+
+
+def test_zero_copy_shared_memory_buffer(qtbot, plot_with_time_axis):
+    plot = plot_with_time_axis
+    g = _make_remote_line_graph(plot)
+    ch = g.remote_channel()
+
+    shm = shared_memory.SharedMemory(create=True, size=100 * 8)
+    try:
+        x = np.ndarray((100,), dtype=np.float64, buffer=shm.buf)
+        x[:] = np.linspace(10.0, 20.0, 100)
+        ch.data_requested.connect(lambda r: ch.set_data(x, x))
+        with qtbot.waitSignal(ch.new_data_2d, timeout=2000):
+            plot.x_axis().set_range(s.SciQLopPlotRange(10.0, 20.0))
+    finally:
+        shm.close()
+        shm.unlink()
+```
+
+Adjust `plot_with_time_axis`, `busy()`, and the data-accessor calls to the suite's real fixtures/API (read `tests/integration/conftest.py` and a colormap/line-graph test first). Replace `add_remote_line_graph` with whatever Task 7 exposes.
+
+- [ ] **Step 2: Run to verify they fail**
+
+```bash
+cd /tmp && PYTHONPATH=/var/home/jeandet/Documents/prog/SciQLopPlots/build-venv \
+  $(cd /var/home/jeandet/Documents/prog/SciQLopPlots && pwd)/.venv/bin/python \
+  -m pytest /var/home/jeandet/Documents/prog/SciQLopPlots/tests/integration/test_remote_data_provider.py -v
+```
+Expected: FAIL — `add_remote_line_graph` does not exist yet (drives Task 7).
+
+- [ ] **Step 3: (after Task 7) Run to verify they pass**
+
+Same command. Expected: 4 passed.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/integration/test_remote_data_provider.py
+git commit -m "test(remote): in-process integration tests incl. zero-copy shm path
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 7: `plot`/factory integration so SciQLop can create a remote line graph
+
+The construction sugar is SciQLop's concern, but SciQLopPlots must expose a creation entry point analogous to the callable path (`SciQLopPlot::plot_impl(GetDataPyCallable, ...)`). Add a no-callable factory that builds a `SciQLopLineGraphRemote`.
+
+**Files:**
+- Modify: `include/SciQLopPlots/SciQLopPlot.hpp`
+- Modify: `src/SciQLopPlot.cpp`
+- Modify: `SciQLopPlots/bindings/bindings.xml`
+
+- [ ] **Step 1: Declare a factory on `SciQLopPlot`**
+
+Mirror the existing `add_*`/`plot_impl` callable methods (`src/SciQLopPlot.cpp:875` `plot_impl(GetDataPyCallable, QStringList labels, ...)`). Add a sibling that takes labels (no callable) and returns the remote graph:
+
+```cpp
+SciQLopLineGraphRemote* add_remote_line_graph(const QStringList& labels = QStringList());
+```
+
+(Place it next to the line-graph creation methods; match their axis-resolution boilerplate.)
+
+- [ ] **Step 2: Define it in `src/SciQLopPlot.cpp`**
+
+Follow the body of the callable line-graph branch in `plot_impl` (around line 889 `add_plottable<SciQLopLineGraphFunction>(...)`), substituting `SciQLopLineGraphRemote` and dropping the callable argument:
+
+```cpp
+SciQLopLineGraphRemote* SciQLopPlot::add_remote_line_graph(const QStringList& labels)
+{
+    return m_impl->add_plottable<SciQLopLineGraphRemote>(
+        /* same axis args as the SciQLopLineGraphFunction branch */ labels);
+}
+```
+
+(Read the exact `add_plottable<SciQLopLineGraphFunction>` call and copy its argument list verbatim, minus the callable.)
+
+- [ ] **Step 3: Bind the factory**
+
+Add `add_remote_line_graph` to the `SciQLopPlot` `<object-type>` in `bindings.xml` (it is a plain method returning a bound type — likely no `<add-function>` needed, just ensure the return type is registered from Task 5). `touch bindings.xml`.
+
+- [ ] **Step 4: Build**
+
+Run the regen+compile command from Task 5 Step 2. Expected: clean.
+
+- [ ] **Step 5: Run the Task 6 tests**
+
+```bash
+cd /tmp && PYTHONPATH=/var/home/jeandet/Documents/prog/SciQLopPlots/build-venv \
+  $(cd /var/home/jeandet/Documents/prog/SciQLopPlots && pwd)/.venv/bin/python \
+  -m pytest /var/home/jeandet/Documents/prog/SciQLopPlots/tests/integration/test_remote_data_provider.py -v
+```
+Expected: **4 passed**. If `busy()`/data-accessor names were guessed wrong, fix the test to the real API and re-run.
+
+- [ ] **Step 6: Run the full integration suite (no regressions)**
+
+```bash
+cd /tmp && PYTHONPATH=/var/home/jeandet/Documents/prog/SciQLopPlots/build-venv \
+  $(cd /var/home/jeandet/Documents/prog/SciQLopPlots && pwd)/.venv/bin/python \
+  -m pytest /var/home/jeandet/Documents/prog/SciQLopPlots/tests/integration -q
+```
+Expected: all pass (same counts as before + the 4 new).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add include/SciQLopPlots/SciQLopPlot.hpp src/SciQLopPlot.cpp SciQLopPlots/bindings/bindings.xml
+git commit -m "feat(remote): add_remote_line_graph factory + binding
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 8: Replicate to the other graph types (follow-up scope)
+
+The line-graph slice proves the pattern end-to-end. The remaining graph types each get a `*Remote` twin mirroring their `*Function` class, reusing `SciQLopRemoteGraph` with the correct `N`:
+
+| Function class | Remote twin | N |
+|---|---|---|
+| `SciQLopSingleLineGraphFunction` | `SciQLopSingleLineGraphRemote` | 2 |
+| `SciQLopCurveFunction` | `SciQLopCurveRemote` | 2 |
+| `SciQLopColorMapFunction` | `SciQLopColorMapRemote` | 3 |
+| `SciQLopHistogram2DFunction` | `SciQLopHistogram2DRemote` | 3 |
+| `SciQLopWaterfallGraphFunction` | `SciQLopWaterfallGraphRemote` | 3 (verify) |
+
+- [ ] For each: add the concrete class (header+cpp) mirroring Task 4, add an `add_remote_*` factory mirroring Task 7, bind it (Task 5 pattern), and add a `set_data`-delivers test mirroring Task 6.
+- [ ] Verify the correct `N` (output arity) per type by checking the `N` its `*Function` ctor passes to `SciQLopFunctionGraph`.
+- [ ] Run the full suite after each.
+
+This task may be split into its own plan if it grows large; it is intentionally listed at lower fidelity because every entry is a mechanical repeat of Tasks 4–7.
+
+---
+
+## Self-review notes
+
+- **Spec coverage:** §Architecture/§Components → Tasks 1,3,4; §Data flow + zero-copy → Tasks 1,6; §Busy semantics → Task 3 + `test_busy_clears_only_after_data_arrives`; §Bindings → Task 5; §Testing (all 5 listed cases) → Task 6 (the optional real-subprocess smoke test is deferred — noted, not required for v1); §Out-of-scope (request token, external attacher) correctly left unimplemented.
+- **Open verification flagged in-task:** the exact `range_changed` carrier (graph vs axis) — Task 3 Step 2 tells the implementer to confirm against how `SciQLopLineGraphFunction` actually receives ranges before finalizing. The test fixtures/accessors (`plot_with_time_axis`, `busy()`, data accessor) are marked "adjust to the suite's real API."
+- **Type consistency:** `remote_channel()` returns `RemoteDataPipeline*` consistently (Tasks 3, 6); `set_data`/`data_requested`/`new_data_*` names match across provider, pipeline, and tests.

--- a/docs/superpowers/specs/2026-06-20-remote-data-provider-design.md
+++ b/docs/superpowers/specs/2026-06-20-remote-data-provider-design.md
@@ -1,0 +1,173 @@
+# RemoteDataProvider — out-of-process data channels
+
+**Date:** 2026-06-20
+**Status:** Approved design, pending implementation plan
+**Branch:** `feat/remote-data-provider`
+
+## Motivation
+
+PySide6 has no realistic No-GIL timeline. Plugins that are *inherently slow and
+Python-only* are a problem today: even though `plot(callback)` runs the callable
+on a worker `QThread`, that thread **holds the GIL for the whole compute**,
+starving every other piece of Python in the app — other plots' callbacks, the
+embedded console, other plugins. There is also no way to get true CPU
+parallelism across several heavy plugins.
+
+Goals, in priority order:
+
+1. **GIL contention (primary)** — a slow plugin must not starve the rest of
+   SciQLop's Python.
+2. **True CPU parallelism (primary)** — N heavy plugins should run on N cores.
+3. **Crash/fault isolation (bonus)** — a segfaulting plugin should not take down
+   SciQLop.
+
+The cure is to run the slow Python work in **separate OS processes** (each with
+its own interpreter, GIL, and core) and stream the result back **zero-copy** via
+shared memory. The user-facing shape is `plot(callback)` → `plot(remote=...)`.
+
+## Scope & boundary
+
+This spec covers **only the SciQLopPlots side**: the thin C++ seam that lets data
+arriving *from outside the process* feed the plotables/resamplers, with no Python
+callable ever running on a worker thread.
+
+Out of scope — **owned by the SciQLop application, not this repo:**
+
+- process spawning and lifecycle (start / restart / kill)
+- the channel/broker and discovery
+- shared-memory allocation
+- the control/wire protocol
+- the user-facing `plot(remote=...)` keyword and the plugin manifest
+
+### Process / channel model (context, implemented in SciQLop)
+
+Process and channel are **decoupled**:
+
+- **Process** = the plugin's lifecycle unit. Spawned once, imports once, holds
+  warm caches/connections shared by all its products. Owns its own interpreter
+  and GIL, fully separate from SciQLop's.
+- **Channel** = the per-product streaming endpoint. One per plotable. Many
+  channels are multiplexed over one process.
+
+Object model: `RemotePlugin (process) → exposes → Channel[] → each binds to one
+graph`.
+
+Deliberate tradeoff: several pure-Python products served by **one** plugin
+process still contend on **that process's** GIL — never on SciQLop's. So goal #1
+is always satisfied; goal #3 is a lever for the plugin author (spread heavy
+products across more processes for parallelism; group cheap ones to save
+interpreters).
+
+## Key insight: zero-copy is already free
+
+`SciQLopPyBuffer(PyObject*)` accepts **any** buffer-protocol object. A numpy
+array backed by `multiprocessing.shared_memory.SharedMemory` is exactly that.
+SciQLop wraps the shared segment as a numpy view and hands it to the provider;
+viewing it via the buffer protocol copies nothing into C++. **No buffer-layer
+changes are required.**
+
+## Existing machinery this reuses
+
+`DataProviderInterface` already has:
+
+- a `DataProviderWorker` on its own `QThread`,
+- a 100 ms rate-limit timer + **decoupled** pending slots for range-based vs
+  data-based updates (a race-safe design where neither path clobbers the other),
+- a **push** path: `set_data(x,y[,z]|nd)` → `new_data_2d/3d/nd`.
+
+`SimplePyCallablePipeline` wraps that and is wired to a graph by
+`SciQLopFunctionGraph` (`src/SciQLopGraphInterface.cpp`):
+
+- `graph.range_changed → pipeline.call(range)`
+- `pipeline.new_data_* → graph.set_data` (guarded by `drop_bad_batch`)
+- `pipeline.pipeline_idle → graph.set_busy(false)`
+
+The remote provider slots into exactly these seams.
+
+## Architecture
+
+The new provider mirrors `SimplePyCallablePipeline` but **inverts the data
+direction**: instead of *pulling* by running a Python callable on the worker
+thread, it *emits a request signal outward* and *receives buffers inward*. It
+never runs plugin code and never holds the GIL for compute — it only marshals a
+request out and buffers in. It is **transport-agnostic**: it knows only "request
+a range" / "here are buffers"; how SciQLop fulfills that (subprocess+shm, a
+thread, or a test stub) is invisible.
+
+### Components (this repo)
+
+- **`RemoteDataProvider : DataProviderInterface`** — reuses the existing worker
+  thread, rate-limit timer, and decoupled pending slots. The one override: its
+  range-update path **emits `Q_SIGNAL data_requested(SciQLopPlotRange)`** instead
+  of calling a callable. The incoming `set_data(...)` push path is the
+  *already-existing* one — buffers flow straight into `new_data_*`.
+- **`RemoteDataPipeline`** — sibling of `SimplePyCallablePipeline`: owns the
+  provider+worker, re-exposes `data_requested` outward and `set_data(...)`
+  inward, plus the existing `new_data_*` / `pipeline_idle`.
+- **`SciQLopRemoteGraph`** (or a small extension of `SciQLopFunctionGraph`) — the
+  adapter: wires `range_changed → data_requested` and `new_data_* →
+  graph.set_data` (reusing the existing `drop_bad_batch` guard), and exposes
+  `data_requested` so SciQLop can connect its IPC send.
+
+## Data flow
+
+```
+pan/zoom → graph.range_changed → [rate-limit/coalesce in worker]
+         → data_requested(range) ──out──► SciQLop IPC
+                                              │ (subprocess fills shm)
+graph.set_data(x,y) ◄── new_data_2d ◄── [push path]
+         ◄── pipeline.set_data(x,y) ◄──in── SciQLop wraps shm-numpy view
+```
+
+## Threading & busy semantics (the one real behavioral change)
+
+With the callable model, "busy" spans the blocking `get_data` call and
+`pipeline_idle` fires when the worker drains. With a **remote** provider, request
+and response are decoupled in time, so the existing idle detection would clear
+"busy" the instant the request is emitted — before data arrives.
+
+Therefore `RemoteDataProvider` must **mark busy on `data_requested` and clear it
+on the matching `set_data` arrival** (or an explicit end-of-stream). This is the
+only behavioral change beyond signal rewiring, and it is contained inside
+`RemoteDataProvider`.
+
+### Backpressure / stale responses
+
+SciQLop owns dropping responses for superseded ranges — it knows the latest
+requested range. C++ stays dumb and delivers whatever `set_data` it is handed.
+A monotonic request token (so C++ could drop stale responses itself) is a
+possible later addition; **not in v1.**
+
+## Bindings
+
+`data_requested` (signal) and `set_data(...)` (slots) on `RemoteDataPipeline`
+must be exposed in `bindings.xml`, since SciQLop drives them from Python.
+Per the project's shiboken convention, each `<add-function>` needs its own
+try/catch in its `<inject-code>`, and `bindings.xml` must be touched after
+editing any Python-exposed interface header (the meson custom_target does not
+track headers).
+
+## Testing
+
+Fully testable **in-process, no real IPC**:
+
+1. Connect `data_requested` to a Python responder that calls `set_data` with
+   numpy arrays; assert the graph updates (2D, 3D, ND).
+2. Drive rapid `range_changed` and assert requests coalesce at the rate limit.
+3. Assert busy is set on request and cleared on the matching `set_data`
+   (the §"busy semantics" change).
+4. Zero-copy proof: back a numpy array with `multiprocessing.shared_memory`,
+   feed it through `set_data`, assert the data lands without a copy.
+5. Optional smoke test: spawn a real child process that fills a shared segment
+   and streams one range back.
+
+Tests follow the project convention — integration tests under `tests/`, run from
+`/tmp` against `build-venv`.
+
+## Out of scope / future
+
+- Monotonic request token for C++-side stale-response dropping.
+- External already-running process attaching to a channel (remote hosts /
+  long-lived daemon). The `data_requested`/`set_data` contract is designed so an
+  external attacher *could* be fulfilled by SciQLop later without changing this
+  primitive.

--- a/docs/superpowers/specs/2026-06-20-remote-data-provider-design.md
+++ b/docs/superpowers/specs/2026-06-20-remote-data-provider-design.md
@@ -126,10 +126,15 @@ With the callable model, "busy" spans the blocking `get_data` call and
 and response are decoupled in time, so the existing idle detection would clear
 "busy" the instant the request is emitted — before data arrives.
 
-Therefore `RemoteDataProvider` must **mark busy on `data_requested` and clear it
-on the matching `set_data` arrival** (or an explicit end-of-stream). This is the
-only behavioral change beyond signal rewiring, and it is contained inside
-`RemoteDataProvider`.
+Therefore the `SciQLopRemoteGraph` adapter drives busy directly: it **sets busy
+on the graph's `range_changed`** (as the request goes out) and **clears it on
+`new_data_*`** (as the response arrives) — it does *not* wire `pipeline_idle`,
+which fires the instant the request is emitted. Because the QCP components that
+back the base `busy()` only exist after the first `set_data`, busy is held in a
+mixin flag (`m_busy`, read by `busy()`); each concrete remote graph's `set_busy`
+override updates that flag, emits `busy_changed`, and also forwards to the base
+so the component's own busy flag stays consistent once components exist. This is
+the only behavioral change beyond signal rewiring.
 
 ### Backpressure / stale responses
 

--- a/docs/superpowers/specs/2026-06-20-remote-data-provider-design.md
+++ b/docs/superpowers/specs/2026-06-20-remote-data-provider-design.md
@@ -1,7 +1,7 @@
 # RemoteDataProvider — out-of-process data channels
 
 **Date:** 2026-06-20
-**Status:** Approved design, pending implementation plan
+**Status:** Implemented (PR #89) — line, curve, waterfall, colormap, histogram2d
 **Branch:** `feat/remote-data-provider`
 
 ## Motivation

--- a/include/SciQLopPlots/DataProducer/DataProducer.hpp
+++ b/include/SciQLopPlots/DataProducer/DataProducer.hpp
@@ -225,6 +225,48 @@ public:
 };
 
 
+// A provider that does not compute: it emits a request for a range and waits.
+// Range get_data emits data_requested and returns nothing (the answer arrives
+// later via set_data). Buffer get_data overrides pass their inputs straight
+// through, so the existing _data_based_update push path turns an incoming
+// set_data(x,y) into new_data_2d(x,y) with no transformation.
+class RemoteDataProvider : public DataProviderInterface
+{
+    Q_OBJECT
+public:
+    RemoteDataProvider(QObject* parent = nullptr) : DataProviderInterface(parent) { }
+    virtual ~RemoteDataProvider() = default;
+
+    inline virtual QList<SciQLopPyBuffer> get_data(double lower, double upper) override
+    {
+        Q_EMIT data_requested(SciQLopPlotRange(lower, upper));
+        return {}; // no synchronous data; response arrives via set_data
+    }
+
+    inline virtual QList<SciQLopPyBuffer> get_data(SciQLopPyBuffer x, SciQLopPyBuffer y) override
+    {
+        return { x, y };
+    }
+
+    inline virtual QList<SciQLopPyBuffer> get_data(SciQLopPyBuffer x, SciQLopPyBuffer y,
+                                                   SciQLopPyBuffer z) override
+    {
+        return { x, y, z };
+    }
+
+    inline virtual QList<SciQLopPyBuffer> get_data(QList<SciQLopPyBuffer> values) override
+    {
+        return values;
+    }
+
+#ifdef BINDINGS_H
+#define Q_SIGNAL
+signals:
+#endif
+    Q_SIGNAL void data_requested(const SciQLopPlotRange& range);
+};
+
+
 class SimplePyCallablePipeline : public QObject
 {
     Q_OBJECT
@@ -251,6 +293,42 @@ public:
 #define Q_SIGNAL
 signals:
 #endif
+    Q_SIGNAL void new_data_3d(SciQLopPyBuffer x, SciQLopPyBuffer y, SciQLopPyBuffer z);
+    Q_SIGNAL void new_data_2d(SciQLopPyBuffer x, SciQLopPyBuffer y);
+    Q_SIGNAL void new_data_nd(QList<SciQLopPyBuffer> values);
+    Q_SIGNAL void pipeline_idle();
+};
+
+
+// The bound "channel" object. One per remote product. data_requested goes out
+// (SciQLop forwards it to the worker process); set_data(...) brings the final
+// buffers back in.
+class RemoteDataPipeline : public QObject
+{
+    Q_OBJECT
+    RemoteDataProvider* m_provider;
+    DataProviderWorker* m_worker;
+
+public:
+    RemoteDataPipeline(QObject* parent = nullptr);
+    virtual ~RemoteDataPipeline() = default;
+
+    inline Q_SLOT void call(const SciQLopPlotRange& range) { m_worker->set_range(range); }
+
+    inline Q_SLOT void set_data(SciQLopPyBuffer x, SciQLopPyBuffer y) { m_worker->set_data(x, y); }
+    inline Q_SLOT void set_data(SciQLopPyBuffer x, SciQLopPyBuffer y, SciQLopPyBuffer z)
+    {
+        m_worker->set_data(x, y, z);
+    }
+    inline Q_SLOT void set_data(QList<SciQLopPyBuffer> values) { m_worker->set_data(values); }
+
+    inline void invalidate_cache() { m_provider->invalidate_cache(); }
+
+#ifdef BINDINGS_H
+#define Q_SIGNAL
+signals:
+#endif
+    Q_SIGNAL void data_requested(const SciQLopPlotRange& range);
     Q_SIGNAL void new_data_3d(SciQLopPyBuffer x, SciQLopPyBuffer y, SciQLopPyBuffer z);
     Q_SIGNAL void new_data_2d(SciQLopPyBuffer x, SciQLopPyBuffer y);
     Q_SIGNAL void new_data_nd(QList<SciQLopPyBuffer> values);

--- a/include/SciQLopPlots/DataProducer/DataProducer.hpp
+++ b/include/SciQLopPlots/DataProducer/DataProducer.hpp
@@ -245,13 +245,13 @@ public:
 
     inline virtual QList<SciQLopPyBuffer> get_data(SciQLopPyBuffer x, SciQLopPyBuffer y) override
     {
-        return { x, y };
+        return { std::move(x), std::move(y) };
     }
 
     inline virtual QList<SciQLopPyBuffer> get_data(SciQLopPyBuffer x, SciQLopPyBuffer y,
                                                    SciQLopPyBuffer z) override
     {
-        return { x, y, z };
+        return { std::move(x), std::move(y), std::move(z) };
     }
 
     inline virtual QList<SciQLopPyBuffer> get_data(QList<SciQLopPyBuffer> values) override

--- a/include/SciQLopPlots/DataProducer/DataProducer.hpp
+++ b/include/SciQLopPlots/DataProducer/DataProducer.hpp
@@ -256,7 +256,7 @@ public:
 
     inline virtual QList<SciQLopPyBuffer> get_data(QList<SciQLopPyBuffer> values) override
     {
-        return values;
+        return std::move(values);
     }
 
 #ifdef BINDINGS_H
@@ -315,12 +315,18 @@ public:
 
     inline Q_SLOT void call(const SciQLopPlotRange& range) { m_worker->set_range(range); }
 
-    inline Q_SLOT void set_data(SciQLopPyBuffer x, SciQLopPyBuffer y) { m_worker->set_data(x, y); }
+    inline Q_SLOT void set_data(SciQLopPyBuffer x, SciQLopPyBuffer y)
+    {
+        m_worker->set_data(std::move(x), std::move(y));
+    }
     inline Q_SLOT void set_data(SciQLopPyBuffer x, SciQLopPyBuffer y, SciQLopPyBuffer z)
     {
-        m_worker->set_data(x, y, z);
+        m_worker->set_data(std::move(x), std::move(y), std::move(z));
     }
-    inline Q_SLOT void set_data(QList<SciQLopPyBuffer> values) { m_worker->set_data(values); }
+    inline Q_SLOT void set_data(QList<SciQLopPyBuffer> values)
+    {
+        m_worker->set_data(std::move(values));
+    }
 
     inline void invalidate_cache() { m_provider->invalidate_cache(); }
 

--- a/include/SciQLopPlots/Plotables/SciQLopColorMap.hpp
+++ b/include/SciQLopPlots/Plotables/SciQLopColorMap.hpp
@@ -188,3 +188,22 @@ public:
 
     inline void invalidate_cache() noexcept override { invalidate_pipeline_cache(); }
 };
+
+class SciQLopColorMapRemote : public SciQLopColorMap, public SciQLopRemoteGraph
+{
+    Q_OBJECT
+public:
+    explicit SciQLopColorMapRemote(QCustomPlot* parent, SciQLopPlotAxis* xAxis,
+                                   SciQLopPlotAxis* yAxis, SciQLopPlotColorScaleAxis* zAxis,
+                                   const QString& name, QVariantMap metaData = {});
+    ~SciQLopColorMapRemote() override = default;
+
+    inline void invalidate_cache() noexcept override { invalidate_pipeline_cache(); }
+
+    inline bool busy() const noexcept override { return remote_busy(); }
+    inline void set_busy(bool busy) noexcept override
+    {
+        set_remote_busy(busy);
+        Q_EMIT busy_changed(busy);
+    }
+};

--- a/include/SciQLopPlots/Plotables/SciQLopColorMap.hpp
+++ b/include/SciQLopPlots/Plotables/SciQLopColorMap.hpp
@@ -204,6 +204,7 @@ public:
     inline void set_busy(bool busy) noexcept override
     {
         set_remote_busy(busy);
+        SciQLopColorMap::set_busy(busy);
         Q_EMIT busy_changed(busy);
     }
 };

--- a/include/SciQLopPlots/Plotables/SciQLopCurve.hpp
+++ b/include/SciQLopPlots/Plotables/SciQLopCurve.hpp
@@ -120,3 +120,23 @@ public:
 
     inline void invalidate_cache() noexcept override { invalidate_pipeline_cache(); }
 };
+
+class SciQLopCurveRemote : public SciQLopCurve, public SciQLopRemoteGraph
+{
+    Q_OBJECT
+public:
+    explicit SciQLopCurveRemote(QCustomPlot* parent, SciQLopPlotAxis* key_axis,
+                                SciQLopPlotAxis* value_axis,
+                                const QStringList& labels = QStringList(),
+                                QVariantMap metaData = {});
+    ~SciQLopCurveRemote() override = default;
+
+    inline void invalidate_cache() noexcept override { invalidate_pipeline_cache(); }
+
+    inline bool busy() const noexcept override { return remote_busy(); }
+    inline void set_busy(bool busy) noexcept override
+    {
+        set_remote_busy(busy);
+        Q_EMIT busy_changed(busy);
+    }
+};

--- a/include/SciQLopPlots/Plotables/SciQLopCurve.hpp
+++ b/include/SciQLopPlots/Plotables/SciQLopCurve.hpp
@@ -137,6 +137,7 @@ public:
     inline void set_busy(bool busy) noexcept override
     {
         set_remote_busy(busy);
+        SciQLopCurve::set_busy(busy);
         Q_EMIT busy_changed(busy);
     }
 };

--- a/include/SciQLopPlots/Plotables/SciQLopGraphInterface.hpp
+++ b/include/SciQLopPlots/Plotables/SciQLopGraphInterface.hpp
@@ -425,12 +425,17 @@ public:
 // the request is emitted (the remote get_data returns immediately), so we must NOT
 // clear busy on pipeline_idle. Instead: busy=true on range request out, busy=false
 // when data actually arrives.
+//
+// The mixin owns the busy flag because QCP components don't exist until the first
+// set_data call — any component-based busy() would silently return false before
+// that. Concrete classes delegate busy()/set_busy() here.
 class SciQLopRemoteGraph
 {
 protected:
     RemoteDataPipeline* m_pipeline = nullptr;
     SciQLopPlottableInterface* as_graph = nullptr;
     QList<QMetaObject::Connection> m_connections;
+    bool m_busy = false;
 
 public:
     SciQLopRemoteGraph() { }
@@ -442,4 +447,7 @@ public:
     inline RemoteDataPipeline* remote_channel() const noexcept { return m_pipeline; }
 
     inline void invalidate_pipeline_cache() noexcept { m_pipeline->invalidate_cache(); }
+
+    inline bool remote_busy() const noexcept { return m_busy; }
+    inline void set_remote_busy(bool busy) noexcept { m_busy = busy; }
 };

--- a/include/SciQLopPlots/Plotables/SciQLopGraphInterface.hpp
+++ b/include/SciQLopPlots/Plotables/SciQLopGraphInterface.hpp
@@ -35,6 +35,7 @@
 #include <QObject>
 #include <QPointer>
 #include <QWidget>
+#include <exception>
 #include <memory>
 #include <utility>
 #include <vector>
@@ -309,6 +310,47 @@ public:
         return false;
     }
 };
+
+// Wire a pipeline's new_data_* signals to graph->set_data, guarding against
+// exceptions escaping a queued connection (which would std::terminate). N picks
+// the arity: 2 -> new_data_2d, 3 -> new_data_3d, else new_data_nd.
+template <typename Pipeline>
+inline QList<QMetaObject::Connection>
+connect_pipeline_data_to_graph(Pipeline* pipeline, SciQLopPlottableInterface* graph, int N)
+{
+    const auto drop_bad_batch = [](SciQLopPlottableInterface* g, auto&&... buffers)
+    {
+        try
+        {
+            g->set_data(std::forward<decltype(buffers)>(buffers)...);
+        }
+        catch (const std::exception& e)
+        {
+            qWarning() << "SciQLopPlots: dropping data batch from provider for"
+                       << g->objectName() << ":" << e.what();
+        }
+    };
+    QList<QMetaObject::Connection> conns;
+    switch (N)
+    {
+        case 2:
+            conns << QObject::connect(pipeline, &Pipeline::new_data_2d, graph,
+                [g = graph, drop_bad_batch](SciQLopPyBuffer x, SciQLopPyBuffer y)
+                { drop_bad_batch(g, std::move(x), std::move(y)); });
+            break;
+        case 3:
+            conns << QObject::connect(pipeline, &Pipeline::new_data_3d, graph,
+                [g = graph, drop_bad_batch](SciQLopPyBuffer x, SciQLopPyBuffer y, SciQLopPyBuffer z)
+                { drop_bad_batch(g, std::move(x), std::move(y), std::move(z)); });
+            break;
+        default:
+            conns << QObject::connect(pipeline, &Pipeline::new_data_nd, graph,
+                [g = graph, drop_bad_batch](const QList<SciQLopPyBuffer>& values)
+                { drop_bad_batch(g, values); });
+            break;
+    }
+    return conns;
+}
 
 class SciQLopFunctionGraph
 {

--- a/include/SciQLopPlots/Plotables/SciQLopGraphInterface.hpp
+++ b/include/SciQLopPlots/Plotables/SciQLopGraphInterface.hpp
@@ -419,3 +419,27 @@ public:
 
     inline void invalidate_pipeline_cache() noexcept { m_pipeline->invalidate_cache(); }
 };
+
+// Mixin that binds a RemoteDataPipeline to a graph. Sibling of SciQLopFunctionGraph.
+// Busy semantics differ from the callable model: pipeline_idle fires as soon as
+// the request is emitted (the remote get_data returns immediately), so we must NOT
+// clear busy on pipeline_idle. Instead: busy=true on range request out, busy=false
+// when data actually arrives.
+class SciQLopRemoteGraph
+{
+protected:
+    RemoteDataPipeline* m_pipeline = nullptr;
+    SciQLopPlottableInterface* as_graph = nullptr;
+    QList<QMetaObject::Connection> m_connections;
+
+public:
+    SciQLopRemoteGraph() { }
+    SciQLopRemoteGraph(SciQLopPlottableInterface* as_graph, int N = 2);
+    virtual ~SciQLopRemoteGraph() = default;
+
+    // The bound channel endpoint: SciQLop connects channel.data_requested to its
+    // IPC send and calls channel.set_data(...) with shared-memory-backed numpy.
+    inline RemoteDataPipeline* remote_channel() const noexcept { return m_pipeline; }
+
+    inline void invalidate_pipeline_cache() noexcept { m_pipeline->invalidate_cache(); }
+};

--- a/include/SciQLopPlots/Plotables/SciQLopHistogram2D.hpp
+++ b/include/SciQLopPlots/Plotables/SciQLopHistogram2D.hpp
@@ -126,6 +126,7 @@ public:
     inline void set_busy(bool busy) noexcept override
     {
         set_remote_busy(busy);
+        SciQLopHistogram2D::set_busy(busy);
         Q_EMIT busy_changed(busy);
     }
 };

--- a/include/SciQLopPlots/Plotables/SciQLopHistogram2D.hpp
+++ b/include/SciQLopPlots/Plotables/SciQLopHistogram2D.hpp
@@ -109,3 +109,23 @@ public:
 
     inline void invalidate_cache() noexcept override { invalidate_pipeline_cache(); }
 };
+
+class SciQLopHistogram2DRemote : public SciQLopHistogram2D, public SciQLopRemoteGraph
+{
+    Q_OBJECT
+public:
+    explicit SciQLopHistogram2DRemote(QCustomPlot* parent, SciQLopPlotAxis* xAxis,
+                                      SciQLopPlotAxis* yAxis, SciQLopPlotColorScaleAxis* zAxis,
+                                      const QString& name, int x_bins = 100, int y_bins = 100,
+                                      QVariantMap metaData = {});
+    ~SciQLopHistogram2DRemote() override = default;
+
+    inline void invalidate_cache() noexcept override { invalidate_pipeline_cache(); }
+
+    inline bool busy() const noexcept override { return remote_busy(); }
+    inline void set_busy(bool busy) noexcept override
+    {
+        set_remote_busy(busy);
+        Q_EMIT busy_changed(busy);
+    }
+};

--- a/include/SciQLopPlots/Plotables/SciQLopLineGraph.hpp
+++ b/include/SciQLopPlots/Plotables/SciQLopLineGraph.hpp
@@ -69,12 +69,15 @@ public:
 
     inline void invalidate_cache() noexcept override { invalidate_pipeline_cache(); }
 
-    // busy() / set_busy(): delegate to the mixin's own flag so that the busy
-    // state is valid even before QCP components are created on first set_data.
+    // busy() reports the remote request/response lifecycle via the mixin flag so
+    // it is valid even before QCP components exist (first set_data). set_busy
+    // also forwards to the base so the component's own busy flag stays consistent
+    // once components exist (a no-op before that).
     inline bool busy() const noexcept override { return remote_busy(); }
     inline void set_busy(bool busy) noexcept override
     {
         set_remote_busy(busy);
+        SciQLopLineGraph::set_busy(busy);
         Q_EMIT busy_changed(busy);
     }
 };

--- a/include/SciQLopPlots/Plotables/SciQLopLineGraph.hpp
+++ b/include/SciQLopPlots/Plotables/SciQLopLineGraph.hpp
@@ -55,3 +55,17 @@ public:
 
     inline void invalidate_cache() noexcept override { invalidate_pipeline_cache(); }
 };
+
+class SciQLopLineGraphRemote : public SciQLopLineGraph,
+                               public SciQLopRemoteGraph
+{
+    Q_OBJECT
+public:
+    explicit SciQLopLineGraphRemote(QCustomPlot* parent, SciQLopPlotAxis* key_axis,
+                                    SciQLopPlotAxis* value_axis,
+                                    const QStringList& labels = QStringList(),
+                                    QVariantMap metaData = {});
+    ~SciQLopLineGraphRemote() override = default;
+
+    inline void invalidate_cache() noexcept override { invalidate_pipeline_cache(); }
+};

--- a/include/SciQLopPlots/Plotables/SciQLopLineGraph.hpp
+++ b/include/SciQLopPlots/Plotables/SciQLopLineGraph.hpp
@@ -68,4 +68,13 @@ public:
     ~SciQLopLineGraphRemote() override = default;
 
     inline void invalidate_cache() noexcept override { invalidate_pipeline_cache(); }
+
+    // busy() / set_busy(): delegate to the mixin's own flag so that the busy
+    // state is valid even before QCP components are created on first set_data.
+    inline bool busy() const noexcept override { return remote_busy(); }
+    inline void set_busy(bool busy) noexcept override
+    {
+        set_remote_busy(busy);
+        Q_EMIT busy_changed(busy);
+    }
 };

--- a/include/SciQLopPlots/Plotables/SciQLopWaterfallGraph.hpp
+++ b/include/SciQLopPlots/Plotables/SciQLopWaterfallGraph.hpp
@@ -86,3 +86,24 @@ public:
 
     inline void invalidate_cache() noexcept override { invalidate_pipeline_cache(); }
 };
+
+class SciQLopWaterfallGraphRemote : public SciQLopWaterfallGraph,
+                                    public SciQLopRemoteGraph
+{
+    Q_OBJECT
+public:
+    explicit SciQLopWaterfallGraphRemote(QCustomPlot* parent, SciQLopPlotAxis* key_axis,
+                                         SciQLopPlotAxis* value_axis,
+                                         const QStringList& labels = QStringList(),
+                                         QVariantMap metaData = {});
+    ~SciQLopWaterfallGraphRemote() override = default;
+
+    inline void invalidate_cache() noexcept override { invalidate_pipeline_cache(); }
+
+    inline bool busy() const noexcept override { return remote_busy(); }
+    inline void set_busy(bool busy) noexcept override
+    {
+        set_remote_busy(busy);
+        Q_EMIT busy_changed(busy);
+    }
+};

--- a/include/SciQLopPlots/Plotables/SciQLopWaterfallGraph.hpp
+++ b/include/SciQLopPlots/Plotables/SciQLopWaterfallGraph.hpp
@@ -104,6 +104,7 @@ public:
     inline void set_busy(bool busy) noexcept override
     {
         set_remote_busy(busy);
+        SciQLopWaterfallGraph::set_busy(busy);
         Q_EMIT busy_changed(busy);
     }
 };

--- a/include/SciQLopPlots/SciQLopPlot.hpp
+++ b/include/SciQLopPlots/SciQLopPlot.hpp
@@ -94,6 +94,7 @@ public:
                                    bool z_log_scale = false);
     SciQLopColorMapFunction* add_color_map(GetDataPyCallable&& callable, const QString& name,
                                            bool y_log_scale = false, bool z_log_scale = false);
+    SciQLopColorMapRemote* add_remote_color_map(const QString& name);
 
     SciQLopHistogram2D* add_histogram2d(const QString& name, int x_bins = 100,
                                         int y_bins = 100, bool x_bins_log = false,
@@ -102,6 +103,8 @@ public:
                                                  const QString& name, int x_bins = 100,
                                                  int y_bins = 100, bool x_bins_log = false,
                                                  bool y_bins_log = false);
+    SciQLopHistogram2DRemote* add_remote_histogram2d(const QString& name, int x_bins = 100,
+                                                      int y_bins = 100);
 
     inline void set_scroll_factor(double factor) noexcept { m_scroll_factor = factor; }
 
@@ -355,6 +358,18 @@ public:
 
     SciQLopLineGraphRemote* add_remote_line_graph(const QStringList& labels = QStringList(),
                                                   QVariantMap metaData = {});
+
+    SciQLopCurveRemote* add_remote_curve(const QStringList& labels = QStringList(),
+                                         QVariantMap metaData = {});
+
+    SciQLopWaterfallGraphRemote* add_remote_waterfall(const QStringList& labels = QStringList(),
+                                                      QVariantMap metaData = {});
+
+    SciQLopColorMapRemote* add_remote_color_map(const QString& name);
+
+    SciQLopHistogram2DRemote* add_remote_histogram2d(const QString& name, int x_bins = 100,
+                                                     int y_bins = 100, bool x_bins_log = false,
+                                                     bool y_bins_log = false);
 
     SciQLopOverlay* overlay();
 

--- a/include/SciQLopPlots/SciQLopPlot.hpp
+++ b/include/SciQLopPlots/SciQLopPlot.hpp
@@ -353,6 +353,9 @@ public:
                                                   const QStringList& labels = {},
                                                   const QList<QColor>& colors = {});
 
+    SciQLopLineGraphRemote* add_remote_line_graph(const QStringList& labels = QStringList(),
+                                                  QVariantMap metaData = {});
+
     SciQLopOverlay* overlay();
 
     inline bool has_colormap() { return m_impl->has_colormap(); }

--- a/src/DataProducer.cpp
+++ b/src/DataProducer.cpp
@@ -247,3 +247,20 @@ SimplePyCallablePipeline::SimplePyCallablePipeline(GetDataPyCallable&& callable,
     connect(m_callable_wrapper, &SimplePyCallablePWrapper::pipeline_idle, this,
         &SimplePyCallablePipeline::pipeline_idle);
 }
+
+RemoteDataPipeline::RemoteDataPipeline(QObject* parent) : QObject(parent)
+{
+    m_provider = new RemoteDataProvider(this);
+    m_worker = new DataProviderWorker(this);
+    m_worker->set_data_provider(m_provider);
+    connect(m_provider, &RemoteDataProvider::data_requested, this,
+            &RemoteDataPipeline::data_requested);
+    connect(m_provider, &RemoteDataProvider::new_data_2d, this,
+            &RemoteDataPipeline::new_data_2d);
+    connect(m_provider, &RemoteDataProvider::new_data_3d, this,
+            &RemoteDataPipeline::new_data_3d);
+    connect(m_provider, &RemoteDataProvider::new_data_nd, this,
+            &RemoteDataPipeline::new_data_nd);
+    connect(m_provider, &RemoteDataProvider::pipeline_idle, this,
+            &RemoteDataPipeline::pipeline_idle);
+}

--- a/src/SciQLopColorMap.cpp
+++ b/src/SciQLopColorMap.cpp
@@ -254,3 +254,13 @@ SciQLopColorMapFunction::SciQLopColorMapFunction(QCustomPlot* parent, SciQLopPlo
 {
     this->set_range({parent->xAxis->range().lower, parent->xAxis->range().upper});
 }
+
+SciQLopColorMapRemote::SciQLopColorMapRemote(QCustomPlot* parent, SciQLopPlotAxis* xAxis,
+                                             SciQLopPlotAxis* yAxis,
+                                             SciQLopPlotColorScaleAxis* zAxis,
+                                             const QString& name, QVariantMap metaData)
+    : SciQLopColorMap{parent, xAxis, yAxis, zAxis, name, std::move(metaData)}
+    , SciQLopRemoteGraph(this, 3)
+{
+    this->set_range({parent->xAxis->range().lower, parent->xAxis->range().upper});
+}

--- a/src/SciQLopCurve.cpp
+++ b/src/SciQLopCurve.cpp
@@ -277,7 +277,7 @@ SciQLopCurveFunction::SciQLopCurveFunction(QCustomPlot* parent, SciQLopPlotAxis*
 SciQLopCurveRemote::SciQLopCurveRemote(QCustomPlot* parent, SciQLopPlotAxis* key_axis,
                                        SciQLopPlotAxis* value_axis,
                                        const QStringList& labels, QVariantMap metaData)
-    : SciQLopCurve{parent, key_axis, value_axis, labels, metaData}
+    : SciQLopCurve{parent, key_axis, value_axis, labels, std::move(metaData)}
     , SciQLopRemoteGraph(this, 2)
 {
     this->set_range({parent->xAxis->range().lower, parent->xAxis->range().upper});

--- a/src/SciQLopCurve.cpp
+++ b/src/SciQLopCurve.cpp
@@ -273,3 +273,12 @@ SciQLopCurveFunction::SciQLopCurveFunction(QCustomPlot* parent, SciQLopPlotAxis*
     QObject::disconnect(m_idle_connection);
     this->set_range({ parent->xAxis->range().lower, parent->xAxis->range().upper });
 }
+
+SciQLopCurveRemote::SciQLopCurveRemote(QCustomPlot* parent, SciQLopPlotAxis* key_axis,
+                                       SciQLopPlotAxis* value_axis,
+                                       const QStringList& labels, QVariantMap metaData)
+    : SciQLopCurve{parent, key_axis, value_axis, labels, metaData}
+    , SciQLopRemoteGraph(this, 2)
+{
+    this->set_range({parent->xAxis->range().lower, parent->xAxis->range().upper});
+}

--- a/src/SciQLopGraphInterface.cpp
+++ b/src/SciQLopGraphInterface.cpp
@@ -102,41 +102,7 @@ SciQLopFunctionGraph::SciQLopFunctionGraph(GetDataPyCallable&& callable,
         : m_pipeline { new SimplePyCallablePipeline(std::move(callable), as_graph) }
         , as_graph { as_graph }
 {
-    // Provider data arrives through a queued connection: a set_data throw here
-    // would escape QObject::event and std::terminate the process. Bad batches
-    // (wrong dtype, mismatched shapes) are dropped with a warning instead —
-    // only direct Python calls to set_data surface the exception.
-    const auto drop_bad_batch = [](SciQLopPlottableInterface* graph, auto&&... buffers)
-    {
-        try
-        {
-            graph->set_data(std::forward<decltype(buffers)>(buffers)...);
-        }
-        catch (const std::exception& e)
-        {
-            qWarning() << "SciQLopPlots: dropping data batch from provider for"
-                       << graph->objectName() << ":" << e.what();
-        }
-    };
-    switch (N)
-    {
-        case 2:
-            QObject::connect(m_pipeline, &SimplePyCallablePipeline::new_data_2d, this->as_graph,
-                             [g = this->as_graph, drop_bad_batch](SciQLopPyBuffer x, SciQLopPyBuffer y)
-                             { drop_bad_batch(g, std::move(x), std::move(y)); });
-            break;
-        case 3:
-            QObject::connect(m_pipeline, &SimplePyCallablePipeline::new_data_3d, this->as_graph,
-                             [g = this->as_graph, drop_bad_batch](SciQLopPyBuffer x, SciQLopPyBuffer y,
-                                                                  SciQLopPyBuffer z)
-                             { drop_bad_batch(g, std::move(x), std::move(y), std::move(z)); });
-            break;
-        default:
-            QObject::connect(m_pipeline, &SimplePyCallablePipeline::new_data_nd, this->as_graph,
-                             [g = this->as_graph, drop_bad_batch](const QList<SciQLopPyBuffer>& values)
-                             { drop_bad_batch(g, values); });
-            break;
-    }
+    connect_pipeline_data_to_graph(m_pipeline, this->as_graph, N);
     m_idle_connection = QObject::connect(m_pipeline, &SimplePyCallablePipeline::pipeline_idle,
                      this->as_graph, [graph = this->as_graph]() { graph->set_busy(false); });
     QObject::connect(this->as_graph, &SciQLopGraphInterface::range_changed, m_pipeline,

--- a/src/SciQLopGraphInterface.cpp
+++ b/src/SciQLopGraphInterface.cpp
@@ -119,12 +119,13 @@ SciQLopRemoteGraph::SciQLopRemoteGraph(SciQLopPlottableInterface* as_graph, int 
     // the request is emitted (get_data returns immediately), before the response.
     m_connections << QObject::connect(this->as_graph,
         &SciQLopGraphInterface::range_changed, m_pipeline,
-        [pipeline = m_pipeline, g = this->as_graph](const SciQLopPlotRange& range)
-        { g->set_busy(true); pipeline->call(range); });
+        [this, pipeline = m_pipeline](const SciQLopPlotRange& range)
+        { this->set_remote_busy(true); this->as_graph->set_busy(true); pipeline->call(range); });
 
     // Clear busy on the same arity the data path is wired for, so a mismatched
     // signal can never drop busy without data having reached the graph.
-    const auto clear_busy = [g = this->as_graph]() { g->set_busy(false); };
+    const auto clear_busy = [this]()
+    { this->set_remote_busy(false); this->as_graph->set_busy(false); };
     switch (N)
     {
         case 2:

--- a/src/SciQLopGraphInterface.cpp
+++ b/src/SciQLopGraphInterface.cpp
@@ -117,6 +117,9 @@ SciQLopRemoteGraph::SciQLopRemoteGraph(SciQLopPlottableInterface* as_graph, int 
     // Set busy when the range request goes out; clear busy when data arrives.
     // NOT on pipeline_idle: for remote providers pipeline_idle fires as soon as
     // the request is emitted (get_data returns immediately), before the response.
+    // set_remote_busy guarantees the flag even if a concrete class forgets to
+    // override set_busy; as_graph->set_busy virtual-dispatches to that override
+    // to emit busy_changed. The two calls protect different things, not one.
     m_connections << QObject::connect(this->as_graph,
         &SciQLopGraphInterface::range_changed, m_pipeline,
         [this, pipeline = m_pipeline](const SciQLopPlotRange& range)
@@ -124,6 +127,7 @@ SciQLopRemoteGraph::SciQLopRemoteGraph(SciQLopPlottableInterface* as_graph, int 
 
     // Clear busy on the same arity the data path is wired for, so a mismatched
     // signal can never drop busy without data having reached the graph.
+    // Same flag-then-emit split as the range lambda above.
     const auto clear_busy = [this]()
     { this->set_remote_busy(false); this->as_graph->set_busy(false); };
     switch (N)

--- a/src/SciQLopGraphInterface.cpp
+++ b/src/SciQLopGraphInterface.cpp
@@ -108,3 +108,36 @@ SciQLopFunctionGraph::SciQLopFunctionGraph(GetDataPyCallable&& callable,
     QObject::connect(this->as_graph, &SciQLopGraphInterface::range_changed, m_pipeline,
                      QOverload<const SciQLopPlotRange&>::of(&SimplePyCallablePipeline::call));
 }
+
+SciQLopRemoteGraph::SciQLopRemoteGraph(SciQLopPlottableInterface* as_graph, int N)
+        : m_pipeline { new RemoteDataPipeline(as_graph) }, as_graph { as_graph }
+{
+    m_connections = connect_pipeline_data_to_graph(m_pipeline, this->as_graph, N);
+
+    // Set busy when the range request goes out; clear busy when data arrives.
+    // NOT on pipeline_idle: for remote providers pipeline_idle fires as soon as
+    // the request is emitted (get_data returns immediately), before the response.
+    m_connections << QObject::connect(this->as_graph,
+        &SciQLopGraphInterface::range_changed, m_pipeline,
+        [pipeline = m_pipeline, g = this->as_graph](const SciQLopPlotRange& range)
+        { g->set_busy(true); pipeline->call(range); });
+
+    // Clear busy on the same arity the data path is wired for, so a mismatched
+    // signal can never drop busy without data having reached the graph.
+    const auto clear_busy = [g = this->as_graph]() { g->set_busy(false); };
+    switch (N)
+    {
+        case 2:
+            m_connections << QObject::connect(m_pipeline, &RemoteDataPipeline::new_data_2d,
+                                              this->as_graph, clear_busy);
+            break;
+        case 3:
+            m_connections << QObject::connect(m_pipeline, &RemoteDataPipeline::new_data_3d,
+                                              this->as_graph, clear_busy);
+            break;
+        default:
+            m_connections << QObject::connect(m_pipeline, &RemoteDataPipeline::new_data_nd,
+                                              this->as_graph, clear_busy);
+            break;
+    }
+}

--- a/src/SciQLopGraphInterface.cpp
+++ b/src/SciQLopGraphInterface.cpp
@@ -117,19 +117,19 @@ SciQLopRemoteGraph::SciQLopRemoteGraph(SciQLopPlottableInterface* as_graph, int 
     // Set busy when the range request goes out; clear busy when data arrives.
     // NOT on pipeline_idle: for remote providers pipeline_idle fires as soon as
     // the request is emitted (get_data returns immediately), before the response.
-    // set_remote_busy guarantees the flag even if a concrete class forgets to
-    // override set_busy; as_graph->set_busy virtual-dispatches to that override
-    // to emit busy_changed. The two calls protect different things, not one.
+    // Drive busy through as_graph->set_busy, which virtual-dispatches to the
+    // concrete remote graph's override (set_remote_busy + busy_changed). The
+    // lambdas capture only QObjects (as_graph and its child pipeline) — never the
+    // non-QObject mixin `this`, whose subobject is destroyed before the QObject
+    // base, which would leave a queued delivery dereferencing a dangling pointer.
     m_connections << QObject::connect(this->as_graph,
         &SciQLopGraphInterface::range_changed, m_pipeline,
-        [this, pipeline = m_pipeline](const SciQLopPlotRange& range)
-        { this->set_remote_busy(true); this->as_graph->set_busy(true); pipeline->call(range); });
+        [g = this->as_graph, pipeline = m_pipeline](const SciQLopPlotRange& range)
+        { g->set_busy(true); pipeline->call(range); });
 
     // Clear busy on the same arity the data path is wired for, so a mismatched
     // signal can never drop busy without data having reached the graph.
-    // Same flag-then-emit split as the range lambda above.
-    const auto clear_busy = [this]()
-    { this->set_remote_busy(false); this->as_graph->set_busy(false); };
+    const auto clear_busy = [g = this->as_graph]() { g->set_busy(false); };
     switch (N)
     {
         case 2:

--- a/src/SciQLopHistogram2D.cpp
+++ b/src/SciQLopHistogram2D.cpp
@@ -277,3 +277,14 @@ SciQLopHistogram2DFunction::SciQLopHistogram2DFunction(QCustomPlot* parent, SciQ
 {
     this->set_range({parent->xAxis->range().lower, parent->xAxis->range().upper});
 }
+
+SciQLopHistogram2DRemote::SciQLopHistogram2DRemote(QCustomPlot* parent, SciQLopPlotAxis* xAxis,
+                                                   SciQLopPlotAxis* yAxis,
+                                                   SciQLopPlotColorScaleAxis* zAxis,
+                                                   const QString& name, int x_bins, int y_bins,
+                                                   QVariantMap metaData)
+    : SciQLopHistogram2D{parent, xAxis, yAxis, zAxis, name, x_bins, y_bins, std::move(metaData)}
+    , SciQLopRemoteGraph(this, 2)
+{
+    this->set_range({parent->xAxis->range().lower, parent->xAxis->range().upper});
+}

--- a/src/SciQLopLineGraph.cpp
+++ b/src/SciQLopLineGraph.cpp
@@ -39,3 +39,13 @@ SciQLopLineGraphFunction::SciQLopLineGraphFunction(QCustomPlot* parent, SciQLopP
 {
     this->set_range({parent->xAxis->range().lower, parent->xAxis->range().upper});
 }
+
+SciQLopLineGraphRemote::SciQLopLineGraphRemote(QCustomPlot* parent, SciQLopPlotAxis* key_axis,
+                                               SciQLopPlotAxis* value_axis,
+                                               const QStringList& labels,
+                                               QVariantMap metaData)
+    : SciQLopLineGraph{parent, key_axis, value_axis, labels, metaData}
+    , SciQLopRemoteGraph(this, 2)
+{
+    this->set_range({parent->xAxis->range().lower, parent->xAxis->range().upper});
+}

--- a/src/SciQLopLineGraph.cpp
+++ b/src/SciQLopLineGraph.cpp
@@ -44,7 +44,7 @@ SciQLopLineGraphRemote::SciQLopLineGraphRemote(QCustomPlot* parent, SciQLopPlotA
                                                SciQLopPlotAxis* value_axis,
                                                const QStringList& labels,
                                                QVariantMap metaData)
-    : SciQLopLineGraph{parent, key_axis, value_axis, labels, metaData}
+    : SciQLopLineGraph{parent, key_axis, value_axis, labels, std::move(metaData)}
     , SciQLopRemoteGraph(this, 2)
 {
     this->set_range({parent->xAxis->range().lower, parent->xAxis->range().upper});

--- a/src/SciQLopPlot.cpp
+++ b/src/SciQLopPlot.cpp
@@ -685,6 +685,16 @@ SciQLopWaterfallGraphFunction* SciQLopPlot::add_waterfall(GetDataPyCallable call
     return wf;
 }
 
+SciQLopLineGraphRemote* SciQLopPlot::add_remote_line_graph(const QStringList& labels,
+                                                           QVariantMap metaData)
+{
+    auto* g = m_impl->add_plottable<SciQLopLineGraphRemote>(labels, metaData);
+    _configure_plotable(g, labels, {}, GraphType::Line, GraphMarkerShape::NoMarker);
+    connect(this->x_axis(), &SciQLopPlotAxisInterface::range_changed, g,
+            &SciQLopPlottableInterface::set_range);
+    return g;
+}
+
 SciQLopOverlay* SciQLopPlot::overlay()
 {
     if (!m_overlay)

--- a/src/SciQLopPlot.cpp
+++ b/src/SciQLopPlot.cpp
@@ -200,6 +200,32 @@ SciQLopColorMapFunction* SciQLopPlot::add_color_map(GetDataPyCallable&& callable
     return nullptr;
 }
 
+SciQLopColorMapRemote* SciQLopPlot::add_remote_color_map(const QString& name)
+{
+    if (m_color_map == nullptr)
+    {
+        auto* cmap = new SciQLopColorMapRemote(
+            this, this->m_axes[0], this->m_axes[3],
+            static_cast<SciQLopPlotColorScaleAxis*>(this->m_axes[4]), name);
+        m_color_map = cmap;
+        _ensure_colorscale_is_visible(m_color_map);
+        _register_plottable_wrapper(m_color_map);
+        return cmap;
+    }
+    return nullptr;
+}
+
+SciQLopHistogram2DRemote* SciQLopPlot::add_remote_histogram2d(const QString& name, int x_bins,
+                                                               int y_bins)
+{
+    auto* hist = new SciQLopHistogram2DRemote(
+        this, this->m_axes[0], this->m_axes[1],
+        static_cast<SciQLopPlotColorScaleAxis*>(this->m_axes[4]), name, x_bins, y_bins);
+    _ensure_colorscale_is_visible(hist);
+    _register_plottable_wrapper(hist);
+    return hist;
+}
+
 void SciQLopPlot::minimize_margins()
 {
     plotLayout()->setMargins(QMargins(0, 0, 0, 0));
@@ -693,6 +719,53 @@ SciQLopLineGraphRemote* SciQLopPlot::add_remote_line_graph(const QStringList& la
     connect(this->x_axis(), &SciQLopPlotAxisInterface::range_changed, g,
             &SciQLopPlottableInterface::set_range);
     return g;
+}
+
+SciQLopCurveRemote* SciQLopPlot::add_remote_curve(const QStringList& labels, QVariantMap metaData)
+{
+    auto* g = m_impl->add_plottable<SciQLopCurveRemote>(labels, metaData);
+    _configure_plotable(g, labels, {}, GraphType::ParametricCurve, GraphMarkerShape::NoMarker);
+    connect(this->x_axis(), &SciQLopPlotAxisInterface::range_changed, g,
+            &SciQLopPlottableInterface::set_range);
+    return g;
+}
+
+SciQLopWaterfallGraphRemote* SciQLopPlot::add_remote_waterfall(const QStringList& labels,
+                                                               QVariantMap metaData)
+{
+    auto* g = m_impl->add_plottable<SciQLopWaterfallGraphRemote>(labels, metaData);
+    _configure_plotable(g, labels, {}, GraphType::Waterfall, GraphMarkerShape::NoMarker);
+    connect(this->x_axis(), &SciQLopPlotAxisInterface::range_changed, g,
+            &SciQLopPlottableInterface::set_range);
+    return g;
+}
+
+SciQLopColorMapRemote* SciQLopPlot::add_remote_color_map(const QString& name)
+{
+    auto* g = m_impl->add_remote_color_map(name);
+    if (g)
+    {
+        _configure_color_map(g, false, false);
+        connect(this->x_axis(), &SciQLopPlotAxisInterface::range_changed, g,
+                &SciQLopPlottableInterface::set_range);
+    }
+    return g;
+}
+
+SciQLopHistogram2DRemote* SciQLopPlot::add_remote_histogram2d(const QString& name, int x_bins,
+                                                               int y_bins, bool x_bins_log,
+                                                               bool y_bins_log)
+{
+    auto* hist = m_impl->add_remote_histogram2d(name, x_bins, y_bins);
+    if (hist)
+    {
+        hist->set_x_bins_log(x_bins_log);
+        hist->set_y_bins_log(y_bins_log);
+        _configure_color_map(hist, y_bins_log, false);
+        connect(this->x_axis(), &SciQLopPlotAxisInterface::range_changed, hist,
+                &SciQLopPlottableInterface::set_range);
+    }
+    return hist;
 }
 
 SciQLopOverlay* SciQLopPlot::overlay()

--- a/src/SciQLopWaterfallGraph.cpp
+++ b/src/SciQLopWaterfallGraph.cpp
@@ -154,7 +154,7 @@ SciQLopWaterfallGraphRemote::SciQLopWaterfallGraphRemote(QCustomPlot* parent,
                                                          SciQLopPlotAxis* value_axis,
                                                          const QStringList& labels,
                                                          QVariantMap metaData)
-    : SciQLopWaterfallGraph{parent, key_axis, value_axis, labels, metaData}
+    : SciQLopWaterfallGraph{parent, key_axis, value_axis, labels, std::move(metaData)}
     , SciQLopRemoteGraph(this, 2)
 {
     this->set_range({parent->xAxis->range().lower, parent->xAxis->range().upper});

--- a/src/SciQLopWaterfallGraph.cpp
+++ b/src/SciQLopWaterfallGraph.cpp
@@ -149,6 +149,17 @@ SciQLopWaterfallGraphFunction::SciQLopWaterfallGraphFunction(QCustomPlot* parent
     this->set_range({parent->xAxis->range().lower, parent->xAxis->range().upper});
 }
 
+SciQLopWaterfallGraphRemote::SciQLopWaterfallGraphRemote(QCustomPlot* parent,
+                                                         SciQLopPlotAxis* key_axis,
+                                                         SciQLopPlotAxis* value_axis,
+                                                         const QStringList& labels,
+                                                         QVariantMap metaData)
+    : SciQLopWaterfallGraph{parent, key_axis, value_axis, labels, metaData}
+    , SciQLopRemoteGraph(this, 2)
+{
+    this->set_range({parent->xAxis->range().lower, parent->xAxis->range().upper});
+}
+
 double SciQLopWaterfallGraph::raw_value_at(int component, double key) const
 {
     if (!_x.is_valid() || !_y.is_valid())

--- a/tests/integration/test_remote_data_provider.py
+++ b/tests/integration/test_remote_data_provider.py
@@ -1,0 +1,87 @@
+"""Integration tests for the remote data provider (out-of-process channel).
+
+A pure-Python responder stands in for the remote worker process: it receives
+the channel's data_requested signal, computes, and calls set_data — exercising
+the full request-out / data-in round trip in-process, no real IPC.
+"""
+import numpy as np
+from multiprocessing import shared_memory
+from PySide6.QtWidgets import QApplication
+
+from SciQLopPlots import SciQLopPlot, SciQLopPlotRange
+
+
+def _remote_line_graph(plot):
+    g = plot.add_remote_line_graph(["B"])
+    QApplication.processEvents()
+    return g
+
+
+def test_request_emitted_on_range_change(qtbot, plot):
+    g = _remote_line_graph(plot)
+    ch = g.remote_channel()
+    requests = []
+    ch.data_requested.connect(lambda r: requests.append((r.start(), r.stop())))
+    plot.x_axis().set_range(SciQLopPlotRange(10.0, 20.0))
+    qtbot.waitUntil(lambda: len(requests) > 0, timeout=2000)
+    assert requests[-1] == (10.0, 20.0)
+
+
+def test_set_data_round_trip_emits_new_data(qtbot, plot):
+    g = _remote_line_graph(plot)
+    ch = g.remote_channel()
+    x = np.linspace(10.0, 20.0, 100).astype(np.float64)
+    y = np.sin(x).astype(np.float64)
+    ch.data_requested.connect(lambda r: ch.set_data(x, y))
+    got = []
+    ch.new_data_2d.connect(lambda a, b: got.append((np.asarray(a), np.asarray(b))))
+    plot.x_axis().set_range(SciQLopPlotRange(10.0, 20.0))
+    qtbot.waitUntil(lambda: len(got) > 0, timeout=2000)
+    # the buffers must round-trip unchanged, not just trigger the signal
+    out_x, out_y = got[-1]
+    assert np.allclose(out_x, x)
+    assert np.allclose(out_y, y)
+
+
+def test_busy_clears_only_after_data_arrives(qtbot, plot):
+    g = _remote_line_graph(plot)
+    ch = g.remote_channel()
+    pending = {}
+    ch.data_requested.connect(lambda r: pending.setdefault("r", r))
+    plot.x_axis().set_range(SciQLopPlotRange(10.0, 20.0))
+    qtbot.waitUntil(lambda: "r" in pending, timeout=2000)
+    assert g.busy() is True  # request out, no data yet
+    x = np.linspace(10.0, 20.0, 10).astype(np.float64)
+    ch.set_data(x, x)
+    qtbot.waitUntil(lambda: g.busy() is False, timeout=2000)
+
+
+def test_zero_copy_shared_memory_buffer(qtbot, plot):
+    """A shared-memory-backed numpy array must traverse the channel intact.
+
+    The library legitimately holds a reference to the buffer until the channel's
+    data is superseded, so the segment is only unlinked after we evict it with a
+    replacement and let the worker settle — freeing it earlier would be a
+    use-after-free, exactly the lifetime contract a real remote producer must
+    honour.
+    """
+    g = _remote_line_graph(plot)
+    ch = g.remote_channel()
+    shm = shared_memory.SharedMemory(create=True, size=100 * 8)
+    try:
+        x = np.ndarray((100,), dtype=np.float64, buffer=shm.buf)
+        x[:] = np.linspace(10.0, 20.0, 100)
+        got = []
+        # copy out in the slot: `got` must stay valid after the segment is freed
+        ch.new_data_2d.connect(lambda a, b: got.append(np.asarray(a).copy()))
+        ch.data_requested.connect(lambda r: ch.set_data(x, x))
+        plot.x_axis().set_range(SciQLopPlotRange(10.0, 20.0))
+        qtbot.waitUntil(lambda: len(got) > 0, timeout=2000)
+        # the shared-memory bytes arrived intact through the channel
+        assert np.allclose(got[-1], x)
+        # release the channel's reference to the shm buffer before unlinking
+        ch.set_data(np.zeros(2), np.zeros(2))
+        qtbot.wait(100)
+    finally:
+        shm.close()
+        shm.unlink()

--- a/tests/integration/test_remote_data_provider.py
+++ b/tests/integration/test_remote_data_provider.py
@@ -5,45 +5,50 @@ the channel's data_requested signal, computes, and calls set_data — exercising
 the full request-out / data-in round trip in-process, no real IPC.
 """
 import numpy as np
+import pytest
 from multiprocessing import shared_memory
 from PySide6.QtWidgets import QApplication
 
 from SciQLopPlots import SciQLopPlot, SciQLopPlotRange
 
 
-def _remote_line_graph(plot):
-    g = plot.add_remote_line_graph(["B"])
+def _xy(n=100):
+    x = np.linspace(10.0, 20.0, n).astype(np.float64)
+    return (x, np.sin(x).astype(np.float64)), "new_data_2d"
+
+
+def _xy_multi(n=10):
+    x = np.linspace(10.0, 20.0, n).astype(np.float64)
+    y = np.column_stack([np.sin(x), np.cos(x)]).astype(np.float64)
+    return (x, y), "new_data_2d"
+
+
+def _xyz():
+    x = np.linspace(10.0, 20.0, 20).astype(np.float64)
+    y = np.linspace(0.0, 5.0, 10).astype(np.float64)
+    z = np.random.rand(len(y), len(x)).astype(np.float64)
+    return (x, y, z), "new_data_3d"
+
+
+# (factory(plot) -> remote graph, make_data() -> (set_data args, new_data signal))
+CASES = [
+    pytest.param(lambda p: p.add_remote_line_graph(["B"]), _xy, id="line"),
+    pytest.param(lambda p: p.add_remote_curve(["c"]), _xy, id="curve"),
+    pytest.param(lambda p: p.add_remote_waterfall(["w"]), _xy_multi, id="waterfall"),
+    pytest.param(lambda p: p.add_remote_color_map("cm"), _xyz, id="colormap"),
+    pytest.param(lambda p: p.add_remote_histogram2d("h"), _xy, id="histogram2d"),
+]
+
+
+def _channel(plot, factory):
+    g = factory(plot)
     QApplication.processEvents()
-    return g
+    return g, g.remote_channel()
 
 
-def _remote_curve(plot):
-    g = plot.add_remote_curve(["c"])
-    QApplication.processEvents()
-    return g
-
-
-def _remote_waterfall(plot):
-    g = plot.add_remote_waterfall(["w"])
-    QApplication.processEvents()
-    return g
-
-
-def _remote_color_map(plot):
-    g = plot.add_remote_color_map("cm")
-    QApplication.processEvents()
-    return g
-
-
-def _remote_histogram2d(plot):
-    g = plot.add_remote_histogram2d("h")
-    QApplication.processEvents()
-    return g
-
-
-def test_request_emitted_on_range_change(qtbot, plot):
-    g = _remote_line_graph(plot)
-    ch = g.remote_channel()
+@pytest.mark.parametrize("factory,make_data", CASES)
+def test_request_emitted_on_range_change(qtbot, plot, factory, make_data):
+    _, ch = _channel(plot, factory)
     requests = []
     ch.data_requested.connect(lambda r: requests.append((r.start(), r.stop())))
     plot.x_axis().set_range(SciQLopPlotRange(10.0, 20.0))
@@ -51,25 +56,22 @@ def test_request_emitted_on_range_change(qtbot, plot):
     assert requests[-1] == (10.0, 20.0)
 
 
-def test_set_data_round_trip_emits_new_data(qtbot, plot):
-    g = _remote_line_graph(plot)
-    ch = g.remote_channel()
-    x = np.linspace(10.0, 20.0, 100).astype(np.float64)
-    y = np.sin(x).astype(np.float64)
-    ch.data_requested.connect(lambda r: ch.set_data(x, y))
+@pytest.mark.parametrize("factory,make_data", CASES)
+def test_set_data_round_trips_to_new_data(qtbot, plot, factory, make_data):
+    _, ch = _channel(plot, factory)
+    args, signal = make_data()
+    ch.data_requested.connect(lambda r: ch.set_data(*args))
     got = []
-    ch.new_data_2d.connect(lambda a, b: got.append((np.asarray(a), np.asarray(b))))
+    getattr(ch, signal).connect(lambda *bufs: got.append([np.asarray(b) for b in bufs]))
     plot.x_axis().set_range(SciQLopPlotRange(10.0, 20.0))
     qtbot.waitUntil(lambda: len(got) > 0, timeout=2000)
     # the buffers must round-trip unchanged, not just trigger the signal
-    out_x, out_y = got[-1]
-    assert np.allclose(out_x, x)
-    assert np.allclose(out_y, y)
+    for out, expected in zip(got[-1], args):
+        assert np.allclose(out, expected)
 
 
 def test_busy_clears_only_after_data_arrives(qtbot, plot):
-    g = _remote_line_graph(plot)
-    ch = g.remote_channel()
+    g, ch = _channel(plot, lambda p: p.add_remote_line_graph(["B"]))
     pending = {}
     ch.data_requested.connect(lambda r: pending.setdefault("r", r))
     plot.x_axis().set_range(SciQLopPlotRange(10.0, 20.0))
@@ -89,8 +91,7 @@ def test_zero_copy_shared_memory_buffer(qtbot, plot):
     use-after-free, exactly the lifetime contract a real remote producer must
     honour.
     """
-    g = _remote_line_graph(plot)
-    ch = g.remote_channel()
+    _, ch = _channel(plot, lambda p: p.add_remote_line_graph(["B"]))
     shm = shared_memory.SharedMemory(create=True, size=100 * 8)
     try:
         x = np.ndarray((100,), dtype=np.float64, buffer=shm.buf)
@@ -109,121 +110,3 @@ def test_zero_copy_shared_memory_buffer(qtbot, plot):
     finally:
         shm.close()
         shm.unlink()
-
-
-# ---------------------------------------------------------------------------
-# SciQLopCurveRemote
-# ---------------------------------------------------------------------------
-
-def test_curve_request_emitted_on_range_change(qtbot, plot):
-    g = _remote_curve(plot)
-    ch = g.remote_channel()
-    requests = []
-    ch.data_requested.connect(lambda r: requests.append((r.start(), r.stop())))
-    plot.x_axis().set_range(SciQLopPlotRange(10.0, 20.0))
-    qtbot.waitUntil(lambda: len(requests) > 0, timeout=2000)
-    assert requests[-1] == (10.0, 20.0)
-
-
-def test_curve_set_data_round_trip(qtbot, plot):
-    g = _remote_curve(plot)
-    ch = g.remote_channel()
-    x = np.linspace(10.0, 20.0, 100).astype(np.float64)
-    y = np.sin(x).astype(np.float64)
-    ch.data_requested.connect(lambda r: ch.set_data(x, y))
-    got = []
-    ch.new_data_2d.connect(lambda a, b: got.append((np.asarray(a), np.asarray(b))))
-    plot.x_axis().set_range(SciQLopPlotRange(10.0, 20.0))
-    qtbot.waitUntil(lambda: len(got) > 0, timeout=2000)
-    out_x, out_y = got[-1]
-    assert np.allclose(out_x, x)
-    assert np.allclose(out_y, y)
-
-
-# ---------------------------------------------------------------------------
-# SciQLopWaterfallGraphRemote
-# ---------------------------------------------------------------------------
-
-def test_waterfall_request_emitted_on_range_change(qtbot, plot):
-    g = _remote_waterfall(plot)
-    ch = g.remote_channel()
-    requests = []
-    ch.data_requested.connect(lambda r: requests.append((r.start(), r.stop())))
-    plot.x_axis().set_range(SciQLopPlotRange(10.0, 20.0))
-    qtbot.waitUntil(lambda: len(requests) > 0, timeout=2000)
-    assert requests[-1] == (10.0, 20.0)
-
-
-def test_waterfall_set_data_round_trip(qtbot, plot):
-    g = _remote_waterfall(plot)
-    ch = g.remote_channel()
-    x = np.linspace(10.0, 20.0, 10).astype(np.float64)
-    y = np.column_stack([np.sin(x), np.cos(x)]).astype(np.float64)
-    ch.data_requested.connect(lambda r: ch.set_data(x, y))
-    got = []
-    ch.new_data_2d.connect(lambda a, b: got.append((np.asarray(a), np.asarray(b))))
-    plot.x_axis().set_range(SciQLopPlotRange(10.0, 20.0))
-    qtbot.waitUntil(lambda: len(got) > 0, timeout=2000)
-    out_x, out_y = got[-1]
-    assert np.allclose(out_x, x)
-    assert np.allclose(out_y, y)
-
-
-# ---------------------------------------------------------------------------
-# SciQLopColorMapRemote
-# ---------------------------------------------------------------------------
-
-def test_colormap_request_emitted_on_range_change(qtbot, plot):
-    g = _remote_color_map(plot)
-    ch = g.remote_channel()
-    requests = []
-    ch.data_requested.connect(lambda r: requests.append((r.start(), r.stop())))
-    plot.x_axis().set_range(SciQLopPlotRange(10.0, 20.0))
-    qtbot.waitUntil(lambda: len(requests) > 0, timeout=2000)
-    assert requests[-1] == (10.0, 20.0)
-
-
-def test_colormap_set_data_round_trip(qtbot, plot):
-    g = _remote_color_map(plot)
-    ch = g.remote_channel()
-    x = np.linspace(10.0, 20.0, 20).astype(np.float64)
-    y = np.linspace(0.0, 5.0, 10).astype(np.float64)
-    z = np.random.rand(len(y), len(x)).astype(np.float64)
-    ch.data_requested.connect(lambda r: ch.set_data(x, y, z))
-    got = []
-    ch.new_data_3d.connect(lambda a, b, c: got.append((np.asarray(a), np.asarray(b), np.asarray(c))))
-    plot.x_axis().set_range(SciQLopPlotRange(10.0, 20.0))
-    qtbot.waitUntil(lambda: len(got) > 0, timeout=2000)
-    out_x, out_y, out_z = got[-1]
-    assert np.allclose(out_x, x)
-    assert np.allclose(out_y, y)
-    assert np.allclose(out_z, z)
-
-
-# ---------------------------------------------------------------------------
-# SciQLopHistogram2DRemote
-# ---------------------------------------------------------------------------
-
-def test_histogram2d_request_emitted_on_range_change(qtbot, plot):
-    g = _remote_histogram2d(plot)
-    ch = g.remote_channel()
-    requests = []
-    ch.data_requested.connect(lambda r: requests.append((r.start(), r.stop())))
-    plot.x_axis().set_range(SciQLopPlotRange(10.0, 20.0))
-    qtbot.waitUntil(lambda: len(requests) > 0, timeout=2000)
-    assert requests[-1] == (10.0, 20.0)
-
-
-def test_histogram2d_set_data_round_trip(qtbot, plot):
-    g = _remote_histogram2d(plot)
-    ch = g.remote_channel()
-    x = np.linspace(10.0, 20.0, 200).astype(np.float64)
-    y = np.sin(x).astype(np.float64)
-    ch.data_requested.connect(lambda r: ch.set_data(x, y))
-    got = []
-    ch.new_data_2d.connect(lambda a, b: got.append((np.asarray(a), np.asarray(b))))
-    plot.x_axis().set_range(SciQLopPlotRange(10.0, 20.0))
-    qtbot.waitUntil(lambda: len(got) > 0, timeout=2000)
-    out_x, out_y = got[-1]
-    assert np.allclose(out_x, x)
-    assert np.allclose(out_y, y)

--- a/tests/integration/test_remote_data_provider.py
+++ b/tests/integration/test_remote_data_provider.py
@@ -17,6 +17,30 @@ def _remote_line_graph(plot):
     return g
 
 
+def _remote_curve(plot):
+    g = plot.add_remote_curve(["c"])
+    QApplication.processEvents()
+    return g
+
+
+def _remote_waterfall(plot):
+    g = plot.add_remote_waterfall(["w"])
+    QApplication.processEvents()
+    return g
+
+
+def _remote_color_map(plot):
+    g = plot.add_remote_color_map("cm")
+    QApplication.processEvents()
+    return g
+
+
+def _remote_histogram2d(plot):
+    g = plot.add_remote_histogram2d("h")
+    QApplication.processEvents()
+    return g
+
+
 def test_request_emitted_on_range_change(qtbot, plot):
     g = _remote_line_graph(plot)
     ch = g.remote_channel()
@@ -85,3 +109,121 @@ def test_zero_copy_shared_memory_buffer(qtbot, plot):
     finally:
         shm.close()
         shm.unlink()
+
+
+# ---------------------------------------------------------------------------
+# SciQLopCurveRemote
+# ---------------------------------------------------------------------------
+
+def test_curve_request_emitted_on_range_change(qtbot, plot):
+    g = _remote_curve(plot)
+    ch = g.remote_channel()
+    requests = []
+    ch.data_requested.connect(lambda r: requests.append((r.start(), r.stop())))
+    plot.x_axis().set_range(SciQLopPlotRange(10.0, 20.0))
+    qtbot.waitUntil(lambda: len(requests) > 0, timeout=2000)
+    assert requests[-1] == (10.0, 20.0)
+
+
+def test_curve_set_data_round_trip(qtbot, plot):
+    g = _remote_curve(plot)
+    ch = g.remote_channel()
+    x = np.linspace(10.0, 20.0, 100).astype(np.float64)
+    y = np.sin(x).astype(np.float64)
+    ch.data_requested.connect(lambda r: ch.set_data(x, y))
+    got = []
+    ch.new_data_2d.connect(lambda a, b: got.append((np.asarray(a), np.asarray(b))))
+    plot.x_axis().set_range(SciQLopPlotRange(10.0, 20.0))
+    qtbot.waitUntil(lambda: len(got) > 0, timeout=2000)
+    out_x, out_y = got[-1]
+    assert np.allclose(out_x, x)
+    assert np.allclose(out_y, y)
+
+
+# ---------------------------------------------------------------------------
+# SciQLopWaterfallGraphRemote
+# ---------------------------------------------------------------------------
+
+def test_waterfall_request_emitted_on_range_change(qtbot, plot):
+    g = _remote_waterfall(plot)
+    ch = g.remote_channel()
+    requests = []
+    ch.data_requested.connect(lambda r: requests.append((r.start(), r.stop())))
+    plot.x_axis().set_range(SciQLopPlotRange(10.0, 20.0))
+    qtbot.waitUntil(lambda: len(requests) > 0, timeout=2000)
+    assert requests[-1] == (10.0, 20.0)
+
+
+def test_waterfall_set_data_round_trip(qtbot, plot):
+    g = _remote_waterfall(plot)
+    ch = g.remote_channel()
+    x = np.linspace(10.0, 20.0, 10).astype(np.float64)
+    y = np.column_stack([np.sin(x), np.cos(x)]).astype(np.float64)
+    ch.data_requested.connect(lambda r: ch.set_data(x, y))
+    got = []
+    ch.new_data_2d.connect(lambda a, b: got.append((np.asarray(a), np.asarray(b))))
+    plot.x_axis().set_range(SciQLopPlotRange(10.0, 20.0))
+    qtbot.waitUntil(lambda: len(got) > 0, timeout=2000)
+    out_x, out_y = got[-1]
+    assert np.allclose(out_x, x)
+    assert np.allclose(out_y, y)
+
+
+# ---------------------------------------------------------------------------
+# SciQLopColorMapRemote
+# ---------------------------------------------------------------------------
+
+def test_colormap_request_emitted_on_range_change(qtbot, plot):
+    g = _remote_color_map(plot)
+    ch = g.remote_channel()
+    requests = []
+    ch.data_requested.connect(lambda r: requests.append((r.start(), r.stop())))
+    plot.x_axis().set_range(SciQLopPlotRange(10.0, 20.0))
+    qtbot.waitUntil(lambda: len(requests) > 0, timeout=2000)
+    assert requests[-1] == (10.0, 20.0)
+
+
+def test_colormap_set_data_round_trip(qtbot, plot):
+    g = _remote_color_map(plot)
+    ch = g.remote_channel()
+    x = np.linspace(10.0, 20.0, 20).astype(np.float64)
+    y = np.linspace(0.0, 5.0, 10).astype(np.float64)
+    z = np.random.rand(len(y), len(x)).astype(np.float64)
+    ch.data_requested.connect(lambda r: ch.set_data(x, y, z))
+    got = []
+    ch.new_data_3d.connect(lambda a, b, c: got.append((np.asarray(a), np.asarray(b), np.asarray(c))))
+    plot.x_axis().set_range(SciQLopPlotRange(10.0, 20.0))
+    qtbot.waitUntil(lambda: len(got) > 0, timeout=2000)
+    out_x, out_y, out_z = got[-1]
+    assert np.allclose(out_x, x)
+    assert np.allclose(out_y, y)
+    assert np.allclose(out_z, z)
+
+
+# ---------------------------------------------------------------------------
+# SciQLopHistogram2DRemote
+# ---------------------------------------------------------------------------
+
+def test_histogram2d_request_emitted_on_range_change(qtbot, plot):
+    g = _remote_histogram2d(plot)
+    ch = g.remote_channel()
+    requests = []
+    ch.data_requested.connect(lambda r: requests.append((r.start(), r.stop())))
+    plot.x_axis().set_range(SciQLopPlotRange(10.0, 20.0))
+    qtbot.waitUntil(lambda: len(requests) > 0, timeout=2000)
+    assert requests[-1] == (10.0, 20.0)
+
+
+def test_histogram2d_set_data_round_trip(qtbot, plot):
+    g = _remote_histogram2d(plot)
+    ch = g.remote_channel()
+    x = np.linspace(10.0, 20.0, 200).astype(np.float64)
+    y = np.sin(x).astype(np.float64)
+    ch.data_requested.connect(lambda r: ch.set_data(x, y))
+    got = []
+    ch.new_data_2d.connect(lambda a, b: got.append((np.asarray(a), np.asarray(b))))
+    plot.x_axis().set_range(SciQLopPlotRange(10.0, 20.0))
+    qtbot.waitUntil(lambda: len(got) > 0, timeout=2000)
+    out_x, out_y = got[-1]
+    assert np.allclose(out_x, x)
+    assert np.allclose(out_y, y)


### PR DESCRIPTION
## Summary

Adds a transport-agnostic **remote data channel** — a `plot(remote)` counterpart to the existing `plot(callback)` — so slow, pure-Python plugins can run **out of process** (their own interpreter, GIL, and core) and stream data into a plot, instead of running a callback on a SciQLopPlots worker thread where it holds the GIL and starves the rest of the app.

The library side stays deliberately thin and **transport-agnostic**: it emits a range request *outward* (`data_requested`) and receives final buffers *inward* (`set_data`). No plugin code ever runs on a worker thread here. Process spawning, the wire protocol, and shared-memory allocation are **out of scope** — they belong to the consuming application (SciQLop).

### What's included
- `RemoteDataProvider` + `RemoteDataPipeline` — the channel, reusing the existing worker-thread + rate-limit/pending machinery. Range `get_data` emits `data_requested` and returns nothing; buffer `get_data` passes inputs straight through.
- `SciQLopRemoteGraph` mixin (busy spans request→response) + concrete remote twins for **line, curve, waterfall, colormap, histogram2d**.
- `connect_pipeline_data_to_graph` helper extracted and shared by the callable and remote paths (pure refactor of the callable path).
- `add_remote_*` factories; the plot's x-axis range drives remote requests.
- Bindings so SciQLop grabs the channel via `graph.remote_channel()`, connects `data_requested` to its IPC, and calls `channel.set_data(x, y[, z])` with shared-memory-backed numpy (zero-copy into C++).

### Usage shape (consumer side)
```python
g  = plot.add_remote_color_map("B_total")
ch = g.remote_channel()
ch.data_requested.connect(lambda r: worker.request(r.start(), r.stop()))   # -> IPC
# on reply: ch.set_data(x, y, z)  # numpy viewing a shared-memory segment, zero-copy
```

### Design / spec
- `docs/superpowers/specs/2026-06-20-remote-data-provider-design.md`
- `docs/superpowers/plans/2026-06-20-remote-data-provider.md`

### Notes
- Zero-copy is free: `set_data` already accepts any buffer-protocol object, so a numpy view over a `multiprocessing.shared_memory` segment needs no buffer-layer change.
- Lifetime contract surfaced and guarded by the tests: the library holds a buffer until the channel's data is superseded, so a producer must not free/unlink a segment while it's live.

## Test Plan
- [x] Full integration suite: **764 passed**
- [x] 12 remote-channel integration tests (in-process, no real IPC): request emission, content-asserting set_data round-trips per graph type, busy lifecycle, lifetime-correct zero-copy shared-memory path
- [x] Builds clean (meson `build-venv`, debugoptimized)

🤖 Generated with [Claude Code](https://claude.com/claude-code)