### PR TITLE
fix(autoscale): keep colormap extent on percentile rescale of shared axis

### DIFF
--- a/src/SciQLopPlotAxis.cpp
+++ b/src/SciQLopPlotAxis.cpp
@@ -365,10 +365,10 @@ void SciQLopPlotAxis::rescale() noexcept
         for (auto* p : plot->sqp_plottables())
         {
             // qobject_cast to SciQLopGraphInterface deliberately excludes
-            // colormaps/histograms: their y axis carries positional metadata
-            // (bin edges, frequency rows), not data values to pool. The
-            // legacy min/max fallthrough still considers them via QCP's own
-            // getValueRange path.
+            // colormaps/histograms: their value axis carries positional metadata
+            // (bin edges, frequency rows), not data values to pool. Their full
+            // value extent is unioned back into the percentile result below so a
+            // colormap sharing the axis with a graph isn't clipped away.
             auto* graph = qobject_cast<SciQLopGraphInterface*>(p);
             if (!graph || graph->y_axis() != this)
                 continue;
@@ -395,11 +395,30 @@ void SciQLopPlotAxis::rescale() noexcept
             // we fall through to min/max rather than appear no-op.
             if (!std::isnan(r.start()) && !std::isnan(r.stop()) && r.start() != r.stop())
             {
+                // Colormaps/histograms were excluded from the pool above, but
+                // their full value extent must still bound the axis when they
+                // share it with a graph. interface1D() is non-null only for 1D
+                // plottables (graphs/curves, already in the pool); colormaps and
+                // histograms return null, so union just their extent back in.
+                QCPRange unioned(r.start(), r.stop());
+                for (auto* plottable : m_axis->plottables())
+                {
+                    if (plottable->interface1D() || !plottable->realVisibility()
+                        || !plottable->keyAxis())
+                        continue;
+                    bool found = false;
+                    const auto extent = (plottable->keyAxis() == m_axis)
+                        ? plottable->getKeyRange(found, signDomain)
+                        : plottable->getValueRange(found, signDomain,
+                                                   plottable->keyAxis()->range());
+                    if (found)
+                        unioned.expand(extent);
+                }
                 // Route through set_range so clamp_range, m_last_valid_range,
                 // and the queued replot stay consistent with manual range
                 // changes (avoids the rangeChanged lambda reverting the new
                 // range when it exceeds m_max_range_size).
-                set_range(r);
+                set_range(SciQLopPlotRange(unioned.lower, unioned.upper, _is_time_axis));
                 return;
             }
         }

--- a/tests/integration/test_value_axis_autoscale_percentile.py
+++ b/tests/integration/test_value_axis_autoscale_percentile.py
@@ -413,3 +413,50 @@ class TestInspectorUI:
     def test_time_axis_delegate_has_no_percentile_group(self, ts_plot, qtbot):
         time_ax = ts_plot.time_axis()
         assert "Autoscale percentile" not in self._group_titles(time_ax, qtbot)
+
+
+class TestColormapSharesAxisWithGraph:
+    """When a colormap and a line graph share the same value axis, percentile
+    autoscale clips the graph's outliers but must still keep the colormap's full
+    value extent visible. The colormap is excluded from the percentile pool (its
+    value axis carries bin positions, not samples to clip), so its extent has to
+    be unioned back in -- otherwise the axis collapses onto the (smaller) line.
+    """
+
+    def _colormap_and_line_on_shared_axis(self, plot):
+        # Colormap value (y) extent spans 0..1000.
+        nx, ny = 60, 50
+        xc = np.linspace(0.0, 100.0, nx).astype(np.float64)
+        yc = np.linspace(0.0, 1000.0, ny).astype(np.float64)
+        zc = np.full((nx, ny), 0.5, dtype=np.float64)
+        cmap = plot.colormap(xc, yc, zc.ravel())
+        _pump_events()
+
+        # Line value (y) extent spans only ~[-1, 1] -- much smaller.
+        xl = np.linspace(0.0, 100.0, 200).astype(np.float64)
+        yl = np.sin(xl * 0.1).astype(np.float64)
+        line = plot.line(xl, yl)
+        line.set_y_axis(cmap.y_axis())  # share the colormap's (right) value axis
+        _pump_events()
+        plot.replot(True)
+        _pump_events()
+        return cmap, line
+
+    def test_default_percentiles_include_colormap_extent(self, plot):
+        cmap, line = self._colormap_and_line_on_shared_axis(plot)
+        ax = cmap.y_axis()
+        ax.rescale()
+        r = ax.range()
+        # min/max path: union of line [-1,1] and colormap [0,1000]
+        assert r.stop() == pytest.approx(1000.0, abs=1.0)
+
+    def test_percentile_keeps_colormap_extent(self, plot):
+        cmap, line = self._colormap_and_line_on_shared_axis(plot)
+        ax = cmap.y_axis()
+        ax.set_autoscale_percentile_low(1.0)
+        ax.set_autoscale_percentile_high(99.0)
+        ax.rescale()
+        r = ax.range()
+        # The colormap's 0..1000 extent must survive percentile clipping of the
+        # line; the axis must not collapse onto the line's ~[-1, 1].
+        assert r.stop() == pytest.approx(1000.0, abs=1.0)


### PR DESCRIPTION
## Problem

When a colormap and a line graph share the same value axis (e.g. both on the right/y2 axis) **and percentile autoscale is active** on that axis, rescaling collapsed the axis onto the line graph's extent, clipping the colormap entirely.

## Root cause

`SciQLopPlotAxis::rescale()` has two paths:

- **Default (percentiles 0/100):** a min/max loop over all QCP plottables on the axis — correctly unions the colormap's `getValueRange`. ✅
- **Percentile path (percentiles ≠ 0/100):** pools y-values from `SciQLopGraphInterface` plottables only — deliberately excluding colormaps/histograms — then **`return`s early**. A stale comment claimed the min/max fallthrough would still consider colormaps, but the early return means it never runs. The colormap's value extent was simply dropped.

Reproduced: default path → `(-1, 1000)` (correct union); percentile path → `(-1, 0.44)` (line only).

## Fix

In the percentile branch, after computing the percentile range from the graph samples, union back the value extents of the colormaps/histograms on the axis before committing. `interface1D()` is the discriminator — non-null for graphs/curves (already pooled), null for colormaps/histograms — so only the excluded 2D plottables get unioned in. Percentile clipping still tames the line's outliers; the colormap's full extent stays visible.

## Tests

- New reproducer `TestColormapSharesAxisWithGraph` (shared-axis colormap + line), covering both the default and percentile paths. The percentile case **fails before** the fix (`0.437 != 1000`) and **passes after**.
- No regressions: 64 percentile/colormap-autoscale tests + 112 axis/colormap/graph/histogram/function-graph tests all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)