### PR TITLE
fix(theme): propagate the panel theme into sub-panels

### DIFF
--- a/include/SciQLopPlots/MultiPlots/SciQLopMultiPlotPanel.hpp
+++ b/include/SciQLopPlots/MultiPlots/SciQLopMultiPlotPanel.hpp
@@ -72,7 +72,7 @@ class SciQLopMultiPlotPanel : public SciQLopPlotPanelInterface, public SciQLopEx
     QList<QMetaObject::Connection> m_creation_connections;                // panel-level (plot_added/removed)
     std::map<QCustomPlot*, QList<QMetaObject::Connection>> m_per_plot_connections;
     QPointer<SciQLopTheme> m_theme;
-    QMetaObject::Connection m_theme_connection;
+    QList<QMetaObject::Connection> m_theme_connections;                   // plot_added/panel_added
 
     void _install_span_creator(SciQLopPlot* plot);
     void _uninstall_span_creator(SciQLopPlot* plot);

--- a/src/SciQLopMultiPlotPanel.cpp
+++ b/src/SciQLopMultiPlotPanel.cpp
@@ -761,11 +761,9 @@ void SciQLopMultiPlotPanel::_on_item_canceled(QCustomPlot*)
 
 void SciQLopMultiPlotPanel::set_theme(SciQLopTheme* theme)
 {
-    if (m_theme_connection)
-    {
-        disconnect(m_theme_connection);
-        m_theme_connection = {};
-    }
+    for (const auto& connection : m_theme_connections)
+        disconnect(connection);
+    m_theme_connections.clear();
 
     m_theme = theme;
 
@@ -775,13 +773,26 @@ void SciQLopMultiPlotPanel::set_theme(SciQLopTheme* theme)
             p->set_theme(theme);
     }
 
+    for (auto* widget : child_widgets())
+    {
+        if (auto* sub_panel = qobject_cast<SciQLopMultiPlotPanel*>(widget); sub_panel)
+            sub_panel->set_theme(theme);
+    }
+
     if (theme)
     {
-        m_theme_connection = connect(this, &SciQLopMultiPlotPanel::plot_added, this,
+        m_theme_connections << connect(this, &SciQLopMultiPlotPanel::plot_added, this,
             [this](SciQLopPlotInterface* plot)
             {
                 if (m_theme && plot)
                     plot->set_theme(m_theme);
+            });
+        m_theme_connections << connect(this, &SciQLopMultiPlotPanel::panel_added, this,
+            [this](SciQLopPlotPanelInterface* panel)
+            {
+                if (auto* sub_panel = qobject_cast<SciQLopMultiPlotPanel*>(panel);
+                    m_theme && sub_panel)
+                    sub_panel->set_theme(m_theme);
             });
     }
 }

--- a/tests/integration/test_subpanel_theme.py
+++ b/tests/integration/test_subpanel_theme.py
@@ -1,0 +1,74 @@
+"""SciQLopMultiPlotPanel::set_theme must reach plots living in sub-panels.
+
+Before the fix, set_theme() only walked plots() (direct SciQLopPlotInterface
+children) and hooked plot_added on itself, so a sub-panel added with
+add_panel()/insert_panel() and every plot created inside it stayed unthemed
+(white background under a dark panel).
+"""
+import pytest
+
+from SciQLopPlots import SciQLopMultiPlotPanel, SciQLopPlot, SciQLopTheme
+
+
+@pytest.fixture
+def theme():
+    return SciQLopTheme.dark()
+
+
+@pytest.fixture
+def sub_panel(qtbot, panel):
+    sub = SciQLopMultiPlotPanel()
+    panel.add_panel(sub)
+    return sub
+
+
+def test_existing_sub_panel_is_themed(panel, sub_panel, theme):
+    panel.set_theme(theme)
+    assert sub_panel.theme() is not None
+
+
+def test_plots_of_existing_sub_panel_are_themed(panel, sub_panel, theme):
+    plot = SciQLopPlot()
+    sub_panel.add_plot(plot)
+    panel.set_theme(theme)
+    assert plot.theme() is not None
+
+
+def test_sub_panel_added_after_set_theme_is_themed(panel, theme):
+    panel.set_theme(theme)
+    sub = SciQLopMultiPlotPanel()
+    panel.add_panel(sub)
+    assert sub.theme() is not None
+
+
+def test_inserted_sub_panel_is_themed(panel, theme):
+    panel.set_theme(theme)
+    sub = SciQLopMultiPlotPanel()
+    panel.insert_panel(0, sub)
+    assert sub.theme() is not None
+
+
+def test_plot_added_to_sub_panel_after_set_theme_is_themed(panel, sub_panel, theme):
+    """The notebook workaround exists because of this: sub-panel plots are
+    created after the panel got its theme."""
+    panel.set_theme(theme)
+    plot = SciQLopPlot()
+    sub_panel.add_plot(plot)
+    assert plot.theme() is not None
+
+
+def test_nested_sub_panels_are_themed(panel, sub_panel, theme):
+    nested = SciQLopMultiPlotPanel()
+    sub_panel.add_panel(nested)
+    plot = SciQLopPlot()
+    nested.add_plot(plot)
+    panel.set_theme(theme)
+    assert nested.theme() is not None
+    assert plot.theme() is not None
+
+
+def test_theme_change_reaches_sub_panel(panel, sub_panel, theme):
+    panel.set_theme(theme)
+    new_theme = SciQLopTheme.light()
+    panel.set_theme(new_theme)
+    assert sub_panel.theme() is new_theme


### PR DESCRIPTION
## Problem

`SciQLopMultiPlotPanel::set_theme()` only walked `plots()` — which `SciQLopPlotContainer::plots()` filters down to *direct* `SciQLopPlotInterface` children — and connected a single `plot_added` hook on itself.

A sub-panel added through `add_panel()` / `insert_panel()` is a `SciQLopPlotPanelInterface`, so it was skipped, and plots created inside it emit `plot_added` on the **sub-panel**, never on the parent. Everything produced by SciQLop's `panel.add_sub_panel()` therefore had `theme() == None` and rendered with a white background under a dark panel.

Users worked around it by walking the widget tree by hand *after* adding every plot, e.g. in the Cassini demo notebook:

```python
def propagate_theme_to_subpanel(panel):
    theme = panel._impl.theme()
    for pl in panel._impl.findChildren(SciQLopPlotInterface):
        if isinstance(pl, SciQLopPlot) and pl.theme() is None:
            pl.set_theme(theme); pl.replot()
```

## Fix

`set_theme()` now also recurses into `SciQLopMultiPlotPanel` children found in `child_widgets()`, and hooks `panel_added` alongside `plot_added` (`m_theme_connection` became a `QList m_theme_connections`).

Because each sub-panel installs its own `plot_added` hook, the order of `add_panel()` / `add_plot()` / `set_theme()` calls no longer matters, and nested sub-sub-panels inherit the theme too.

## Tests

New `tests/integration/test_subpanel_theme.py` — 7 cases: sub-panel present before and after `set_theme`, `insert_panel`, plot added to an already-themed sub-panel, nested sub-sub-panel, and theme replacement. All 7 fail before the change, pass after.

Full local suite: **1052 passed** (integration + unit). The unrelated `test_inspector_properties::TestColorMapAutoScaleYLivesOnY2Axis` failure is pre-existing (verified by stashing this change and rebuilding).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JaiWw6FUB4k7Z3zP8t4KNw