### PR TITLE
LaTeX labels, plus two gallery-run fixes

### DIFF
--- a/include/SciQLopPlots/SciQLopNDProjectionPlot.hpp
+++ b/include/SciQLopPlots/SciQLopNDProjectionPlot.hpp
@@ -97,6 +97,13 @@ public:
             plot->set_color_palette(palette);
     }
 
+    /*!
+     * \brief add_reference_curve Add a static curve, projected on every subplot.
+     * \param dimensions Either one buffer per subplot, or -- as parametric_curve()
+     *        takes it -- time first followed by one buffer per subplot. Only the
+     *        latter carries time, so only it can be time-coloured or time-marked.
+     * \return The new curve, or nullptr on any other buffer count.
+     */
     SciQLopGraphInterface* add_reference_curve(
         const QList<SciQLopPyBuffer>& dimensions,
         const QString& label = QString(),

--- a/include/SciQLopPlots/SciQLopPlot.hpp
+++ b/include/SciQLopPlots/SciQLopPlot.hpp
@@ -209,6 +209,9 @@ protected:
 
     void _register_plottable_wrapper(SciQLopPlottableInterface* plottable);
 
+    //! Hide the left axis while no plottable is scaled to it (colormaps use yAxis2).
+    void _update_value_axis_visibility();
+
     void _ensure_colorscale_is_visible(SciQLopColorMap* cmap);
     void _ensure_colorscale_is_visible(SciQLopHistogram2D* hist);
 

--- a/include/SciQLopPlots/SciQLopPlot.hpp
+++ b/include/SciQLopPlots/SciQLopPlot.hpp
@@ -211,6 +211,8 @@ protected:
 
     //! Hide the left axis while no plottable is scaled to it (colormaps use yAxis2).
     void _update_value_axis_visibility();
+    //! True while _update_value_axis_visibility is the one holding the left axis hidden.
+    bool m_value_axis_hidden_here = false;
 
     void _ensure_colorscale_is_visible(SciQLopColorMap* cmap);
     void _ensure_colorscale_is_visible(SciQLopHistogram2D* hist);

--- a/src/SciQLopNDProjectionPlot.cpp
+++ b/src/SciQLopNDProjectionPlot.cpp
@@ -175,7 +175,8 @@ SciQLopGraphInterface* SciQLopNDProjectionPlot::add_reference_curve(
     const QList<SciQLopPyBuffer>& dimensions, const QString& label, const QColor& color)
 {
     const auto n = m_plots.size();
-    if (dimensions.size() != n)
+    const bool with_time = dimensions.size() == n + 1;
+    if (dimensions.size() != n && !with_time)
         return nullptr;
 
     QStringList labels;
@@ -184,13 +185,22 @@ SciQLopGraphInterface* SciQLopNDProjectionPlot::add_reference_curve(
 
     auto* graph = new SciQLopNDProjectionCurves(this, m_plots, labels);
 
-    QList<SciQLopPyBuffer> paired_data;
-    for (int i = 0; i < n; ++i)
+    if (with_time)
     {
-        paired_data.append(dimensions[i % n]);
-        paired_data.append(dimensions[(i + 1) % n]);
+        // set_data pairs the dimensions itself on this form, and time-tags the
+        // curves -- pre-pairing here would land on its untimed 2n branch instead.
+        graph->set_data(dimensions);
     }
-    graph->set_data(paired_data);
+    else
+    {
+        QList<SciQLopPyBuffer> paired_data;
+        for (int i = 0; i < n; ++i)
+        {
+            paired_data.append(dimensions[i % n]);
+            paired_data.append(dimensions[(i + 1) % n]);
+        }
+        graph->set_data(paired_data);
+    }
 
     if (color.isValid())
         graph->set_colors(QList<QColor>(n, color));

--- a/src/SciQLopPlot.cpp
+++ b/src/SciQLopPlot.cpp
@@ -532,6 +532,17 @@ bool SciQLopPlot::_handle_tool_tip(QEvent* event)
     return true;
 }
 
+void SciQLopPlot::_update_value_axis_visibility()
+{
+    // Colormaps read on yAxis2, so a colormap-only plot would draw a left axis
+    // nothing is scaled to. An empty plot keeps its axes: there is no data to
+    // contradict them yet.
+    bool used = m_plottables.isEmpty();
+    for (const auto* p : std::as_const(m_plottables))
+        used = used || p->y_axis() == m_axes[1];
+    m_axes[1]->set_visible(used);
+}
+
 void SciQLopPlot::_register_plottable_wrapper(SciQLopPlottableInterface* plottable)
 {
     m_plottables.append(plottable);
@@ -541,11 +552,13 @@ void SciQLopPlot::_register_plottable_wrapper(SciQLopPlottableInterface* plottab
                 m_plottables.removeOne(plottable);
                 if (m_color_map == plottable)
                     m_color_map = nullptr;
+                _update_value_axis_visibility();
                 emit this->plotables_list_changed();
             });
     connect(plottable, &SciQLopGraphInterface::replot, this, [this]() { this->replot(); });
     connect(this, &SciQLopPlot::resized, plottable,
             &SciQLopPlottableInterface::parent_plot_resized);
+    _update_value_axis_visibility();
     emit this->plotables_list_changed();
 }
 

--- a/src/SciQLopPlot.cpp
+++ b/src/SciQLopPlot.cpp
@@ -540,7 +540,19 @@ void SciQLopPlot::_update_value_axis_visibility()
     bool used = m_plottables.isEmpty();
     for (const auto* p : std::as_const(m_plottables))
         used = used || p->y_axis() == m_axes[1];
-    m_axes[1]->set_visible(used);
+
+    // Only ever undo our own hiding: a caller who hid the axis on purpose must
+    // not have it reappear underneath them the next time a graph is added.
+    if (!used && m_axes[1]->visible())
+    {
+        m_value_axis_hidden_here = true;
+        m_axes[1]->set_visible(false);
+    }
+    else if (used && m_value_axis_hidden_here)
+    {
+        m_value_axis_hidden_here = false;
+        m_axes[1]->set_visible(true);
+    }
 }
 
 void SciQLopPlot::_register_plottable_wrapper(SciQLopPlottableInterface* plottable)

--- a/tests/integration/test_colormap_api.py
+++ b/tests/integration/test_colormap_api.py
@@ -494,6 +494,20 @@ class TestUnusedLeftAxisIsHidden:
         process_events()
         assert plot.y_axis().visible() is True
 
+    def test_an_explicit_hide_is_not_undone(self, qtbot):
+        """Hiding the axis yourself must stick when a graph is added.
+
+        The rule only ever undoes its *own* hiding -- otherwise a caller who
+        hid the left axis on purpose gets it back underneath them as soon as
+        anything is plotted.
+        """
+        plot = SciQLopPlot()
+        qtbot.addWidget(plot)
+        plot.y_axis().set_visible(False)
+        self._line(plot)
+        process_events()
+        assert plot.y_axis().visible() is False
+
     def test_a_histogram2d_keeps_the_left_axis(self, qtbot):
         """histogram2d binds to the left axis, so it must stay drawn."""
         plot = SciQLopPlot()

--- a/tests/integration/test_colormap_api.py
+++ b/tests/integration/test_colormap_api.py
@@ -11,7 +11,7 @@ from SciQLopPlots import (
     SciQLopPlot, SciQLopGraphInterface, SciQLopPlotRange,
     ColorGradient,
 )
-from conftest import force_gc
+from conftest import force_gc, process_events
 
 
 # Subprocess cwd: outside the repo so the in-tree `SciQLopPlots/` source dir
@@ -432,3 +432,74 @@ class TestColormapEmptyData:
             f"stderr={result.stderr.decode(errors='replace')[-400:]}"
         )
         assert b"OK" in result.stdout
+
+
+class TestUnusedLeftAxisIsHidden:
+    """A colormap reads on the right (Y Axis 2), leaving the left axis unused.
+
+    It was still drawn, showing whatever default range it happened to hold
+    (0..5) next to a spectrogram whose real energies run on the right -- a scale
+    that means nothing. The left axis is now hidden while nothing is bound to
+    it, and comes back as soon as something is.
+    """
+
+    @staticmethod
+    def _spectrogram(plot):
+        x = np.linspace(0, 100, 60).astype(np.float64)
+        y = np.geomspace(10, 1000, 40).astype(np.float64)
+        z = np.random.rand(60, 40).astype(np.float64)
+        return plot.plot(x, y, z, name="spectro", y_log_scale=True)
+
+    @staticmethod
+    def _line(plot):
+        x = np.linspace(0, 100, 60).astype(np.float64)
+        return plot.plot(x, np.sin(x), labels=["line"])
+
+    def test_an_empty_plot_keeps_its_left_axis(self, qtbot):
+        plot = SciQLopPlot()
+        qtbot.addWidget(plot)
+        assert plot.y_axis().visible() is True
+
+    def test_a_colormap_only_plot_hides_the_left_axis(self, qtbot):
+        plot = SciQLopPlot()
+        qtbot.addWidget(plot)
+        self._spectrogram(plot)
+        process_events()
+        assert plot.y2_axis().visible() is True
+        assert plot.y_axis().visible() is False
+
+    def test_a_line_graph_keeps_the_left_axis(self, qtbot):
+        plot = SciQLopPlot()
+        qtbot.addWidget(plot)
+        self._line(plot)
+        process_events()
+        assert plot.y_axis().visible() is True
+
+    def test_a_colormap_beside_a_line_graph_keeps_the_left_axis(self, qtbot):
+        plot = SciQLopPlot()
+        qtbot.addWidget(plot)
+        self._spectrogram(plot)
+        self._line(plot)
+        process_events()
+        assert plot.y_axis().visible() is True
+
+    def test_the_left_axis_comes_back_when_the_colormap_goes(self, qtbot):
+        plot = SciQLopPlot()
+        qtbot.addWidget(plot)
+        cmap = self._spectrogram(plot)
+        process_events()
+        assert plot.y_axis().visible() is False
+
+        plot.remove_plottable(cmap)  # synchronous C++ delete
+        process_events()
+        assert plot.y_axis().visible() is True
+
+    def test_a_histogram2d_keeps_the_left_axis(self, qtbot):
+        """histogram2d binds to the left axis, so it must stay drawn."""
+        plot = SciQLopPlot()
+        qtbot.addWidget(plot)
+        rng = np.random.default_rng(0)
+        plot.histogram2d(rng.normal(size=500), rng.normal(size=500),
+                         name="h", x_bins=20, y_bins=20)
+        process_events()
+        assert plot.y_axis().visible() is True

--- a/tests/integration/test_latex_axis_labels.py
+++ b/tests/integration/test_latex_axis_labels.py
@@ -184,3 +184,33 @@ class TestLatexElsewhere:
         process_events()
         assert _bands_in(_render(plot, tmp_path, "item_plain"), 100, 300) == 1
         del item
+
+
+class TestMathSpanSpacing:
+    """A space touching a `$` delimiter used to be swallowed.
+
+    LaTeX renders it about a pixel wide where an ordinary text-mode space is
+    six, so `time $t$ [s]` set as "timet [s]". The renderer now makes those
+    spaces explicit before parsing.
+    """
+
+    def test_spaces_around_a_math_span_survive(self, qtbot, tmp_path):
+        spaced = _last_band_width(
+            _render(_plot_with_label(qtbot, r"aaa $b$ ccc"), tmp_path, "spaced"))
+        tight = _last_band_width(
+            _render(_plot_with_label(qtbot, r"aaa$b$ccc"), tmp_path, "tight"))
+        assert spaced > tight + 4, (
+            f"the two spaces barely widened the label: {spaced} vs {tight}")
+
+    def test_spacing_matches_ordinary_text(self, qtbot, tmp_path):
+        """The gap must be a word space, not a hairline.
+
+        Compared against the same string set entirely as text, so this pins the
+        actual width rather than just 'wider than nothing'.
+        """
+        math = _last_band_width(
+            _render(_plot_with_label(qtbot, r"aaa $b$ ccc"), tmp_path, "m"))
+        plain = _last_band_width(
+            _render(_plot_with_label(qtbot, r"aaa b ccc"), tmp_path, "p"))
+        assert abs(math - plain) < 0.35 * plain, (
+            f"math-span spacing is off from plain text: {math} vs {plain}")

--- a/tests/integration/test_latex_axis_labels.py
+++ b/tests/integration/test_latex_axis_labels.py
@@ -1,0 +1,104 @@
+"""LaTeX in axis labels.
+
+Axis labels were painted with a single QPainter::drawText, so `$B_x$` appeared
+literally, dollars and all. QCPAxis now takes a pluggable QCPLabelRenderer and
+SciQLopPlots installs one backed by JKQTMathText, which typesets any `$...$`
+span. Text without such a span still goes through drawText untouched -- that is
+what keeps ordinary labels free, and what stops a lone `$` from turning prose
+into an equation.
+
+The assertions here read the rendered image by *horizontal ink bands*: rows of
+the bottom of the plot that contain ink, grouped into contiguous runs. Typeset
+markup is structural, so it shows up as structure -- a fraction splits into
+numerator, rule and denominator bands, which no single line of text can do.
+A fixed pixel strip would not work, because a taller label legitimately moves
+the whole axis rect up.
+"""
+import numpy as np
+import pytest
+from PySide6.QtGui import QImage
+
+from SciQLopPlots import SciQLopPlot
+from conftest import process_events
+
+BOTTOM = 60  # rows to inspect: the axis line, its tick labels, and the label
+
+
+def _plot_with_label(qtbot, label):
+    plot = SciQLopPlot()
+    qtbot.addWidget(plot)
+    x = np.linspace(0, 10, 100).astype(np.float64)
+    graph = plot.plot(x, np.sin(x), labels=["s"])
+    qtbot.waitUntil(lambda: not graph.busy(), timeout=5000)
+    process_events()
+    plot.legend().set_visible(False)
+    plot.x_axis().set_label(label)
+    plot.rescale_axes()
+    process_events()
+    return plot
+
+
+def _render(plot, tmp_path, name):
+    path = tmp_path / f"{name}.png"
+    assert plot.save_png(str(path), 600, 400) is True
+    img = QImage(str(path)).convertToFormat(QImage.Format_ARGB32)
+    assert not img.isNull()
+    return img
+
+
+def _bands(img):
+    """Contiguous runs of inked rows across the bottom of the plot."""
+    inked = [any(img.pixelColor(x, y).lightness() < 140 for x in range(img.width()))
+             for y in range(img.height() - BOTTOM, img.height())]
+    return sum(1 for i, v in enumerate(inked) if v and (i == 0 or not inked[i - 1]))
+
+
+def _last_band_width(img):
+    """Ink width of the lowest band -- the axis label itself."""
+    rows = [[x for x in range(img.width())
+             if img.pixelColor(x, y).lightness() < 140]
+            for y in range(img.height() - BOTTOM, img.height())]
+    last = [xs for xs in rows if xs]
+    if not last:
+        return 0
+    lowest, seen = [], False
+    for xs in reversed(rows):
+        if xs:
+            lowest.extend(xs)
+            seen = True
+        elif seen:
+            break
+    return max(lowest) - min(lowest)
+
+
+class TestLatexAxisLabels:
+    def test_a_plain_label_still_paints(self, qtbot, tmp_path):
+        labelled = _bands(_render(_plot_with_label(qtbot, "time [s]"), tmp_path, "p"))
+        bare = _bands(_render(_plot_with_label(qtbot, ""), tmp_path, "e"))
+        assert labelled > bare, "a plain label must still add a band of ink"
+
+    def test_a_fraction_is_typeset_not_printed_literally(self, qtbot, tmp_path):
+        r"""`$\frac{a}{b}$` must stack; `\frac{a}{b}` must stay one line."""
+        typeset = _bands(_render(_plot_with_label(qtbot, r"$\frac{a}{b}$"),
+                                 tmp_path, "typeset"))
+        literal = _bands(_render(_plot_with_label(qtbot, r"\frac{a}{b}"),
+                                 tmp_path, "literal"))
+        assert typeset > literal, (
+            f"a stacked fraction should occupy more bands than its markup "
+            f"({typeset} vs {literal})")
+
+    def test_a_subscript_is_narrower_than_its_markup(self, qtbot, tmp_path):
+        """Typeset `B_x` drops the underscore and shrinks the x."""
+        typeset = _last_band_width(
+            _render(_plot_with_label(qtbot, r"$B_x$ [nT]"), tmp_path, "sub"))
+        literal = _last_band_width(
+            _render(_plot_with_label(qtbot, r"B_x [nT]"), tmp_path, "lit"))
+        assert 0 < typeset < literal
+
+    @pytest.mark.parametrize("label", ["Cost [$/kg]", "100 $"])
+    def test_a_lone_dollar_is_currency_not_math(self, qtbot, tmp_path, label):
+        """One `$` opens nothing; the label must set like any other text."""
+        got = _bands(_render(_plot_with_label(qtbot, label), tmp_path, "cur"))
+        plain = _bands(_render(_plot_with_label(qtbot, "Cost per kg"),
+                               tmp_path, "plain"))
+        assert got == plain

--- a/tests/integration/test_latex_axis_labels.py
+++ b/tests/integration/test_latex_axis_labels.py
@@ -53,22 +53,28 @@ def _bands(img):
     return sum(1 for i, v in enumerate(inked) if v and (i == 0 or not inked[i - 1]))
 
 
+# A descender or an underscore can sit a row or two clear of the rest of the
+# glyphs, and whether it does is a font and DPI question -- it differs between
+# this machine and CI. Rows separated by no more than this many blank rows are
+# therefore one band; the gap up to the tick labels above is far wider.
+_BAND_GAP = 3
+
+
 def _last_band_width(img):
     """Ink width of the lowest band -- the axis label itself."""
     rows = [[x for x in range(img.width())
              if img.pixelColor(x, y).lightness() < 140]
             for y in range(img.height() - BOTTOM, img.height())]
-    last = [xs for xs in rows if xs]
-    if not last:
-        return 0
-    lowest, seen = [], False
+    lowest, seen, gap = [], False, 0
     for xs in reversed(rows):
         if xs:
             lowest.extend(xs)
-            seen = True
+            seen, gap = True, 0
         elif seen:
-            break
-    return max(lowest) - min(lowest)
+            gap += 1
+            if gap > _BAND_GAP:
+                break
+    return (max(lowest) - min(lowest)) if lowest else 0
 
 
 class TestLatexAxisLabels:
@@ -88,11 +94,16 @@ class TestLatexAxisLabels:
             f"({typeset} vs {literal})")
 
     def test_a_subscript_is_narrower_than_its_markup(self, qtbot, tmp_path):
-        """Typeset `B_x` drops the underscore and shrinks the x."""
+        """Typeset, `B_{xyz}` loses its braces and underscore and shrinks the xyz.
+
+        A multi-character subscript is used on purpose: with `B_x` the two
+        renderings differ by only a few pixels, which is too thin a margin to
+        mean anything across fonts and DPIs.
+        """
         typeset = _last_band_width(
-            _render(_plot_with_label(qtbot, r"$B_x$ [nT]"), tmp_path, "sub"))
+            _render(_plot_with_label(qtbot, r"$B_{xyz}$ [nT]"), tmp_path, "sub"))
         literal = _last_band_width(
-            _render(_plot_with_label(qtbot, r"B_x [nT]"), tmp_path, "lit"))
+            _render(_plot_with_label(qtbot, r"B_{xyz} [nT]"), tmp_path, "lit"))
         assert 0 < typeset < literal
 
     @pytest.mark.parametrize("label", ["Cost [$/kg]", "100 $"])

--- a/tests/integration/test_latex_axis_labels.py
+++ b/tests/integration/test_latex_axis_labels.py
@@ -102,3 +102,85 @@ class TestLatexAxisLabels:
         plain = _bands(_render(_plot_with_label(qtbot, "Cost per kg"),
                                tmp_path, "plain"))
         assert got == plain
+
+
+def _bands_in(img, y0, y1):
+    """Contiguous runs of inked rows between y0 and y1."""
+    inked = [any(img.pixelColor(x, y).lightness() < 140 for x in range(img.width()))
+             for y in range(y0, y1)]
+    return sum(1 for i, v in enumerate(inked) if v and (i == 0 or not inked[i - 1]))
+
+
+def _ink_height(img, y0, y1):
+    """Vertical extent of ink between y0 and y1."""
+    rows = [y for y in range(y0, y1)
+            if any(img.pixelColor(x, y).lightness() < 140 for x in range(img.width()))]
+    return (max(rows) - min(rows)) if rows else 0
+
+
+def _quiet_plot(qtbot):
+    """A plot with its axes hidden, so only the element under test leaves ink.
+
+    The axis rect's borders are vertical lines, which put ink in *every* row and
+    would collapse any band count to one.
+    """
+    from SciQLopPlots import SciQLopPlotRange
+    plot = SciQLopPlot()
+    qtbot.addWidget(plot)
+    plot.x_axis().set_range(SciQLopPlotRange(0.0, 10.0))
+    plot.y_axis().set_range(SciQLopPlotRange(-1.0, 1.0))
+    for axis in (plot.x_axis(), plot.y_axis()):
+        axis.set_visible(False)
+    process_events()
+    return plot
+
+
+class TestLatexElsewhere:
+    """The same renderer serves every element that sets user text."""
+
+    def test_a_legend_entry_grows_to_fit_a_fraction(self, qtbot, tmp_path):
+        r"""A graph named `$\frac{a}{b}$` stacks, so its legend entry gets taller.
+
+        This also pins the measurement half: the legend sizes itself from the
+        text, so it can only grow if the size hint went through the renderer
+        too, not just the painting.
+        """
+        def legend_height(name, tag):
+            plot = _quiet_plot(qtbot)
+            x = np.linspace(0, 10, 50).astype(np.float64)
+            graph = plot.plot(x, np.full_like(x, -0.9), labels=[name])
+            qtbot.waitUntil(lambda: not graph.busy(), timeout=5000)
+            process_events()
+            return _ink_height(_render(plot, tmp_path, tag), 0, 100)
+
+        typeset = legend_height(r"$\frac{a}{b}$", "leg_tex")
+        literal = legend_height(r"\frac{a}{b}", "leg_lit")
+        assert typeset > literal, f"legend did not grow: {typeset} vs {literal}"
+
+    def test_a_text_item_is_typeset(self, qtbot, tmp_path):
+        r"""QCPItemText goes through the same seam, so items typeset too."""
+        from PySide6.QtCore import QPointF
+        from SciQLopPlots import SciQLopTextItem, Coordinates
+
+        def item_bands(text, tag):
+            plot = _quiet_plot(qtbot)
+            item = SciQLopTextItem(plot, text, QPointF(5.0, 0.0), False,
+                                   Coordinates.Data)
+            process_events()
+            bands = _bands_in(_render(plot, tmp_path, tag), 100, 300)
+            del item
+            return bands
+
+        assert item_bands(r"$\frac{a}{b}$", "item_tex") > \
+               item_bands(r"\frac{a}{b}", "item_lit")
+
+    def test_a_plain_item_is_unaffected(self, qtbot, tmp_path):
+        from PySide6.QtCore import QPointF
+        from SciQLopPlots import SciQLopTextItem, Coordinates
+
+        plot = _quiet_plot(qtbot)
+        item = SciQLopTextItem(plot, "hello", QPointF(5.0, 0.0), False,
+                               Coordinates.Data)
+        process_events()
+        assert _bands_in(_render(plot, tmp_path, "item_plain"), 100, 300) == 1
+        del item

--- a/tests/integration/test_projection_improvements.py
+++ b/tests/integration/test_projection_improvements.py
@@ -262,3 +262,106 @@ class TestProjectionFloat32Data:
         graph = proj.parametric_curve([t, x, y, z], labels=["a", "b", "c"])
         process_events()
         assert graph is not None
+
+
+class TestTimeColoredReferenceCurve:
+    """add_reference_curve() rejected the time-first form it needs to colour by time.
+
+    It required exactly one buffer per subplot and paired them itself, always
+    landing on SciQLopNDProjectionCurves::set_data's `2 * curves_count` branch --
+    the one that sets no time values. So a reference curve could never be
+    time-coloured nor carry a time marker, and callers passing time as a trailing
+    array (SciQLop's plot_time_colored_curve did) silently got it plotted as a
+    spatial dimension. The `[t, d0..dn-1]` form used by parametric_curve() is now
+    accepted and forwarded whole.
+    """
+
+    N = 200
+
+    @staticmethod
+    def _orbit(n):
+        """(t, x, y, z) -- a unit-ish helix on an epoch-scale time axis.
+
+        t is deliberately 9 orders of magnitude away from x/y/z so that a time
+        buffer mistaken for a spatial dimension is unmissable on an axis range.
+        """
+        a = np.linspace(0, 2 * np.pi, n)
+        return (
+            np.linspace(1.0e9, 1.0e9 + 100.0, n),
+            np.cos(a),
+            np.sin(a),
+            np.linspace(-1.0, 1.0, n),
+        )
+
+    def test_time_first_form_is_accepted(self, qtbot):
+        proj = SciQLopNDProjectionPlot(3)
+        qtbot.addWidget(proj)
+        t, x, y, z = self._orbit(self.N)
+
+        ref = proj.add_reference_curve([t, x, y, z], label="orbit")
+        process_events()
+        assert ref is not None
+
+    def test_only_n_and_n_plus_one_buffers_are_accepted(self, qtbot):
+        proj = SciQLopNDProjectionPlot(3)
+        qtbot.addWidget(proj)
+        t, x, y, z = self._orbit(self.N)
+        assert proj.add_reference_curve([x, y]) is None
+        assert proj.add_reference_curve([t, x, y, z, x]) is None
+
+    def test_time_is_not_plotted_as_a_dimension(self, qtbot):
+        proj = SciQLopNDProjectionPlot(3)
+        qtbot.addWidget(proj)
+        t, x, y, z = self._orbit(self.N)
+
+        ref = proj.add_reference_curve([t, x, y, z], label="orbit")
+        assert ref is not None
+        qtbot.waitUntil(lambda: not ref.busy(), timeout=5000)
+        process_events()
+
+        for i in range(proj.subplot_count()):
+            proj.subplot(i).rescale_axes()
+        process_events()
+
+        for i in range(proj.subplot_count()):
+            for name, axis in (("x", proj.subplot(i).x_axis()),
+                               ("y", proj.subplot(i).y_axis())):
+                r = axis.range()
+                assert r.start() < -0.9 and r.stop() > 0.9, (
+                    f"subplot {i} {name} axis {r.start()}..{r.stop()} does not "
+                    "span the trajectory")
+                assert abs(r.start()) < 2.0 and abs(r.stop()) < 2.0, (
+                    f"subplot {i} {name} axis {r.start()}..{r.stop()} looks like "
+                    "the time buffer")
+
+    def test_reference_curve_colours_by_time(self, qtbot, tmp_path):
+        from PySide6.QtGui import QColor, QImage
+
+        def hues(plot, name):
+            path = tmp_path / f"{name}.png"
+            assert plot.save_png(str(path), 500, 400) is True
+            img = QImage(str(path)).convertToFormat(QImage.Format_ARGB32)
+            assert not img.isNull()
+            return len({img.pixelColor(px, py).hue() // 10
+                        for py in range(img.height())
+                        for px in range(img.width())
+                        if img.pixelColor(px, py).saturation() > 100
+                        and img.pixelColor(px, py).value() > 60})
+
+        t, x, y, z = self._orbit(self.N)
+        plain, tinted = SciQLopNDProjectionPlot(3), SciQLopNDProjectionPlot(3)
+        for p in (plain, tinted):
+            qtbot.addWidget(p)
+            ref = p.add_reference_curve([t, x, y, z], label="orbit")
+            assert ref is not None
+            qtbot.waitUntil(lambda: not ref.busy(), timeout=5000)
+            process_events()  # the resampled data reaches the curve on a queued signal
+            for i in range(p.subplot_count()):
+                p.subplot(i).legend().set_visible(False)
+                p.subplot(i).rescale_axes()
+        tinted.set_time_color_gradient(QColor("blue"), QColor("red"))
+        tinted.set_time_color_enabled(True)
+        process_events()
+
+        assert hues(plain.subplot(0), "plain") <= 2, "baseline is not single-hued"
+        assert hues(tinted.subplot(0), "tinted") > 4


### PR DESCRIPTION
Two bug fixes found while shooting the gallery, and the SciQLopPlots half of LaTeX label support.

## Fixes

**`add_reference_curve` could not carry time.** It required exactly one buffer per subplot and paired them itself, which is the `2 * curves_count` tag for `SciQLopNDProjectionCurves::set_data` — the branch that sets *no* time values. So a projection reference curve could never be time-coloured or time-marked, and callers passing time as a trailing array had it silently plotted as a spatial dimension. The `[t, d0..dn-1]` form `parametric_curve()` already takes is now accepted and forwarded whole.

**Colormap plots drew a meaningless left axis.** Colormaps bind to `yAxis2`, so a colormap-only plot showed the left axis at whatever default range it held (`0..5`) next to a spectrogram whose real energies run on the right. Left-axis visibility is now derived from actual use, recomputed in `_register_plottable_wrapper` and its `destroyed` handler so removal is covered too. An empty plot keeps its axes, and `histogram2d` — which does bind to the left axis — is unaffected.

The last commit fixes a defect in that second one, caught only by combining these branches: deriving visibility outright also *showed* the axis whenever a plottable used it, clobbering anyone who had hidden it deliberately. It now only undoes its own hiding.

## LaTeX labels

The feature itself is in NeoQCP (`QCPLabelRenderer` + `QCPLatexLabelRenderer`, already on `main` there); this PR is the end-to-end coverage through the Python API. Axis labels, legend entries, plot titles and text items typeset any `$...$` span — everything else takes the plain `drawText` path, so ordinary labels cost nothing and a lone `$` stays a currency sign.

The image assertions read contiguous horizontal ink bands rather than a fixed pixel strip, because a taller label legitimately moves the axis rect up, which would leave a fixed strip measuring tick labels instead. A typeset fraction splits into numerator, rule and denominator bands, which one line of text cannot fake. Validated by uninstalling the renderer and rebuilding: the feature cases fail, the plain-label guards still pass.

## Verification

`1011 passed`, exit 0. Every fix has a reproducer that fails without it.

**Requires** NeoQCP `93f6d36` or later, which is on NeoQCP `main` — the wrap tracks that branch, so CI should pick it up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)